### PR TITLE
Add `Socket` class

### DIFF
--- a/.changeset/tiny-clocks-crash.md
+++ b/.changeset/tiny-clocks-crash.md
@@ -1,0 +1,5 @@
+---
+'nxjs-runtime': patch
+---
+
+Add `Socket` class, which is returned by `Switch.connect()`

--- a/.changeset/two-hotels-report.md
+++ b/.changeset/two-hotels-report.md
@@ -1,0 +1,5 @@
+---
+'nxjs-runtime': patch
+---
+
+Add `Socket` class, which is returned via `Switch.connect()`

--- a/.changeset/two-hotels-report.md
+++ b/.changeset/two-hotels-report.md
@@ -1,5 +1,0 @@
----
-'nxjs-runtime': patch
----
-
-Add `Socket` class, which is returned via `Switch.connect()`

--- a/apps/starwars/src/line-iterator.ts
+++ b/apps/starwars/src/line-iterator.ts
@@ -1,0 +1,16 @@
+const decoder = new TextDecoder();
+
+export async function* lineIterator(readable: ReadableStreamDefaultReader) {
+	let buffer = '';
+	while (true) {
+		const chunk = await readable.read();
+		if (chunk.done) break;
+		buffer += decoder.decode(chunk.value);
+		const lines = buffer.split('\r\n');
+		for (let i = 0; i < lines.length - 1; i++) {
+			yield lines[i];
+		}
+		buffer = lines[lines.length - 1];
+	}
+	if (buffer) yield buffer;
+}

--- a/apps/starwars/src/line-iterator.ts
+++ b/apps/starwars/src/line-iterator.ts
@@ -1,6 +1,8 @@
 const decoder = new TextDecoder();
 
