### PR TITLE
Add HarfBuzz

### DIFF
--- a/.changeset/kind-zoos-fix.md
+++ b/.changeset/kind-zoos-fix.md
@@ -1,0 +1,5 @@
+---
+'nxjs-runtime': patch
+---
+
+Use HarfBuzz for Canvas text placement and measurement

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:=  -pthread -lmbedtls -lmbedx509 -lmbedcrypto -lharfbuzz-cairo -lharfbuzz `freetype-config --libs` `aarch64-none-elf-pkg-config cairo --libs` -lturbojpeg -lwebp -lquickjs -lm3 -lm
+LIBS	:=  -pthread -lmbedtls -lmbedx509 -lmbedcrypto -lharfbuzz `freetype-config --libs` `aarch64-none-elf-pkg-config cairo --libs` -lturbojpeg -lwebp -lquickjs -lm3 -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:=  -pthread -lmbedtls -lmbedx509 -lmbedcrypto `freetype-config --libs` `aarch64-none-elf-pkg-config cairo --libs` -lturbojpeg -lwebp -lquickjs -lm3 -lm
+LIBS	:=  -pthread -lmbedtls -lmbedx509 -lmbedcrypto -lharfbuzz-cairo -lharfbuzz `freetype-config --libs` `aarch64-none-elf-pkg-config cairo --libs` -lturbojpeg -lwebp -lquickjs -lm3 -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/apps/2048/src/canvas_actuator.js
+++ b/apps/2048/src/canvas_actuator.js
@@ -221,7 +221,7 @@ export class CanvasActuator {
 			ctx.fillText(
 				val,
 				x + this.tileSize / 2 - m.width / 2,
-				y + this.tileSize / 2 + m.height / 2
+				y + this.tileSize / 2 + fontSize / 2
 			);
 		}
 	}
@@ -257,7 +257,7 @@ export class CanvasActuator {
 		const scoreMeasure = ctx.measureText(scoreStr);
 		const scoreTextX = scoreX + (scoreWidth / 2 - scoreMeasure.width / 2);
 		const scoreTextY =
-			10 + scoreY + (scoreHeight / 2 + scoreMeasure.height / 2);
+			10 + scoreY + (scoreHeight / 2 + 36 / 2);
 		ctx.fillText(scoreStr, scoreTextX, scoreTextY);
 
 		const now = Date.now();
@@ -311,7 +311,7 @@ export class CanvasActuator {
 		const message = won ? 'You win!' : 'Game over!';
 		const m = this.ctx.measureText(message);
 		const x = this.gridX + (this.gridSize / 2 - m.width / 2);
-		const y = this.gridY + (this.gridSize / 2 + m.height / 2);
+		const y = this.gridY + (this.gridSize / 2 + 64 / 2);
 		this.ctx.fillText(message, x, y);
 	}
 }

