### PR TITLE
Fix Canvas `font`, `fillStyle`, `strokeStyle` after `ctx.restore()`

### DIFF
--- a/.changeset/rude-olives-travel.md
+++ b/.changeset/rude-olives-travel.md
@@ -1,0 +1,5 @@
+---
+'nxjs-runtime': patch
+---
+
+Fix Canvas `font`, `fillStyle`, `strokeStyle` after `ctx.restore()`

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -39,15 +39,25 @@ export interface Init {
 	canvasContext2dGetTransform(
 		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
 	): number[];
+	canvasContext2dGetFont(
+		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
+	): string;
 	canvasContext2dSetFont(
 		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
 		font: FontFace,
-		size: number
+		size: number,
+		fontString: string
 	): number[];
+	canvasContext2dGetFillStyle(
+		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
+	): RGBA;
 	canvasContext2dSetFillStyle(
 		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
 		...rgba: RGBA
 	): number[];
+	canvasContext2dGetStrokeStyle(
+		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
+	): RGBA;
 	canvasContext2dSetStrokeStyle(
 		ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
 		...rgba: RGBA

--- a/packages/runtime/src/canvas/canvas-rendering-context-2d.ts
+++ b/packages/runtime/src/canvas/canvas-rendering-context-2d.ts
@@ -22,16 +22,12 @@ import type {
 	GlobalCompositeOperation,
 	ImageSmoothingQuality,
 } from '../types';
-import type { RGBA } from '../internal';
 import type { SwitchClass } from '../switch';
 
 declare const Switch: SwitchClass;
 
 interface CanvasRenderingContext2DInternal {
 	canvas: Screen;
-	fillStyle: RGBA;
-	strokeStyle: RGBA;
-	font: string;
 }
 
 const _ = createInternal<
@@ -48,12 +44,7 @@ export class CanvasRenderingContext2D {
 		const canvas: Screen = arguments[1];
 		const ctx = $.canvasContext2dNew(canvas);
 		Object.setPrototypeOf(ctx, CanvasRenderingContext2D.prototype);
-		_.set(ctx, {
-			canvas,
-			strokeStyle: [0, 0, 0, 1],
-			fillStyle: [0, 0, 0, 1],
-			font: '',
-		});
+		_.set(ctx, { canvas });
 		ctx.font = '10px system-ui';
 		return ctx;
 	}
@@ -77,12 +68,10 @@ export class CanvasRenderingContext2D {
 	 * @see https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/font
 	 */
 	get font(): string {
-		return _(this).font;
+		return $.canvasContext2dGetFont(this);
 	}
 	set font(v: string) {
-		if (!v) return;
-		const i = _(this);
-		if (i.font === v) return;
+		if (!v || this.font === v) return;
 
 		const parsed = parseCssFont(v);
 		if ('system' in parsed) {
@@ -111,8 +100,7 @@ export class CanvasRenderingContext2D {
 				return;
 			}
 		}
-		i.font = v;
-		$.canvasContext2dSetFont(this, font, px);
+		$.canvasContext2dSetFont(this, font, px, v);
 	}
 
 	/**
@@ -147,7 +135,7 @@ export class CanvasRenderingContext2D {
 	 * @see https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillStyle
 	 */
 	get fillStyle(): string {
-		return rgbaToString(_(this).fillStyle);
+		return rgbaToString($.canvasContext2dGetFillStyle(this));
 	}
 	set fillStyle(v: string) {
 		if (typeof v === 'string') {
@@ -155,7 +143,6 @@ export class CanvasRenderingContext2D {
 			if (!parsed || parsed.length !== 4) {
 				return;
 			}
-			_(this).fillStyle = parsed;
 			$.canvasContext2dSetFillStyle(this, ...parsed);
 		} else {
 			throw new Error('CanvasGradient/CanvasPattern not implemented.');
@@ -169,7 +156,7 @@ export class CanvasRenderingContext2D {
 	 * @see https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/strokeStyle
 	 */
 	get strokeStyle(): string {
-		return rgbaToString(_(this).strokeStyle);
+		return rgbaToString($.canvasContext2dGetStrokeStyle(this));
 	}
 	set strokeStyle(v: string) {
 		if (typeof v === 'string') {
@@ -177,7 +164,6 @@ export class CanvasRenderingContext2D {
 			if (!parsed || parsed.length !== 4) {
 				return;
 			}
-			_(this).strokeStyle = parsed;
 			$.canvasContext2dSetStrokeStyle(this, ...parsed);
 		} else {
 			throw new Error('CanvasGradient/CanvasPattern not implemented.');

--- a/packages/runtime/src/canvas/offscreen-canvas-rendering-context-2d.ts
+++ b/packages/runtime/src/canvas/offscreen-canvas-rendering-context-2d.ts
@@ -20,16 +20,12 @@ import type {
 	GlobalCompositeOperation,
 	ImageSmoothingQuality,
 } from '../types';
-import type { RGBA } from '../internal';
 import type { SwitchClass } from '../switch';
 
 declare const Switch: SwitchClass;
 
 interface OffscreenCanvasRenderingContext2DInternal {
 	canvas: OffscreenCanvas;
-	fillStyle: RGBA;
-	strokeStyle: RGBA;
-	font: string;
 }
 
 const _ = createInternal<
@@ -46,12 +42,7 @@ export class OffscreenCanvasRenderingContext2D {
 		const canvas: OffscreenCanvas = arguments[1];
 		const ctx = $.canvasContext2dNew(canvas);
 		Object.setPrototypeOf(ctx, OffscreenCanvasRenderingContext2D.prototype);
-		_.set(ctx, {
-			canvas,
-			strokeStyle: [0, 0, 0, 1],
-			fillStyle: [0, 0, 0, 1],
-			font: '',
-		});
+		_.set(ctx, { canvas });
 		ctx.font = '10px system-ui';
 		return ctx;
 	}
@@ -73,12 +64,10 @@ export class OffscreenCanvasRenderingContext2D {
 	 * @see https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/font
 	 */
 	get font(): string {
-		return _(this).font;
+		return $.canvasContext2dGetFont(this);
 	}
 	set font(v: string) {
-		if (!v) return;
-		const i = _(this);
-		if (i.font === v) return;
+		if (!v || this.font === v) return;
 
 		const parsed = parseCssFont(v);
 		if ('system' in parsed) {
@@ -107,8 +96,7 @@ export class OffscreenCanvasRenderingContext2D {
 				return;
 			}
 		}
-		i.font = v;
-		$.canvasContext2dSetFont(this, font, px);
+		$.canvasContext2dSetFont(this, font, px, v);
 	}
 
 	/**
@@ -143,7 +131,7 @@ export class OffscreenCanvasRenderingContext2D {
 	 * @see https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/fillStyle
 	 */
 	get fillStyle(): string {
-		return rgbaToString(_(this).fillStyle);
+		return rgbaToString($.canvasContext2dGetFillStyle(this));
 	}
 	set fillStyle(v: string) {
 		if (typeof v === 'string') {
@@ -151,7 +139,6 @@ export class OffscreenCanvasRenderingContext2D {
 			if (!parsed || parsed.length !== 4) {
 				return;
 			}
-			_(this).fillStyle = parsed;
 			$.canvasContext2dSetFillStyle(this, ...parsed);
 		} else {
 			throw new Error('CanvasGradient/CanvasPattern not implemented.');
@@ -165,7 +152,7 @@ export class OffscreenCanvasRenderingContext2D {
 	 * @see https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/strokeStyle
 	 */
 	get strokeStyle(): string {
-		return rgbaToString(_(this).strokeStyle);
+		return rgbaToString($.canvasContext2dGetStrokeStyle(this));
 	}
 	set strokeStyle(v: string) {
 		if (typeof v === 'string') {
@@ -173,7 +160,6 @@ export class OffscreenCanvasRenderingContext2D {
 			if (!parsed || parsed.length !== 4) {
 				return;
 			}
-			_(this).strokeStyle = parsed;
 			$.canvasContext2dSetStrokeStyle(this, ...parsed);
 		} else {
 			throw new Error('CanvasGradient/CanvasPattern not implemented.');

--- a/source/canvas.c
+++ b/source/canvas.c
@@ -469,6 +469,8 @@ static JSValue nx_canvas_context_2d_set_font(JSContext *ctx, JSValueConst this_v
 {
 	CANVAS_CONTEXT_ARGV0;
 
+	JS_FreeValue(ctx, context->state->font);
+
 	context->state->font = JS_DupValue(ctx, argv[1]);
 	nx_font_face_t *face = nx_get_font_face(ctx, context->state->font);
 	if (!face)

--- a/source/canvas.c
+++ b/source/canvas.c
@@ -1293,6 +1293,10 @@ static JSValue nx_canvas_context_2d_save(JSContext *ctx, JSValueConst this_val, 
 	memcpy(state, context->state, sizeof(nx_canvas_context_2d_state_t));
 	state->next = context->state;
 	state->font = context->state->font;
+	if (context->state->font_string)
+	{
+		state->font_string = strdup(context->state->font_string);
+	}
 	context->state = state;
 	return JS_UNDEFINED;
 }
@@ -2078,6 +2082,7 @@ static JSValue nx_canvas_context_2d_new(JSContext *ctx, JSValueConst this_val, i
 	context->ctx = cairo_create(canvas->surface);
 
 	// Match browser defaults
+	state->next = NULL;
 	state->font = JS_UNDEFINED;
 	state->font_size = 10.;
 	state->fill.a = 1.;

--- a/source/canvas.c
+++ b/source/canvas.c
@@ -469,9 +469,7 @@ static JSValue nx_canvas_context_2d_set_font(JSContext *ctx, JSValueConst this_v
 {
 	CANVAS_CONTEXT_ARGV0;
 
-	JS_FreeValue(ctx, context->state->font);
-
-	context->state->font = JS_DupValue(ctx, argv[1]);
+	context->state->font = argv[1];
 	nx_font_face_t *face = nx_get_font_face(ctx, context->state->font);
 	if (!face)
 		return JS_EXCEPTION;
@@ -1096,14 +1094,10 @@ static JSValue nx_canvas_context_2d_draw_image(JSContext *ctx, JSValueConst this
 
 static void finalizer_canvas_context_2d_state(JSRuntime *rt, nx_canvas_context_2d_state_t *state)
 {
-	fprintf(stderr, "finalizer_canvas_context_2d_state\n");
+	// printf("finalizer_canvas_context_2d_state\n");
 	if (state->next)
 	{
 		finalizer_canvas_context_2d_state(rt, state->next);
-	}
-	if (!JS_IsUndefined(state->font))
-	{
-		JS_FreeValueRT(rt, state->font);
 	}
 	if (state->font_string)
 	{
@@ -1114,7 +1108,7 @@ static void finalizer_canvas_context_2d_state(JSRuntime *rt, nx_canvas_context_2
 
 static void finalizer_canvas_context_2d(JSRuntime *rt, JSValue val)
 {
-	fprintf(stderr, "finalizer_canvas_context_2d\n");
+	// printf("finalizer_canvas_context_2d\n");
 	nx_canvas_context_2d_t *context = JS_GetOpaque(val, nx_canvas_context_class_id);
 	if (context)
 	{
@@ -1298,7 +1292,7 @@ static JSValue nx_canvas_context_2d_save(JSContext *ctx, JSValueConst this_val, 
 	nx_canvas_context_2d_state_t *state = js_mallocz(ctx, sizeof(nx_canvas_context_2d_state_t));
 	memcpy(state, context->state, sizeof(nx_canvas_context_2d_state_t));
 	state->next = context->state;
-	state->font = JS_DupValue(ctx, context->state->font);
+	state->font = context->state->font;
 	context->state = state;
 	return JS_UNDEFINED;
 }
@@ -1311,7 +1305,6 @@ static JSValue nx_canvas_context_2d_restore(JSContext *ctx, JSValueConst this_va
 		cairo_restore(cr);
 		nx_canvas_context_2d_state_t *prev = context->state;
 		context->state = prev->next;
-		JS_FreeValue(ctx, prev->font);
 		if (prev->font_string)
 		{
 			free((void *)prev->font_string);

--- a/source/canvas.h
+++ b/source/canvas.h
@@ -35,29 +35,25 @@ typedef struct nx_canvas_context_2d_state_s
 
 	nx_rgba_t fill;
 	nx_rgba_t stroke;
-	//nx_rgba_t shadow;
-	//double shadowOffsetX;
-	//double shadowOffsetY;
-	//cairo_pattern_t *fillPattern;
-	//cairo_pattern_t *strokePattern;
-	//cairo_pattern_t *fillGradient;
-	//cairo_pattern_t *strokeGradient;
-	// PangoFontDescription *fontDescription;
-	// std::string fontStr;
-	//cairo_filter_t image;
-	//int shadowBlur;
+	// nx_rgba_t shadow;
+	// double shadowOffsetX;
+	// double shadowOffsetY;
+	// cairo_pattern_t *fillPattern;
+	// cairo_pattern_t *strokePattern;
+	// cairo_pattern_t *fillGradient;
+	// cairo_pattern_t *strokeGradient;
+	// int shadowBlur;
 	// text_align_t textAlignment = TEXT_ALIGNMENT_LEFT; // TODO default is supposed to be START
 	// text_baseline_t textBaseline = TEXT_BASELINE_ALPHABETIC;
 	// canvas_draw_mode_t textDrawingMode;
 	cairo_filter_t image_smoothing_quality;
 	JSValue font;
 	double font_size;
-	const char* font_string;
+	const char *font_string;
 	hb_font_t *hb_font;
-	//FT_Face ft_face;
 	bool image_smoothing_enabled;
 	double global_alpha;
-	struct nx_canvas_context_2d_state_s* next;
+	struct nx_canvas_context_2d_state_s *next;
 } nx_canvas_context_2d_state_t;
 
 /**

--- a/source/canvas.h
+++ b/source/canvas.h
@@ -24,6 +24,42 @@ typedef struct
 	double a;
 } nx_rgba_t;
 
+/*
+ * State struct.
+ *
+ * Used in conjunction with `ctx.save()` / `ctx.restore()` since
+ * cairo's gstate maintains only a single source pattern at a time.
+ */
+typedef struct nx_canvas_context_2d_state_s
+{
+
+	nx_rgba_t fill;
+	nx_rgba_t stroke;
+	//nx_rgba_t shadow;
+	//double shadowOffsetX;
+	//double shadowOffsetY;
+	//cairo_pattern_t *fillPattern;
+	//cairo_pattern_t *strokePattern;
+	//cairo_pattern_t *fillGradient;
+	//cairo_pattern_t *strokeGradient;
+	// PangoFontDescription *fontDescription;
+	// std::string fontStr;
+	//cairo_filter_t image;
+	//int shadowBlur;
+	// text_align_t textAlignment = TEXT_ALIGNMENT_LEFT; // TODO default is supposed to be START
+	// text_baseline_t textBaseline = TEXT_BASELINE_ALPHABETIC;
+	// canvas_draw_mode_t textDrawingMode;
+	cairo_filter_t image_smoothing_quality;
+	JSValue font;
+	double font_size;
+	const char* font_string;
+	hb_font_t *hb_font;
+	//FT_Face ft_face;
+	bool image_smoothing_enabled;
+	double global_alpha;
+	struct nx_canvas_context_2d_state_s* next;
+} nx_canvas_context_2d_state_t;
+
 /**
  * `CanvasRenderingContext2D` / `OffscreenCanvasRenderingContext2D`
  */
@@ -32,13 +68,7 @@ typedef struct
 	nx_canvas_t *canvas;
 	cairo_t *ctx;
 	cairo_path_t *path;
-	cairo_filter_t image_smoothing_quality;
-	hb_font_t *hb_font;
-	FT_Face ft_face;
-	bool image_smoothing_enabled;
-	double global_alpha;
-	nx_rgba_t fill_style;
-	nx_rgba_t stroke_style;
+	nx_canvas_context_2d_state_t *state;
 } nx_canvas_context_2d_t;
 
 nx_canvas_context_2d_t *nx_get_canvas_context_2d(JSContext *ctx, JSValueConst obj);


### PR DESCRIPTION
Use a separate "state" struct as a linked list to store Canvas rendering context state, since Cairo only preserves one layer deep with `cairo_save()` / `cairo_restore()`.

This moves the source of truth to the C side for `font`, `fillStyle` and `strokeStyle`, instead of maintaining it on the JS side as well.