-export async function* lineIterator(readable: ReadableStreamDefaultReader) {
+export async function* lineIterator(
+	readable: ReadableStreamDefaultReader<Uint8Array>
+) {
 	let buffer = '';
 	while (true) {
 		const chunk = await readable.read();

--- a/apps/starwars/src/main.ts
+++ b/apps/starwars/src/main.ts
@@ -32,7 +32,7 @@ async function* frameIterator(
 async function main() {
 	// "towel.blinkenlights.nl" no longer works on IPv4, so we'll
 	// connect to "telehack.com" and type the "starwars" command
-	const socket = Switch.connect2('telehack.com:23');
+	const socket = Switch.connect('telehack.com:23');
 	const reader = socket.readable.getReader();
 
 	// wait for prompt

--- a/apps/starwars/src/main.ts
+++ b/apps/starwars/src/main.ts
@@ -3,6 +3,7 @@ import { lineIterator } from './line-iterator';
 
 const LINES_PER_FRAME = 13;
 const decoder = new TextDecoder();
+const encoder = new TextEncoder();
 
 // Register "Geist Mono" font
 const fontUrl = new URL('GeistMono-Regular.otf', Switch.entrypoint);
@@ -10,7 +11,9 @@ const fontData = Switch.readFileSync(fontUrl);
 const font = new FontFace('Geist Mono', fontData);
 Switch.fonts.add(font);
 
-async function* frameIterator(readable: ReadableStreamDefaultReader) {
+async function* frameIterator(
+	readable: ReadableStreamDefaultReader<Uint8Array>
+) {
 	const it = lineIterator(readable);
 
 	// first line is the "starwars" echo, which we can ignore
@@ -44,7 +47,7 @@ async function main() {
 
 	// write "starwars" command
 	const writer = socket.writable.getWriter();
-	await writer.write('starwars\r\n');
+	await writer.write(encoder.encode('starwars\r\n'));
 
 	const ctx = Switch.screen.getContext('2d');
 	const fontSize = 30.83;

--- a/apps/starwars/src/main.ts
+++ b/apps/starwars/src/main.ts
@@ -1,55 +1,50 @@
 import stripAnsi from 'strip-ansi';
+import { lineIterator } from './line-iterator';
 
-const fontData = Switch.readFileSync(
-	new URL('GeistMono-Regular.otf', Switch.entrypoint)
-);
+const LINES_PER_FRAME = 13;
+const decoder = new TextDecoder();
+
+// Register "Geist Mono" font
+const fontUrl = new URL('GeistMono-Regular.otf', Switch.entrypoint);
+const fontData = Switch.readFileSync(fontUrl);
 const font = new FontFace('Geist Mono', fontData);
 Switch.fonts.add(font);
 
-function fdToStream(fd: number) {
-	const decoder = new TextDecoder();
-	const buffer = new ArrayBuffer(102400);
-	let prev = '';
-	return new ReadableStream<string>({
-		async pull(controller) {
-			const bytesRead = await Switch.read(fd, buffer);
-			if (bytesRead === 0) {
-				controller.close();
-			} else {
-				const str = prev + decoder.decode(buffer.slice(0, bytesRead));
-				const lines = str.split('\r\n');
-				prev = lines.pop()!;
-				if (lines.length === 0) {
-					return this.pull!(controller);
-				}
-				for (const line of lines) {
-					controller.enqueue(`${line}\n`);
-				}
-			}
-		},
-	});
+async function* frameIterator(readable: ReadableStreamDefaultReader) {
+	const it = lineIterator(readable);
+
+	// first line is the "starwars" echo, which we can ignore
+	await it.next();
+
+	const lines: string[] = [];
+	for await (const line of it) {
+		lines.push(stripAnsi(line));
+		if (lines.length === LINES_PER_FRAME) {
+			yield lines;
+			lines.length = 0;
+		}
+	}
 }
 
 async function main() {
 	// "towel.blinkenlights.nl" no longer works on IPv4, so we'll
 	// connect to "telehack.com" and type the "starwars" command
-	const fd = await Switch.connect({ hostname: 'telehack.com', port: 23 });
-	const stream = fdToStream(fd);
-	const reader = stream.getReader();
+	const socket = Switch.connect2('telehack.com:23');
+	const reader = socket.readable.getReader();
 
 	// wait for prompt
 	while (true) {
 		const chunk = await reader.read();
-		if (chunk.value?.includes('Press control-C')) {
+		if (!chunk.value) throw new Error('Connection closed');
+		const value = decoder.decode(chunk.value);
+		if (value.includes('Press control-C')) {
 			break;
 		}
 	}
 
 	// write "starwars" command
-	await Switch.write(fd, 'starwars\r\n');
-
-	// next line is the "starwars" echo, which we can ignore
-	await reader.read();
+	const writer = socket.writable.getWriter();
+	await writer.write('starwars\r\n');
 
 	const ctx = Switch.screen.getContext('2d');
 	const fontSize = 30.83;
@@ -57,27 +52,16 @@ async function main() {
 	ctx.font = `${fontSize}px "Geist Mono"`;
 
 	// dump the movie to the console
-	let lineCount = 0;
-	while (true) {
-		const chunk = await reader.read();
-		if (chunk.done) break;
-		if (chunk.value) {
-			const line = lineCount++ % 13;
-			// there's 13 lines per frame, so when the line is
-			// zero then clear the screen to begin drawing the
-			// new frame
-			if (line === 0) {
-				ctx.fillStyle = 'black';
-				ctx.fillRect(0, 0, Switch.screen.width, Switch.screen.height);
-				ctx.fillStyle = 'white';
-			}
-			ctx.fillText(
-				stripAnsi(chunk.value).slice(0, 67),
-				0,
-				line * fontSize + yOffset
-			);
+	for await (const frame of frameIterator(reader)) {
+		ctx.fillStyle = 'black';
+		ctx.fillRect(0, 0, Switch.screen.width, Switch.screen.height);
+		ctx.fillStyle = 'white';
+		for (let line = 0; line < frame.length; line++) {
+			const y = line * fontSize + yOffset;
+			ctx.fillText(frame[line], 0, y);
 		}
 	}
+
 	console.log('TCP socket closed');
 }
 

--- a/apps/tcp-server/src/main.ts
+++ b/apps/tcp-server/src/main.ts
@@ -1,25 +1,28 @@
-// Create a TCP server bound to "0.0.0.0:8080".
+/**
+ * Create a TCP echo server bound to "0.0.0.0:8080".
+ */
 const port = 8080;
 const server = Switch.listen({ port });
 
-// "accept" event occurs when a new TCP client has connected.
-server.addEventListener('accept', async ({ fd }) => {
+// "accept" event occurs when a new TCP client has connected
+server.addEventListener('accept', async ({ socket }) => {
+	console.log('Client connection established');
+	const reader = socket.readable.getReader();
+	const writer = socket.writable.getWriter();
 	try {
-		console.log('Client connection established (fd=%d)', fd);
-		const buf = new ArrayBuffer(1024);
-		while (1) {
-			let bytes = await Switch.read(fd, buf);
-			if (bytes === 0) {
-				console.log('Client connection closed (fd=%d)', fd);
+		while (true) {
+			const chunk = await reader.read();
+			if (chunk.done) {
+				console.log('Client closed connection');
 				break;
 			}
-			const arr = new Uint8Array(buf, 0, bytes);
-			const text = new TextDecoder().decode(arr);
-			console.log('Read', { fd, text, bytes });
+
+			const text = new TextDecoder().decode(chunk.value);
+			console.log('Read', { text });
 
 			// Echo the input back to the client
-			bytes = await Switch.write(fd, arr);
-			console.log('Write', { fd, bytes });
+			await writer.write(chunk.value);
+			console.log('Wrote %d bytes', chunk.value.length);
 		}
 	} catch (err) {
 		console.error(err);

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -10,6 +10,9 @@ export interface Init {
 	batteryInitClass(c: any): void;
 	batteryExit(): void;
 
+	// dns.c
+	dnsResolve(cb: Callback<string[]>, hostname: string): void;
+
 	// error.c
 	onError(fn: (err: any) => number): void;
 	onUnhandledRejection(

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -44,6 +44,7 @@ export interface Init {
 	connect(cb: Callback<number>, ip: string, port: number): void;
 	write(cb: Callback<number>, fd: number, data: ArrayBuffer): void;
 	read(cb: Callback<number>, fd: number, buffer: ArrayBuffer): void;
+	close(fd: number): void;
 	tcpInitServer(c: any): void;
 	tcpServerNew(
 		ip: string,

--- a/packages/runtime/src/dns.ts
+++ b/packages/runtime/src/dns.ts
@@ -1,0 +1,15 @@
+import { $ } from './$';
+import { toPromise } from './utils';
+
+/**
+ * Performs a DNS lookup to resolve a hostname to an array of IP addresses.
+ *
+ * @example
+ *
+ * ```typescript
+ * const ipAddresses = await Switch.resolveDns('example.com');
+ * ```
+ */
+export function resolve(hostname: string) {
+	return toPromise($.dnsResolve, hostname);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -61,7 +61,7 @@ export type * from './crypto';
 export type * from './image';
 export type * from './dompoint';
 export type * from './domrect';
-export type { Server } from './tcp';
+export type { Socket, Server } from './tcp';
 export type {
 	TimerHandler,
 	setTimeout,

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -1,3 +1,6 @@
+import type { connect } from './tcp';
+import type { SocketOptions } from './types';
+
 export const INTERNAL_SYMBOL = Symbol('Internal');
 
 export type Callback<T> = (err: Error | null, result: T) => void;
@@ -15,3 +18,7 @@ export type CallbackArguments<T> = T extends (
 ) => any
 	? U
 	: never;
+
+export interface SocketOptionsInternal extends SocketOptions {
+	connect: typeof connect;
+}

--- a/packages/runtime/src/polyfills/event.ts
+++ b/packages/runtime/src/polyfills/event.ts
@@ -1,5 +1,6 @@
 import { def } from '../utils';
 import { INTERNAL_SYMBOL } from '../internal';
+import type { Socket } from '../tcp';
 
 export interface EventInit {
 	bubbles?: boolean;
@@ -512,14 +513,14 @@ export class PromiseRejectionEvent
 }
 
 export interface SocketEventInit extends EventInit {
-	fd: number;
+	socket: Socket;
 }
 
 export class SocketEvent extends Event {
-	fd: number;
+	socket: Socket;
 	constructor(type: string, init: SocketEventInit) {
 		super(type, init);
-		this.fd = init.fd;
+		this.socket = init.socket;
 	}
 }
 

--- a/packages/runtime/src/switch.ts
+++ b/packages/runtime/src/switch.ts
@@ -6,14 +6,7 @@ import { inspect } from './inspect';
 import { bufferSourceToArrayBuffer, toPromise } from './utils';
 import { setTimeout, clearTimeout } from './timers';
 import { encoder } from './polyfills/text-encoder';
-import {
-	Socket,
-	connect,
-	createServer,
-	parseAddress,
-	read,
-	write,
-} from './tcp';
+import { Socket, connect, createServer, parseAddress } from './tcp';
 import { resolve as dnsResolve } from './dns';
 import type {
 	PathLike,
@@ -630,7 +623,7 @@ export class SwitchClass extends EventTarget {
 	 * @param opts
 	 * @see https://sockets-api.proposal.wintercg.org
 	 */
-	connect2<Host extends string, Port extends string>(
+	connect<Host extends string, Port extends string>(
 		address: `${Host}:${Port}` | SocketAddress,
 		opts?: SocketOptions
 	) {
@@ -638,7 +631,7 @@ export class SwitchClass extends EventTarget {
 			// @ts-expect-error Internal constructor
 			INTERNAL_SYMBOL,
 			typeof address === 'string' ? parseAddress(address) : address,
-			opts
+			{ ...opts, connect }
 		);
 	}
 
@@ -646,10 +639,6 @@ export class SwitchClass extends EventTarget {
 		const { ip = '0.0.0.0', port } = opts;
 		return createServer(ip, port);
 	}
-
-	connect = connect;
-	read = read;
-	write = write;
 
 	networkInfo() {
 		if (!this[INTERNAL_SYMBOL].nifmInitialized) {

--- a/packages/runtime/src/switch.ts
+++ b/packages/runtime/src/switch.ts
@@ -632,7 +632,7 @@ export class SwitchClass extends EventTarget {
 	 */
 	connect2<Host extends string, Port extends string>(
 		address: `${Host}:${Port}` | SocketAddress,
-		opts: SocketOptions = {}
+		opts?: SocketOptions
 	) {
 		return new Socket(
 			// @ts-expect-error Internal constructor

--- a/packages/runtime/src/switch.ts
+++ b/packages/runtime/src/switch.ts
@@ -6,9 +6,22 @@ import { inspect } from './inspect';
 import { bufferSourceToArrayBuffer, toPromise } from './utils';
 import { setTimeout, clearTimeout } from './timers';
 import { encoder } from './polyfills/text-encoder';
-import { createServer } from './tcp';
-import type { PathLike, Stats, ConnectOpts, ListenOpts } from './types';
+import {
+	Socket,
+	connect,
+	createServer,
+	parseAddress,
+	read,
+	write,
+} from './tcp';
 import { resolve as dnsResolve } from './dns';
+import type {
+	PathLike,
+	Stats,
+	ListenOpts,
+	SocketAddress,
+	SocketOptions,
+} from './types';
 
 export type Opaque<T> = { __type: T };
 export type CanvasRenderingContext2DState =
@@ -611,19 +624,22 @@ export class SwitchClass extends EventTarget {
 	}
 
 	/**
-	 * Creates a TCP connection specified by the `hostname`
-	 * and `port`.
+	 * Creates a TCP connection to the specified `address`.
 	 *
-	 * @param opts Object containing the `port` number and `hostname` (defaults to `127.0.0.1`) to connect to.
-	 * @returns Promise that is fulfilled once the connection has been successfully established.
+	 * @param address
+	 * @param opts
+	 * @see https://sockets-api.proposal.wintercg.org
 	 */
-	async connect(opts: ConnectOpts) {
-		const { hostname = '127.0.0.1', port } = opts;
-		const [ip] = await this.resolveDns(hostname);
-		if (!ip) {
-			throw new Error(`Could not resolve "${hostname}" to an IP address`);
-		}
-		return toPromise($.connect, ip, port);
+	connect2<Host extends string, Port extends string>(
+		address: `${Host}:${Port}` | SocketAddress,
+		opts: SocketOptions = {}
+	) {
+		return new Socket(
+			// @ts-expect-error Internal constructor
+			INTERNAL_SYMBOL,
+			typeof address === 'string' ? parseAddress(address) : address,
+			opts
+		);
 	}
 
 	listen(opts: ListenOpts) {
@@ -631,16 +647,9 @@ export class SwitchClass extends EventTarget {
 		return createServer(ip, port);
 	}
 
-	read(fd: number, buffer: BufferSource) {
-		const ab = bufferSourceToArrayBuffer(buffer);
-		return toPromise($.read, fd, ab);
-	}
-
-	write(fd: number, data: string | BufferSource) {
-		const d = typeof data === 'string' ? encoder.encode(data) : data;
-		const ab = bufferSourceToArrayBuffer(d);
-		return toPromise($.write, fd, ab);
-	}
+	connect = connect;
+	read = read;
+	write = write;
 
 	networkInfo() {
 		if (!this[INTERNAL_SYMBOL].nifmInitialized) {

--- a/packages/runtime/src/switch.ts
+++ b/packages/runtime/src/switch.ts
@@ -8,6 +8,7 @@ import { setTimeout, clearTimeout } from './timers';
 import { encoder } from './polyfills/text-encoder';
 import { createServer } from './tcp';
 import type { PathLike, Stats, ConnectOpts, ListenOpts } from './types';
+import { resolve as dnsResolve } from './dns';
 
 export type Opaque<T> = { __type: T };
 export type CanvasRenderingContext2DState =
@@ -59,9 +60,6 @@ export interface Native {
 	hidGetTouchScreenStates(): Touch[] | undefined;
 	hidGetKeyboardStates(): Keys;
 	hidSendVibrationValues(v: VibrationValues): void;
-
-	// dns
-	resolveDns(cb: Callback<string[]>, hostname: string): void;
 
 	// fs
 	readFile(cb: Callback<ArrayBuffer>, path: string): void;
@@ -536,18 +534,7 @@ export class SwitchClass extends EventTarget {
 		return this.native.chdir(String(dir));
 	}
 
-	/**
-	 * Performs a DNS lookup to resolve a hostname to an array of IP addresses.
-	 *
-	 * @example
-	 *
-	 * ```typescript
-	 * const ipAddresses = await Switch.resolveDns('example.com');
-	 * ```
-	 */
-	resolveDns(hostname: string) {
-		return toPromise(this.native.resolveDns, hostname);
-	}
+	resolveDns = dnsResolve;
 
 	/**
 	 * Returns a Promise which resolves to an `ArrayBuffer` containing

--- a/packages/runtime/src/tcp.ts
+++ b/packages/runtime/src/tcp.ts
@@ -1,6 +1,159 @@
 import { $ } from './$';
+import { encoder } from './polyfills/text-encoder';
 import { SocketEvent } from './polyfills/event';
-import { assertInternalConstructor } from './utils';
+import {
+	Deferred,
+	assertInternalConstructor,
+	bufferSourceToArrayBuffer,
+	def,
+	toPromise,
+} from './utils';
+import type {
+	BufferSource,
+	SecureTransportKind,
+	SocketAddress,
+	SocketInfo,
+	SocketOptions,
+} from './types';
+import { resolve } from './dns';
+
+interface SocketInternal {
+	fd: number;
+	opened: Deferred<SocketInfo>;
+	closed: Deferred<void>;
+	secureTransport: SecureTransportKind;
+	allowHalfOpen: boolean;
+}
+
+const socketInternal = new WeakMap<Socket, SocketInternal>();
+
+export function parseAddress(address: string): SocketAddress {
+	const firstColon = address.indexOf(':');
+	return {
+		hostname: address.slice(0, firstColon),
+		port: +address.slice(firstColon + 1),
+	};
+}
+
+export function read(fd: number, buffer: BufferSource) {
+	const ab = bufferSourceToArrayBuffer(buffer);
+	return toPromise($.read, fd, ab);
+}
+
+export function write(fd: number, data: string | BufferSource) {
+	const d = typeof data === 'string' ? encoder.encode(data) : data;
+	const ab = bufferSourceToArrayBuffer(d);
+	return toPromise($.write, fd, ab);
+}
+
+/**
+ * Creates a TCP connection specified by the `hostname`
+ * and `port`.
+ *
+ * @param opts Object containing the `port` number and `hostname` (defaults to `127.0.0.1`) to connect to.
+ * @returns Promise that is fulfilled once the connection has been successfully established.
+ */
+export async function connect(opts: SocketAddress) {
+	const { hostname = '127.0.0.1', port } = opts;
+	const [ip] = await resolve(hostname);
+	if (!ip) {
+		throw new Error(`Could not resolve "${hostname}" to an IP address`);
+	}
+	return toPromise($.connect, ip, port);
+}
+
+export class Socket {
+	readonly readable: ReadableStream;
+	readonly writable: WritableStream;
+
+	readonly opened: Promise<SocketInfo>;
+	readonly closed: Promise<void>;
+
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		const address: SocketAddress = arguments[1];
+		const {
+			secureTransport = 'off',
+			allowHalfOpen = false,
+		}: SocketOptions = arguments[2];
+		assertInternalConstructor(arguments);
+		const socket = this;
+		const i: SocketInternal = {
+			fd: -1,
+			opened: new Deferred(),
+			closed: new Deferred(),
+			secureTransport,
+			allowHalfOpen,
+		};
+		socketInternal.set(this, i);
+		this.opened = i.opened.promise;
+		this.closed = i.closed.promise;
+
+		const readBuffer = new ArrayBuffer(64 * 1024);
+		this.readable = new ReadableStream({
+			async pull(controller) {
+				if (i.opened.pending) {
+					await socket.opened;
+				}
+				const bytesRead = await read(i.fd, readBuffer);
+				if (bytesRead === 0) {
+					controller.close();
+					if (!allowHalfOpen) {
+						socket.close();
+					}
+					return;
+				}
+				controller.enqueue(readBuffer.slice(0, bytesRead));
+			},
+		});
+		this.writable = new WritableStream({
+			async write(chunk, controller) {
+				if (i.opened.pending) {
+					await socket.opened;
+				}
+				await write(i.fd, chunk);
+			},
+		});
+
+		connect(address)
+			.then((fd) => {
+				i.fd = fd;
+				i.opened.resolve({
+					localAddress: '',
+					remoteAddress: '',
+				});
+			})
+			.catch((err) => {
+				this.close(err);
+			});
+	}
+
+	/**
+	 * Closes the socket and its underlying connection.
+	 */
+	close(reason?: any) {
+		this.readable.cancel(reason);
+		this.writable.abort(reason);
+		const i = socketInternal.get(this);
+		if (i && i.opened.pending) {
+			i.opened.reject(reason);
+		}
+		return this.closed;
+	}
+
+	/**
+	 * Enables opportunistic TLS (otherwise known as
+	 * {@link https://en.wikipedia.org/wiki/Opportunistic_TLS | StartTLS})
+	 * which is a requirement for some protocols
+	 * (primarily postgres/mysql and other DB protocols).
+	 */
+	startTls(): Socket {
+		throw new Error('Method not implemented.');
+	}
+}
+def('Socket', Socket);
 
 export class Server extends EventTarget {
 	/**
@@ -42,6 +195,7 @@ export class Server extends EventTarget {
 	close() {}
 }
 $.tcpInitServer(Server);
+def('Server', Server);
 
 export function createServer(ip: string, port: number) {
 	const server = $.tcpServerNew(ip, port, function onAccept(fd) {

--- a/packages/runtime/src/tcp.ts
+++ b/packages/runtime/src/tcp.ts
@@ -63,8 +63,8 @@ export async function connect(opts: SocketAddress) {
 }
 
 export class Socket {
-	readonly readable: ReadableStream;
-	readonly writable: WritableStream;
+	readonly readable: ReadableStream<Uint8Array>;
+	readonly writable: WritableStream<Uint8Array>;
 
 	readonly opened: Promise<SocketInfo>;
 	readonly closed: Promise<void>;
@@ -105,7 +105,7 @@ export class Socket {
 					}
 					return;
 				}
-				controller.enqueue(readBuffer.slice(0, bytesRead));
+				controller.enqueue(new Uint8Array(readBuffer, 0, bytesRead));
 			},
 		});
 		this.writable = new WritableStream({

--- a/packages/runtime/src/tcp.ts
+++ b/packages/runtime/src/tcp.ts
@@ -62,6 +62,13 @@ export async function connect(opts: SocketAddress) {
 	return toPromise($.connect, ip, port);
 }
 
+/**
+ * The `Socket` class represents a TCP connection, from which you can
+ * read and write data. A socket begins in a _connected_ state (if the
+ * socket fails to connect, an error is thrown). While in a _connected_
+ * state, the socket’s `ReadableStream` and `WritableStream` can be
+ * read from and written to respectively.
+ */
 export class Socket {
 	readonly readable: ReadableStream<Uint8Array>;
 	readonly writable: WritableStream<Uint8Array>;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,3 +1,6 @@
+import type { SwitchClass } from './switch';
+import type { Socket } from './tcp';
+
 export type PathLike = string | URL;
 
 export interface Stats {
@@ -90,7 +93,19 @@ export interface SocketAddress {
 export type SecureTransportKind = 'off' | 'on' | 'starttls';
 
 export interface SocketOptions {
+	/**
+	 * Specifies whether or not to use TLS when creating the TCP socket.
+	 *  - `off` — Do not use TLS.
+	 *  - `on` — Use TLS.
+	 *  - `starttls` — Do not use TLS initially, but allow the socket to be upgraded to use TLS by calling {@link Socket.startTls | `startTls()`}.
+	 */
 	secureTransport?: SecureTransportKind;
+	/**
+	 * Defines whether the writable side of the TCP socket will automatically close on end-of-file (EOF).
+	 * When set to false, the writable side of the TCP socket will automatically close on EOF.
+	 * When set to true, the writable side of the TCP socket will remain open on EOF.
+	 * This option is similar to that offered by the Node.js net module and allows interoperability with code which utilizes it.
+	 */
 	allowHalfOpen?: boolean;
 }
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -29,26 +29,8 @@ export interface ArrayBufferView {
 
 export type BufferSource = ArrayBufferView | ArrayBuffer;
 
-/**
- * Specifies the port number and optional hostname for connecting
- * to a remove server over the network.
- *
- * {@link SwitchClass.connect}
- */
 export interface ConnectOpts {
-	/**
-	 * The hostname of the destination server to connect to.
-	 *
-	 * If not defined, then `hostname` defaults to `127.0.0.1`.
-	 *
-	 * @example "example.com"
-	 */
 	hostname?: string;
-	/**
-	 * The port number to connect to.
-	 *
-	 * @example 80
-	 */
 	port: number;
 }
 
@@ -80,4 +62,39 @@ export interface NetworkInfo {
 	ip: string;
 	subnetMask: string;
 	gateway: string;
+}
+
+/**
+ * Specifies the port number and optional hostname for connecting
+ * to a remove server over the network.
+ *
+ * {@link SwitchClass.connect}
+ */
+export interface SocketAddress {
+	/**
+	 * The hostname of the destination server to connect to.
+	 *
+	 * If not defined, then `hostname` defaults to `127.0.0.1`.
+	 *
+	 * @example "example.com"
+	 */
+	hostname: string;
+	/**
+	 * The port number to connect to.
+	 *
+	 * @example 80
+	 */
+	port: number;
+}
+
+export type SecureTransportKind = 'off' | 'on' | 'starttls';
+
+export interface SocketOptions {
+	secureTransport?: SecureTransportKind;
+	allowHalfOpen?: boolean;
+}
+
+export interface SocketInfo {
+	remoteAddress: string;
+	localAddress: string;
 }

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -63,8 +63,14 @@ export class Deferred<T> {
 	reject!: (v: any) => void;
 	constructor() {
 		this.promise = new Promise<T>((res, rej) => {
-			this.resolve = res;
-			this.reject = rej;
+			this.resolve = (v) => {
+				this.pending = false;
+				res(v);
+			};
+			this.reject = (v) => {
+				this.pending = false;
+				rej(v);
+			};
 		});
 	}
 }

--- a/source/dns.h
+++ b/source/dns.h
@@ -1,14 +1,4 @@
 #pragma once
-#include <switch.h>
-#include <quickjs/quickjs.h>
 #include "types.h"
 
-typedef struct
-{
-    int err;
-    const char *hostname;
-    char **entries;
-    size_t num_entries;
-} nx_dns_resolve_t;
-
-JSValue js_dns_resolve(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv);
+void nx_init_dns(JSContext *ctx, JSValueConst init_obj);

--- a/source/main.c
+++ b/source/main.c
@@ -475,6 +475,7 @@ int main(int argc, char *argv[])
     JSValue init_obj = JS_NewObject(ctx);
     nx_init_error(ctx, init_obj);
     nx_init_battery(ctx, init_obj);
+    nx_init_dns(ctx, init_obj);
     nx_init_nifm(ctx, init_obj);
     nx_init_tcp(ctx, init_obj);
     nx_init_swkbd(ctx, init_obj);
@@ -589,10 +590,7 @@ int main(int argc, char *argv[])
 
         // framebuffer renderer
         JS_CFUNC_DEF("framebufferInit", 0, js_framebuffer_init),
-        JS_CFUNC_DEF("framebufferExit", 0, js_framebuffer_exit),
-
-        // dns
-        JS_CFUNC_DEF("resolveDns", 0, js_dns_resolve)};
+        JS_CFUNC_DEF("framebufferExit", 0, js_framebuffer_exit)};
     JS_SetPropertyFunctionList(ctx, native_obj, function_list, countof(function_list));
 
     // `Switch.entrypoint`

--- a/source/poll.c
+++ b/source/poll.c
@@ -179,8 +179,8 @@ int nx_tcp_connect(nx_poll_t *p, nx_connect_t *req, const char *ip, int port, nx
 
     if (set_nonblocking(sockfd) == -1)
     {
-        close(sockfd);
         printf("fcntl() err: %s\n", strerror(errno));
+        close(sockfd);
         return -1;
     }
 
@@ -198,9 +198,9 @@ int nx_tcp_connect(nx_poll_t *p, nx_connect_t *req, const char *ip, int port, nx
     int r = connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
     if (r < 0 && errno != EINPROGRESS)
     {
-        close(sockfd);
         req->err = errno;
         printf("connect() err: %s\n", strerror(errno));
+        close(sockfd);
         return -1;
     }
     if (r == 0)
@@ -209,6 +209,7 @@ int nx_tcp_connect(nx_poll_t *p, nx_connect_t *req, const char *ip, int port, nx
         req->err = -EINVAL;
         return -1;
     }
+    errno = 0;
 
     req->fd = sockfd;
     req->events = POLLOUT | POLLERR;

--- a/source/tcp.c
+++ b/source/tcp.c
@@ -177,6 +177,20 @@ JSValue nx_js_tcp_write(JSContext *ctx, JSValueConst this_val, int argc, JSValue
     return JS_UNDEFINED;
 }
 
+JSValue nx_js_tcp_close(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    int fd;
+    if (JS_ToInt32(ctx, &fd, argv[0])) {
+        return JS_EXCEPTION;
+    }
+    if (close(fd)) {
+        // TODO: Throw a regular error
+        JS_ThrowTypeError(ctx, strerror(errno));
+        return JS_EXCEPTION;
+    }
+    return JS_UNDEFINED;
+}
+
 static JSClassID nx_tcp_server_class_id;
 
 typedef struct
@@ -278,6 +292,7 @@ static const JSCFunctionListEntry function_list[] = {
     JS_CFUNC_DEF("connect", 1, nx_js_tcp_connect),
     JS_CFUNC_DEF("read", 1, nx_js_tcp_read),
     JS_CFUNC_DEF("write", 1, nx_js_tcp_write),
+    JS_CFUNC_DEF("close", 1, nx_js_tcp_close),
 
     JS_CFUNC_DEF("tcpInitServer", 1, nx_js_tcp_init_server),
     JS_CFUNC_DEF("tcpServerNew", 3, nx_js_tcp_server_new)};


### PR DESCRIPTION
Adds a `Socket` class which implements the spec defined in the [WinterCG `Socket` spec](https://sockets-api.proposal.wintercg.org/).

`Switch.connect()` has been updated to return an instance of this class as well as match the `connect()` function defined in that spec.

Internally, `fetch()` has been updated to leverage the `Socket` instance, and the "starwars" demo app has also been updated.

Closes #30.