--- a/packages/runtime/src/canvas/canvas-rendering-context-2d.ts
+++ b/packages/runtime/src/canvas/canvas-rendering-context-2d.ts
@@ -747,7 +747,7 @@ export class CanvasRenderingContext2D {
 		y: number,
 		maxWidth?: number | undefined
 	): void {
-		throw new Error('Method not implemented.');
+		stub();
 	}
 
 	createConicGradient(

--- a/packages/runtime/src/canvas/canvas-rendering-context-2d.ts
+++ b/packages/runtime/src/canvas/canvas-rendering-context-2d.ts
@@ -747,7 +747,7 @@ export class CanvasRenderingContext2D {
 		y: number,
 		maxWidth?: number | undefined
 	): void {
-		stub();
+		throw new Error('Method not implemented.');
 	}
 
 	createConicGradient(

--- a/packages/runtime/src/switch.ts
+++ b/packages/runtime/src/switch.ts
@@ -127,6 +127,7 @@ interface SwitchEventHandlersEventMap {
 export interface Versions {
 	cairo: string;
 	freetype2: string;
+	harfbuzz: string;
 	nxjs: string;
 	png: string;
 	quickjs: string;

--- a/source/canvas.c
+++ b/source/canvas.c
@@ -468,6 +468,7 @@ static JSValue nx_canvas_context_2d_set_font(JSContext *ctx, JSValueConst this_v
     cairo_set_font_face(context->ctx, face->cairo_font);
     cairo_set_font_size(context->ctx, font_size);
     context->ft_face = face->ft_face;
+    context->hb_font = face->hb_font;
     return JS_UNDEFINED;
 }
 
@@ -540,6 +541,109 @@ static JSValue nx_canvas_context_2d_fill_text(JSContext *ctx, JSValueConst this_
 
     cairo_show_text(context->ctx, text);
     JS_FreeCString(ctx, text);
+    return JS_UNDEFINED;
+}
+
+static JSValue nx_canvas_context_2d_stroke_text(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    CANVAS_CONTEXT_THIS;
+    double args[2];
+    if (js_validate_doubles_args(ctx, argv, args, 2, 1))
+        return JS_EXCEPTION;
+
+    const char *text = JS_ToCString(ctx, argv[0]);
+    if (!text)
+        return JS_EXCEPTION;
+
+    save_path(context);
+    cairo_move_to(context->ctx, args[0], args[1]);
+
+    cairo_text_path(context->ctx, text);
+    // Create a buffer for harfbuzz to use
+//    hb_buffer_t *hb_buffer = hb_buffer_create();
+//
+//    // Add text to buffer
+//    hb_buffer_add_utf8(hb_buffer, text, -1, 0, -1);
+//	//hb_buffer_guess_segment_properties(hb_buffer);
+//
+//    // Set script, language and direction of the text
+//    hb_buffer_set_direction(hb_buffer, HB_DIRECTION_LTR);
+//    hb_buffer_set_script(hb_buffer, HB_SCRIPT_LATIN);
+//    hb_buffer_set_language(hb_buffer, hb_language_from_string("en", -1));
+//
+//    // Shape the text
+//    hb_shape(context->hb_font, hb_buffer, NULL, 0);
+//
+//	// Convert HarfBuzz buffer to Cairo glyphs
+//    unsigned int num_glyphs;
+//    hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(hb_buffer, &num_glyphs);
+//    hb_glyph_position_t *glyph_pos = hb_buffer_get_glyph_positions(hb_buffer, &num_glyphs);
+//
+//    //cairo_glyph_t *cairo_glyphs = (cairo_glyph_t *)calloc(num_glyphs, sizeof(cairo_glyph_t));
+//    //for (unsigned int i = 0; i < num_glyphs; ++i) {
+//    //    cairo_glyphs[i].index = glyph_info[i].codepoint;
+//    //    cairo_glyphs[i].x = ((i + 1) * 25) + glyph_pos[i].x_offset / 64.0;
+//    //    cairo_glyphs[i].y = 100 + -glyph_pos[i].y_offset / 64.0;
+//    //}
+//        // Draw each glyph out one at a time
+//	double cursor_x = args[0];
+//    double cursor_y = args[1];
+//    for (unsigned int i = 0; i < num_glyphs; i++) {
+//        hb_codepoint_t glyph = glyph_info[i].codepoint;
+//        double x_advance =glyph_pos[i].x_advance / 64.;
+//        double y_advance =glyph_pos[i].y_advance / 64.;
+//        double x_offset = glyph_pos[i].x_offset / 64.;
+//        double y_offset = glyph_pos[i].y_offset / 64.;
+//		fprintf(stderr, "i: %u, glyph: %d, x_advance: %f, y_advance: %f, x_offset: %f, y_offset: %f\n", i, glyph, x_advance, y_advance, x_offset, y_offset);
+//
+//        // Draw the glyph at its position
+//        cairo_glyph_t cairo_glyph;
+//        cairo_glyph.index = glyph;
+//        cairo_glyph.x = x_offset;
+//        cairo_glyph.y = -y_offset;
+//        cairo_show_glyphs(context->ctx, &cairo_glyph, 1);
+//
+//        // Move the cairo cursor forward
+//        //cairo_rel_move_to(context->ctx, x_advance, -y_advance);
+//		cursor_x += x_advance;
+//        cursor_y += y_advance;
+//    }
+
+	// Convert HarfBuzz buffer to Cairo glyphs
+//    cairo_glyph_t *cairo_glyphs;
+//    unsigned int num_glyphs;
+//	cairo_text_cluster_t *clusters;
+//    unsigned int num_clusters;
+//    cairo_text_cluster_flags_t cluster_flags;
+//
+//	hb_cairo_glyphs_from_buffer(
+//        hb_buffer,
+//        true, // utf8_clusters
+//        10.0, // x_scale_factor
+//        10.0, // y_scale_factor
+//        500.0, // x
+//        500.0, // y
+//        text, // utf8
+//        -1, // utf8_len (auto-detect length)
+//        &cairo_glyphs,
+//        &num_glyphs,
+//        &clusters,
+//        &num_clusters,
+//        &cluster_flags
+//    );
+
+    // Draw the text onto the Cairo surface
+    //cairo_glyph_path(context->ctx, cairo_glyphs, num_glyphs);
+
+    stroke(context, false);
+
+    restore_path(context);
+
+    //cairo_glyph_free(cairo_glyphs);
+    //cairo_text_cluster_free(clusters);
+    //hb_buffer_destroy(hb_buffer);
+    JS_FreeCString(ctx, text);
+
     return JS_UNDEFINED;
 }
 
@@ -1831,6 +1935,7 @@ static JSValue nx_canvas_context_2d_init_class(JSContext *ctx, JSValueConst this
     NX_DEF_FUNC(proto, "setLineDash", nx_canvas_context_2d_set_line_dash, 1);
     NX_DEF_FUNC(proto, "stroke", nx_canvas_context_2d_stroke, 0);
     NX_DEF_FUNC(proto, "strokeRect", nx_canvas_context_2d_stroke_rect, 4);
+    NX_DEF_FUNC(proto, "strokeText", nx_canvas_context_2d_stroke_text, 3);
     NX_DEF_FUNC(proto, "transform", nx_canvas_context_2d_transform, 6);
     NX_DEF_FUNC(proto, "translate", nx_canvas_context_2d_translate, 2);
     JS_FreeValue(ctx, proto);

--- a/source/canvas.h
+++ b/source/canvas.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cairo.h>
+#include <harfbuzz/hb.h>
 #include "types.h"
 
 /**
@@ -31,6 +32,7 @@ typedef struct
     cairo_t *ctx;
     cairo_path_t *path;
     cairo_filter_t image_smoothing_quality;
+    hb_font_t *hb_font;
     FT_Face ft_face;
     bool image_smoothing_enabled;
     double global_alpha;

--- a/source/font.c
+++ b/source/font.c
@@ -29,7 +29,19 @@ static JSValue nx_new_font_face(JSContext *ctx, JSValueConst this_val, int argc,
                        0,         /* face_index           */
                        &context->ft_face);
 
+	FT_Set_Char_Size(
+        context->ft_face,    /* handle to face object           */
+        0,          /* char_width in 1/64th of points  */
+        1*64,    /* char_height in 1/64th of points */
+        0,          /* horizontal device resolution    */
+        0);         /* vertical device resolution      */
+
+    // Create a HarfBuzz font
+    context->hb_font = NULL;
+    //context->hb_font = hb_ft_font_create(context->ft_face, NULL);
+
     // Create a Cairo font face from the FreeType face
+	//context->cairo_font = hb_cairo_font_face_create_for_font(context->hb_font);
     context->cairo_font = cairo_ft_font_face_create_for_ft_face(context->ft_face, FT_LOAD_COLOR | FT_LOAD_RENDER);
     // printf("ft_face %p, cairo_font: %p\n", context->ft_face, context->cairo_font);
 
@@ -52,6 +64,10 @@ static JSValue nx_font_face_dispose(JSContext *ctx, JSValueConst this_val, int a
     {
         FT_Done_Face(context->ft_face);
         context->ft_face = NULL;
+    }
+    if (context->hb_font) {
+        hb_font_destroy(context->hb_font);
+        context->hb_font = NULL;
     }
     if (context->cairo_font)
     {
@@ -82,6 +98,9 @@ static void finalizer_font_face(JSRuntime *rt, JSValue val)
         if (context->ft_face)
         {
             FT_Done_Face(context->ft_face);
+        }
+        if (context->hb_font) {
+            hb_font_destroy(context->hb_font);
         }
         if (context->cairo_font)
         {

--- a/source/font.h
+++ b/source/font.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <quickjs/quickjs.h>
+#include <cairo.h>
 #include <ft2build.h>
 #include <harfbuzz/hb.h>
 #include <harfbuzz/hb-ft.h>
-#include <harfbuzz/hb-cairo.h>
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/source/font.h
+++ b/source/font.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <quickjs/quickjs.h>
-#include <cairo-ft.h>
 #include <ft2build.h>
+#include <harfbuzz/hb.h>
+#include <harfbuzz/hb-ft.h>
+#include <harfbuzz/hb-cairo.h>
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
@@ -10,6 +12,7 @@
 typedef struct
 {
     FT_Face ft_face;
+    hb_font_t *hb_font;
     cairo_font_face_t *cairo_font;
     JSValue font_buffer;
 } nx_font_face_t;

--- a/source/main.c
+++ b/source/main.c
@@ -568,6 +568,7 @@ int main(int argc, char *argv[])
     JSValue version_obj = JS_NewObject(ctx);
     JS_SetPropertyStr(ctx, version_obj, "cairo", JS_NewString(ctx, cairo_version_string()));
     JS_SetPropertyStr(ctx, version_obj, "freetype2", JS_NewString(ctx, FREETYPE_VERSION_STR));
+    JS_SetPropertyStr(ctx, version_obj, "harfbuzz", JS_NewString(ctx, HB_VERSION_STRING));
     JS_SetPropertyStr(ctx, version_obj, "mbedtls", JS_NewString(ctx, MBEDTLS_VERSION_STRING));
     JS_SetPropertyStr(ctx, version_obj, "nxjs", JS_NewString(ctx, NXJS_VERSION));
     JS_SetPropertyStr(ctx, version_obj, "png", JS_NewString(ctx, PNG_LIBPNG_VER_STRING));


### PR DESCRIPTION
Use `libharfbuzz` for fonts. Using the HarfBuzz API directly gives greater control over the positioning of glyphs, and allows for more precise text measurements.