### PR TITLE
Implement `navigator.getGamepads()`

### DIFF
--- a/.changeset/cyan-parrots-admire.md
+++ b/.changeset/cyan-parrots-admire.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/constants": patch
+---
+
+Add `HidDeviceTypeBits` enum

--- a/.changeset/hungry-eyes-fold.md
+++ b/.changeset/hungry-eyes-fold.md
@@ -1,0 +1,7 @@
+---
+"nxjs-runtime": patch
+---
+
+Implement `navigator.getGamepads()`
+ - Removes non-standard `buttondown` and `buttonup` events
+ - Use `preventDefault()` on "beforeunload" event to prevent exiting

--- a/.changeset/hungry-eyes-fold.md
+++ b/.changeset/hungry-eyes-fold.md
@@ -3,5 +3,7 @@
 ---
 
 Implement `navigator.getGamepads()`
+ - Allows for up to 8 gamepads to be individually controlled
+ - Adds support for l/r analog stick positions to be utilzed
  - Removes non-standard `buttondown` and `buttonup` events
  - Use `preventDefault()` on "beforeunload" event to prevent exiting

--- a/.changeset/nasty-mice-protect.md
+++ b/.changeset/nasty-mice-protect.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/constants": patch
+---
+
+Add gamepad `Button` enum

--- a/.changeset/strong-owls-enjoy.md
+++ b/.changeset/strong-owls-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/constants": patch
+---
+
+Add `HidNpadStyleTag` enum

--- a/apps/2048/src/input_manager.js
+++ b/apps/2048/src/input_manager.js
@@ -1,4 +1,35 @@
-import { HidNpadButton } from '@nx.js/constants';
+import { Button } from '@nx.js/constants';
+
+class GamepadEvents extends Array {
+	constructor(numPlayers) {
+		super(numPlayers);
+		for (let i = 0; i < numPlayers; i++) {
+			this[i] = new EventTarget();
+			this[i].pressed = [];
+		}
+		this.#tick();
+	}
+
+	#tick = () => {
+		requestAnimationFrame(this.#tick);
+		const gamepads = navigator.getGamepads();
+		for (let i = 0; i < this.length; i++) {
+			const gamepad = gamepads[i];
+			if (!gamepad) continue;
+			for (let j = 0; j < gamepad.buttons.length; j++) {
+				const wasPressed = this[i].pressed[j];
+				const pressed = gamepad.buttons[j].pressed;
+				if (!wasPressed && pressed) {
+					this[i].pressed[j] = true;
+					this[i].dispatchEvent(new CustomEvent('buttondown', { detail: j }));
+				} else if (wasPressed && !pressed) {
+					this[i].pressed[j] = false;
+					this[i].dispatchEvent(new CustomEvent('buttonup', { detail: j }));
+				}
+			}
+		}
+	};
+}
 
 export class InputManager {
 	constructor(gameManager) {
@@ -45,22 +76,26 @@ export class InputManager {
 			}
 		});
 
-		addEventListener('buttondown', (event) => {
-			if (event.detail & HidNpadButton.AnyLeft) {
+		addEventListener('beforeunload', (event) => {
+			if (this.gameManager.won && !this.gameManager.keepPlaying) {
+				event.preventDefault();
+				this.gameManager.continueGame();
+			}
+		});
+
+		const gamepadEvents = new GamepadEvents(1);
+
+		gamepadEvents[0].addEventListener('buttondown', (event) => {
+			if (event.detail === Button.Left) {
 				this.gameManager.move(3);
-			} else if (event.detail & HidNpadButton.AnyRight) {
+			} else if (event.detail === Button.Right) {
 				this.gameManager.move(1);
-			} else if (event.detail & HidNpadButton.AnyUp) {
+			} else if (event.detail === Button.Up) {
 				this.gameManager.move(0);
-			} else if (event.detail & HidNpadButton.AnyDown) {
+			} else if (event.detail === Button.Down) {
 				this.gameManager.move(2);
-			} else if (event.detail & HidNpadButton.Minus) {
+			} else if (event.detail === Button.Minus) {
 				this.gameManager.restart();
-			} else if (this.gameManager.won && !this.gameManager.keepPlaying) {
-				if (event.detail & HidNpadButton.Plus) {
-					event.preventDefault();
-					this.gameManager.continueGame();
-				}
 			}
 		});
 	}

--- a/apps/gamepads/.gitignore
+++ b/apps/gamepads/.gitignore
@@ -1,0 +1,5 @@
+/*.nro
+/*.nsp
+/node_modules
+/romfs/main.js
+/romfs/main.js.map

--- a/apps/gamepads/package.json
+++ b/apps/gamepads/package.json
@@ -9,6 +9,9 @@
     "nsp": "nxjs-nsp"
   },
   "license": "MIT",
+  "dependencies": {
+    "@nx.js/constants": "workspace:*"
+  },
   "devDependencies": {
     "@nx.js/nro": "workspace:^",
     "@nx.js/nsp": "workspace:^",

--- a/apps/gamepads/package.json
+++ b/apps/gamepads/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "gamepads",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example app which uses the `navigator.getGamepads()` API",
+  "scripts": {
+    "build": "esbuild --bundle --sourcemap --sources-content=false --target=es2022 --format=esm --outdir=romfs src/main.ts",
+    "nro": "nxjs-nro",
+    "nsp": "nxjs-nsp"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@nx.js/nro": "workspace:^",
+    "@nx.js/nsp": "workspace:^",
+    "esbuild": "^0.17.19",
+    "nxjs-runtime": "workspace:^"
+  }
+}

--- a/apps/gamepads/src/main.ts
+++ b/apps/gamepads/src/main.ts
@@ -1,43 +1,26 @@
-enum Button {
-	B,
-	A,
-	Y,
-	X,
-	L,
-	R,
-	ZL,
-	ZR,
-	Minus,
-	Plus,
-	StickL,
-	StickR,
-	Up,
-	Down,
-	Left,
-	Right,
-}
+import { Button, HidNpadStyleTag, HidDeviceTypeBits } from '@nx.js/constants';
 
 function update() {
 	requestAnimationFrame(update);
 	console.print('\x1B[2J\x1B[1G');
 	const pads = navigator.getGamepads();
-	for (let i = 0; i < 8; i++) {
-		const pad = pads[i];
-		if (pad) {
-			console.log(
-				i,
-				pad.axes.map((v) => v.toFixed(2)),
-			);
-			const pressed: string[] = [];
-			for (let j = 0; j < pad.buttons.length; j++) {
-				const b = pad.buttons[j];
-				if (b.pressed) {
-					pressed.push(Button[j]);
-				}
+	for (const pad of pads) {
+		if (!pad) continue;
+		console.log(
+			pad.index,
+			HidNpadStyleTag[pad.styleSet] ?? pad.styleSet,
+			HidDeviceTypeBits[pad.deviceType] ?? pad.deviceType,
+			pad.axes.map((v) => v.toFixed(2)),
+		);
+		const pressed: string[] = [];
+		for (let j = 0; j < pad.buttons.length; j++) {
+			const b = pad.buttons[j];
+			if (b.pressed) {
+				pressed.push(Button[j]);
 			}
-			console.log(`Presed: ${pressed.join(', ')}`);
-			console.log();
 		}
+		console.log(`Presed: ${pressed.join(', ')}`);
+		console.log();
 	}
 }
 

--- a/apps/gamepads/src/main.ts
+++ b/apps/gamepads/src/main.ts
@@ -1,0 +1,44 @@
+enum Button {
+	B,
+	A,
+	Y,
+	X,
+	L,
+	R,
+	ZL,
+	ZR,
+	Minus,
+	Plus,
+	StickL,
+	StickR,
+	Up,
+	Down,
+	Left,
+	Right,
+}
+
+function update() {
+	requestAnimationFrame(update);
+	console.print('\x1B[2J\x1B[1G');
+	const pads = navigator.getGamepads();
+	for (let i = 0; i < 8; i++) {
+		const pad = pads[i];
+		if (pad) {
+			console.log(
+				i,
+				pad.axes.map((v) => v.toFixed(2)),
+			);
+			const pressed: string[] = [];
+			for (let j = 0; j < pad.buttons.length; j++) {
+				const b = pad.buttons[j];
+				if (b.pressed) {
+					pressed.push(Button[j]);
+				}
+			}
+			console.log(`Presed: ${pressed.join(', ')}`);
+			console.log();
+		}
+	}
+}
+
+update();

--- a/apps/gamepads/tsconfig.json
+++ b/apps/gamepads/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [
+      "nxjs-runtime"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/apps/virtual-keyboard/src/main.ts
+++ b/apps/virtual-keyboard/src/main.ts
@@ -1,4 +1,4 @@
-import { HidNpadButton, SwkbdType } from '@nx.js/constants';
+import { Button, SwkbdType } from '@nx.js/constants';
 
 const ctx = screen.getContext('2d');
 const vk = navigator.virtualKeyboard;
@@ -25,20 +25,29 @@ function render() {
 	}
 }
 
-addEventListener('buttondown', (e) => {
+// Prevent "+" from exiting the app while the virtual keyboard is open
+addEventListener('beforeunload', (e) => {
 	const isOpen = vk.boundingRect.height > 0;
 	if (isOpen) {
-		if (e.detail & HidNpadButton.Plus) {
-			e.preventDefault();
-		} else if (e.detail & HidNpadButton.ZL) {
+		e.preventDefault();
+	}
+});
+
+function handleInput() {
+	requestAnimationFrame(handleInput);
+	const gp = navigator.getGamepads()[0];
+	if (!gp) return;
+	const isOpen = vk.boundingRect.height > 0;
+	if (isOpen) {
+		if (gp.buttons[Button.ZL].pressed) {
 			vk.hide();
 		}
 	} else {
-		if (e.detail & HidNpadButton.ZR) {
+		if (gp.buttons[Button.ZR].pressed) {
 			vk.type = SwkbdType.Normal;
 			vk.okButtonText = 'Done';
 			vk.show();
-		} else if (e.detail & HidNpadButton.ZL) {
+		} else if (gp.buttons[Button.ZL].pressed) {
 			vk.type = SwkbdType.NumPad;
 			vk.okButtonText = 'Submit';
 			vk.leftButtonText = ':';
@@ -46,9 +55,10 @@ addEventListener('buttondown', (e) => {
 			vk.show();
 		}
 	}
-});
+}
 
 vk.addEventListener('change', render);
 vk.addEventListener('cursormove', render);
 vk.addEventListener('geometrychange', render);
+handleInput();
 render();

--- a/packages/constants/src/gamepad.ts
+++ b/packages/constants/src/gamepad.ts
@@ -1,3 +1,18 @@
+/**
+ * Mapping of the button indicies on a `Gamepad` to the
+ * corresponding name of the button on the controller.
+ *
+ * @example
+ *
+ * ```typescript
+ * import { Button } from '@nx.js/constants';
+ *
+ * const pad = navigator.getGamepads()[0];
+ * if (pad.buttons[Button.A].pressed) {
+ *   console.log('Button A is pressed');
+ * }
+ * ```
+ */
 export enum Button {
 	B,
 	A,

--- a/packages/constants/src/gamepad.ts
+++ b/packages/constants/src/gamepad.ts
@@ -1,0 +1,18 @@
+export enum Button {
+	B,
+	A,
+	Y,
+	X,
+	L,
+	R,
+	ZL,
+	ZR,
+	Minus,
+	Plus,
+	StickL,
+	StickR,
+	Up,
+	Down,
+	Left,
+	Right,
+}

--- a/packages/constants/src/hid.ts
+++ b/packages/constants/src/hid.ts
@@ -66,3 +66,21 @@ export enum HidDeviceTypeBits {
 	Lager = 1 << 17, ///< Sega Genesis controller
 	System = 1 << 31, ///< Generic controller.
 }
+
+/// HID controller styles
+export enum HidNpadStyleTag {
+	FullKey = 1 << 0, ///< Pro Controller
+	Handheld = 1 << 1, ///< Joy-Con controller in handheld mode
+	JoyDual = 1 << 2, ///< Joy-Con controller in dual mode
+	JoyLeft = 1 << 3, ///< Joy-Con left controller in single mode
+	JoyRight = 1 << 4, ///< Joy-Con right controller in single mode
+	Gc = 1 << 5, ///< GameCube controller
+	Palma = 1 << 6, ///< Poké Ball Plus controller
+	Lark = 1 << 7, ///< NES/Famicom controller
+	HandheldLark = 1 << 8, ///< NES/Famicom controller in handheld mode
+	Lucia = 1 << 9, ///< SNES controller
+	Lagon = 1 << 10, ///< N64 controller
+	Lager = 1 << 11, ///< Sega Genesis controller
+	SystemExt = 1 << 29, ///< Generic external controller
+	System = 1 << 30, ///< Generic controller
+}

--- a/packages/constants/src/hid.ts
+++ b/packages/constants/src/hid.ts
@@ -43,3 +43,26 @@ export enum HidNpadButton {
 	AnySL = (1 << 24) | (1 << 26), ///< Bitmask containing SL buttons on both Joy-Cons (Left/Right)
 	AnySR = (1 << 25) | (1 << 27), ///< Bitmask containing SR buttons on both Joy-Cons (Left/Right)
 }
+
+/// DeviceType (system)
+export enum HidDeviceTypeBits {
+	FullKey = 1 << 0, ///< Pro Controller and Gc controller.
+	DebugPad = 1 << 1, ///< DebugPad
+	HandheldLeft = 1 << 2, ///< Joy-Con/Famicom/NES left controller in handheld mode.
+	HandheldRight = 1 << 3, ///< Joy-Con/Famicom/NES right controller in handheld mode.
+	JoyLeft = 1 << 4, ///< Joy-Con left controller.
+	JoyRight = 1 << 5, ///< Joy-Con right controller.
+	Palma = 1 << 6, ///< Poké Ball Plus controller.
+	LarkHvcLeft = 1 << 7, ///< Famicom left controller.
+	LarkHvcRight = 1 << 8, ///< Famicom right controller (with microphone).
+	LarkNesLeft = 1 << 9, ///< NES left controller.
+	LarkNesRight = 1 << 10, ///< NES right controller.
+	HandheldLarkHvcLeft = 1 << 11, ///< Famicom left controller in handheld mode.
+	HandheldLarkHvcRight = 1 << 12, ///< Famicom right controller (with microphone) in handheld mode.
+	HandheldLarkNesLeft = 1 << 13, ///< NES left controller in handheld mode.
+	HandheldLarkNesRight = 1 << 14, ///< NES right controller in handheld mode.
+	Lucia = 1 << 15, ///< SNES controller
+	Lagon = 1 << 16, ///< N64 controller
+	Lager = 1 << 17, ///< Sega Genesis controller
+	System = 1 << 31, ///< Generic controller.
+}

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,5 +1,6 @@
 export * from './applet';
 export * from './caps';
 export * from './fs';
+export * from './gamepad';
 export * from './hid';
 export * from './swkbd';

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -37,6 +37,7 @@ import type { FontFace } from './font/font-face';
 import type { URL, URLSearchParams } from './polyfills/url';
 import type { DOMPoint, DOMPointInit } from './dompoint';
 import type { DOMMatrix, DOMMatrixReadOnly, DOMMatrixInit } from './dommatrix';
+import type { Gamepad, GamepadButton } from './navigator/gamepad';
 
 type ClassOf<T> = {
 	new (...args: any[]): T;
@@ -160,6 +161,12 @@ export interface Init {
 	saveDataFilter(filter: SaveDataFilter): SaveDataIterator;
 	fsOpenSaveDataInfoReader(saveDataSpaceId: number): SaveDataIterator | null;
 	fsSaveDataInfoReaderNext(iterator: SaveDataIterator): SaveData | null;
+
+	// gamepad.c
+	gamepadInit(c: ClassOf<Gamepad>): void;
+	gamepadNew(index: number): Gamepad;
+	gamepadButtonInit(c: ClassOf<GamepadButton>): void;
+	gamepadButtonNew(gamepad: Gamepad, index: number): void;
 
 	// image.c
 	imageInit(c: ClassOf<Image | ImageBitmap>): void;

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -195,7 +195,7 @@ export interface Init {
 	setenv(name: string, value: string): void;
 	unsetenv(name: string): void;
 	envToObject(): Record<string, string>;
-	onFrame(fn: (kDown: number) => void): void;
+	onFrame(fn: (plusDown: boolean) => void): void;
 	onExit(fn: () => void): void;
 	framebufferInit(screen: Screen): void;
 	hidInitializeTouchScreen(): void;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -89,7 +89,6 @@ def(setInterval);
 def(clearTimeout);
 def(clearInterval);
 
-//import './navigator';
 import { navigator } from './navigator';
 
 import './source-map';
@@ -181,16 +180,20 @@ $.onUnhandledRejection((p, r) => {
 	return 1;
 });
 
+let plusWasPressed: boolean | undefined;
+
 $.onFrame(() => {
 	// Default behavior is to exit when the "+" button is pressed on the first controller.
 	// Can be prevented by calling `preventDefault()` on the "beforeunload" event.
-	if (navigator.getGamepads()[0].buttons[9].pressed) {
-		const e = new Event('beforeunload');
+	const plusPressed = navigator.getGamepads()[0]?.buttons[9].pressed;
+	if (plusPressed && !plusWasPressed) {
+		const e = new Event('beforeunload', { cancelable: true });
 		globalThis.dispatchEvent(e);
 		if (!e.defaultPrevented) {
 			return $.exit();
 		}
 	}
+	plusWasPressed = plusPressed;
 
 	processTimers();
 	callRafCallbacks();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -89,7 +89,7 @@ def(setInterval);
 def(clearTimeout);
 def(clearInterval);
 
-import { navigator } from './navigator';
+import './navigator';
 
 import './source-map';
 import { $ } from './$';
@@ -180,20 +180,16 @@ $.onUnhandledRejection((p, r) => {
 	return 1;
 });
 
-let plusWasPressed: boolean | undefined;
-
-$.onFrame(() => {
+$.onFrame((plusDown) => {
 	// Default behavior is to exit when the "+" button is pressed on the first controller.
 	// Can be prevented by calling `preventDefault()` on the "beforeunload" event.
-	const plusPressed = navigator.getGamepads()[0]?.buttons[9].pressed;
-	if (plusPressed && !plusWasPressed) {
+	if (plusDown) {
 		const e = new Event('beforeunload', { cancelable: true });
 		globalThis.dispatchEvent(e);
 		if (!e.defaultPrevented) {
 			return $.exit();
 		}
 	}
-	plusWasPressed = plusPressed;
 
 	processTimers();
 	callRafCallbacks();

--- a/packages/runtime/src/navigator.ts
+++ b/packages/runtime/src/navigator.ts
@@ -107,7 +107,7 @@ export class Navigator {
 	/**
 	 * Returns an array of {@link Gamepad} objects, one for each gamepad connected to the device.
 	 *
-	 * The indexes of the gamepads array map to the paired controller numbers assigned by the
+	 * The indicies of the gamepads array map to the paired controller numbers assigned by the
 	 * system. Index 0 is the first controller, index 1 is the second controller, and so on.
 	 *
 	 * Index 0 is a special case, which represents input from both the first controller as well

--- a/packages/runtime/src/navigator.ts
+++ b/packages/runtime/src/navigator.ts
@@ -126,7 +126,7 @@ export class Navigator {
 	 *
 	 * @see https://developer.mozilla.org/docs/Web/API/Navigator/getGamepads
 	 */
-	getGamepads(): Gamepad[] {
+	getGamepads(): (Gamepad | null)[] {
 		const g = Array(8);
 		for (let i = 0; i < 8; i++) {
 			const e = gamepads[i];

--- a/packages/runtime/src/navigator.ts
+++ b/packages/runtime/src/navigator.ts
@@ -1,6 +1,7 @@
 import { $ } from './$';
-import { assertInternalConstructor, def } from './utils';
+import { assertInternalConstructor, def, lazyProp } from './utils';
 import { BatteryManager } from './navigator/battery';
+import { type Gamepad, gamepads, gamepadNew } from './navigator/gamepad';
 import { INTERNAL_SYMBOL, VibrationValues } from './internal';
 import { setTimeout, clearTimeout } from './timers';
 import {
@@ -101,6 +102,53 @@ export class Navigator {
 			);
 		}
 		return state.batt;
+	}
+
+	/**
+	 * Returns an array of {@link Gamepad} objects, one for each gamepad connected to the device.
+	 *
+	 * The indexes of the gamepads array map to the paired controller numbers assigned by the
+	 * system. Index 0 is the first controller, index 1 is the second controller, and so on.
+	 *
+	 * Index 0 is a special case, which represents input from both the first controller as well
+	 * as the handheld mode controller.
+	 *
+	 * The gamepads array contains 8 entries, so up to 8 controllers can be connected to the
+	 * device at a time. Disconnected controllers will have `null` values in the array.
+	 *
+	 * @example
+	 *
+	 * ```typescript
+	 * if (navigator.getGamepads()[0].buttons[0].pressed) {
+	 *   console.log('Button B is pressed on the first controller');
+	 * }
+	 * ```
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/Navigator/getGamepads
+	 */
+	getGamepads(): Gamepad[] {
+		const g = Array(8);
+		for (let i = 0; i < 8; i++) {
+			const e = gamepads[i];
+			if (e) {
+				g[i] = e.connected ? e : null;
+			} else {
+				lazyProp(
+					g,
+					i,
+					() => {
+						const v = gamepadNew(i);
+						gamepads[i] = v;
+						return v.connected ? v : null;
+					},
+					{
+						configurable: true,
+						enumerable: true,
+					},
+				);
+			}
+		}
+		return g;
 	}
 
 	/**

--- a/packages/runtime/src/navigator.ts
+++ b/packages/runtime/src/navigator.ts
@@ -1,7 +1,7 @@
 import { $ } from './$';
-import { assertInternalConstructor, def, lazyProp } from './utils';
+import { assertInternalConstructor, def } from './utils';
 import { BatteryManager } from './navigator/battery';
-import { type Gamepad, gamepads, gamepadNew } from './navigator/gamepad';
+import { type Gamepad, gamepads } from './navigator/gamepad';
 import { INTERNAL_SYMBOL, VibrationValues } from './internal';
 import { setTimeout, clearTimeout } from './timers';
 import {
@@ -130,23 +130,7 @@ export class Navigator {
 		const g = Array(8);
 		for (let i = 0; i < 8; i++) {
 			const e = gamepads[i];
-			if (e) {
-				g[i] = e.connected ? e : null;
-			} else {
-				lazyProp(
-					g,
-					i,
-					() => {
-						const v = gamepadNew(i);
-						gamepads[i] = v;
-						return v.connected ? v : null;
-					},
-					{
-						configurable: true,
-						enumerable: true,
-					},
-				);
-			}
+			g[i] = e.connected ? e : null;
 		}
 		return g;
 	}

--- a/packages/runtime/src/navigator/gamepad.ts
+++ b/packages/runtime/src/navigator/gamepad.ts
@@ -84,8 +84,6 @@ export class GamepadHapticActuator implements globalThis.GamepadHapticActuator {
 }
 def(GamepadHapticActuator);
 
-export const gamepads: Gamepad[] = Array(8);
-
 export function gamepadNew(index: number) {
 	const g = proto($.gamepadNew(index), Gamepad);
 	// @ts-expect-error Readonly prop
@@ -96,3 +94,7 @@ export function gamepadNew(index: number) {
 	}
 	return g;
 }
+
+export const gamepads: Gamepad[] = Array(8)
+	.fill(0)
+	.map((_, i) => gamepadNew(i));

--- a/packages/runtime/src/navigator/gamepad.ts
+++ b/packages/runtime/src/navigator/gamepad.ts
@@ -87,6 +87,8 @@ def(GamepadHapticActuator);
 export function gamepadNew(index: number) {
 	const g = proto($.gamepadNew(index), Gamepad);
 	// @ts-expect-error Readonly prop
+	g.mapping = 'standard';
+	// @ts-expect-error Readonly prop
 	g.buttons = Array(16);
 	for (let i = 0; i < 16; i++) {
 		// @ts-expect-error Readonly array

--- a/packages/runtime/src/navigator/gamepad.ts
+++ b/packages/runtime/src/navigator/gamepad.ts
@@ -1,0 +1,93 @@
+import { $ } from '../$';
+import { assertInternalConstructor, def, proto } from '../utils';
+import type {
+	GamepadHapticActuatorType,
+	GamepadMappingType,
+	GamepadEffectParameters,
+} from '../types';
+
+/**
+ * Defines an individual gamepad or other controller, allowing access
+ * to information such as button presses, axis positions, and id.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/Gamepad
+ */
+export class Gamepad implements globalThis.Gamepad {
+	readonly axes!: readonly number[];
+	readonly buttons!: readonly GamepadButton[];
+	readonly connected!: boolean;
+	readonly id!: string;
+	readonly index!: number;
+	readonly mapping!: GamepadMappingType;
+	readonly timestamp!: number;
+	readonly vibrationActuator!: GamepadHapticActuator | null;
+
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		assertInternalConstructor(arguments);
+	}
+}
+def(Gamepad);
+$.gamepadInit(Gamepad);
+
+/**
+ * Defines an individual button of a gamepad or other controller, allowing access
+ * to the current state of different types of buttons available on the control device.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/GamepadButton
+ */
+export class GamepadButton implements globalThis.GamepadButton {
+	pressed!: boolean;
+	touched!: boolean;
+	value!: number;
+
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		assertInternalConstructor(arguments);
+	}
+}
+def(GamepadButton);
+$.gamepadButtonInit(GamepadButton);
+
+/**
+ * Represents hardware in the controller designed to provide haptic feedback
+ * to the user (if available), most commonly vibration hardware.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator
+ */
+export class GamepadHapticActuator implements globalThis.GamepadHapticActuator {
+	readonly type!: GamepadHapticActuatorType;
+
+	playEffect(
+		type: 'dual-rumble',
+		params?: GamepadEffectParameters,
+	): Promise<GamepadHapticsResult> {
+		throw new Error('Method not implemented.');
+	}
+
+	reset(): Promise<GamepadHapticsResult> {
+		throw new Error('Method not implemented.');
+	}
+
+	pulse(duration: number, delay?: number): void {
+		throw new Error('Method not implemented.');
+	}
+}
+def(GamepadHapticActuator);
+
+export const gamepads: Gamepad[] = Array(8);
+
+export function gamepadNew(index: number) {
+	const g = proto($.gamepadNew(index), Gamepad);
+	// @ts-expect-error Readonly prop
+	g.buttons = Array(16);
+	for (let i = 0; i < 16; i++) {
+		// @ts-expect-error Readonly array
+		g.buttons[i] = proto($.gamepadButtonNew(g, i), GamepadButton);
+	}
+	return g;
+}

--- a/packages/runtime/src/navigator/gamepad.ts
+++ b/packages/runtime/src/navigator/gamepad.ts
@@ -20,7 +20,7 @@ export class Gamepad implements globalThis.Gamepad {
 	readonly index!: number;
 	readonly mapping!: GamepadMappingType;
 	readonly timestamp!: number;
-	readonly vibrationActuator!: GamepadHapticActuator | null;
+	readonly vibrationActuator!: GamepadHapticActuator;
 
 	// Non-standard
 	readonly deviceType!: number;

--- a/packages/runtime/src/navigator/gamepad.ts
+++ b/packages/runtime/src/navigator/gamepad.ts
@@ -22,6 +22,11 @@ export class Gamepad implements globalThis.Gamepad {
 	readonly timestamp!: number;
 	readonly vibrationActuator!: GamepadHapticActuator | null;
 
+	// Non-standard
+	readonly deviceType!: number;
+	readonly rawButtons!: bigint;
+	readonly styleSet!: number;
+
 	/**
 	 * @ignore
 	 */

--- a/packages/runtime/src/polyfills/event.ts
+++ b/packages/runtime/src/polyfills/event.ts
@@ -1,5 +1,6 @@
 import { assertInternalConstructor, createInternal, def } from '../utils';
 import type { EventTarget } from './event-target';
+import type { Gamepad } from '../navigator/gamepad';
 
 export interface EventInit {
 	bubbles?: boolean;
@@ -583,6 +584,18 @@ export class PromiseRejectionEvent
 	}
 }
 
+export interface GamepadEventInit extends EventInit {
+	gamepad: Gamepad;
+}
+
+export class GamepadEvent extends Event implements globalThis.GamepadEvent {
+	readonly gamepad: Gamepad;
+	constructor(type: string, options: GamepadEventInit) {
+		super(type, options);
+		this.gamepad = options.gamepad;
+	}
+}
+
 def(Event);
 def(CustomEvent);
 def(ErrorEvent);
@@ -590,3 +603,4 @@ def(PromiseRejectionEvent);
 def(UIEvent);
 def(KeyboardEvent);
 def(TouchEvent);
+def(GamepadEvent);

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -110,3 +110,12 @@ export type ImageOrientation = 'flipY' | 'from-image' | 'none';
 export type PremultiplyAlpha = 'default' | 'none' | 'premultiply';
 export type ResizeQuality = 'high' | 'low' | 'medium' | 'pixelated';
 export type ImageBitmapSource = CanvasImageSource | Blob | ImageData;
+
+export type GamepadMappingType = '' | 'standard' | 'xr-standard';
+export type GamepadHapticActuatorType = 'vibration';
+export interface GamepadEffectParameters {
+	duration?: number;
+	startDelay?: number;
+	strongMagnitude?: number;
+	weakMagnitude?: number;
+}

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -166,3 +166,22 @@ export function first<T>(it: Iterator<T>): T | undefined {
 	const n = it.next();
 	return n.value || undefined;
 }
+
+export function lazyProp(
+	obj: any,
+	prop: PropertyKey,
+	init: () => any,
+	desc: PropertyDescriptor,
+) {
+	Object.defineProperty(obj, prop, {
+		...desc,
+		get() {
+			const v = init();
+			Object.defineProperty(obj, prop, {
+				...desc,
+				value: v,
+			});
+			return v;
+		},
+	});
+}

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -166,22 +166,3 @@ export function first<T>(it: Iterator<T>): T | undefined {
 	const n = it.next();
 	return n.value || undefined;
 }
-
-export function lazyProp(
-	obj: any,
-	prop: PropertyKey,
-	init: () => any,
-	desc: PropertyDescriptor,
-) {
-	Object.defineProperty(obj, prop, {
-		...desc,
-		get() {
-			const v = init();
-			Object.defineProperty(obj, prop, {
-				...desc,
-				value: v,
-			});
-			return v;
-		},
-	});
-}

--- a/packages/runtime/src/window.ts
+++ b/packages/runtime/src/window.ts
@@ -7,7 +7,6 @@ import {
 import type { console } from './console';
 import type {
 	Event,
-	UIEvent,
 	ErrorEvent,
 	PromiseRejectionEvent,
 } from './polyfills/event';
@@ -31,18 +30,6 @@ def(Window);
 export var window: Window & typeof globalThis = globalThis;
 Object.setPrototypeOf(window, Window.prototype);
 def(window, 'window');
-
-export function addEventListener(
-	type: 'buttondown',
-	callback: EventListenerOrEventListenerObject<UIEvent>,
-	options?: AddEventListenerOptions | boolean,
-): void;
-
-export function addEventListener(
-	type: 'buttonup',
-	callback: EventListenerOrEventListenerObject<UIEvent>,
-	options?: AddEventListenerOptions | boolean,
-): void;
 
 /**
  * @see https://developer.mozilla.org/docs/Web/API/Element/keydown_event
@@ -99,7 +86,7 @@ export function addEventListener(
  * The `beforeunload` event is fired when the `+` button is pressed on the first controller.
  *
  * This event gives the application a chance to prevent the default behavior of the
- * application exiting. If the event is canceled, the application will **not** exit.
+ * application exiting. If the event is canceled, the application **will not exit**.
  *
  * @see https://developer.mozilla.org/docs/Web/API/Window/beforeunload_event
  */

--- a/packages/runtime/src/window.ts
+++ b/packages/runtime/src/window.ts
@@ -96,6 +96,20 @@ export function addEventListener(
 ): void;
 
 /**
+ * The `beforeunload` event is fired when the `+` button is pressed on the first controller.
+ *
+ * This event gives the application a chance to prevent the default behavior of the
+ * application exiting. If the event is canceled, the application will **not** exit.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/Window/beforeunload_event
+ */
+export function addEventListener(
+	type: 'beforeunload',
+	callback: (event: Event) => any,
+	options?: AddEventListenerOptions | boolean,
+): void;
+
+/**
  * The `unload` event is fired when the application is exiting.
  *
  * By the time this event occurs, the event loop has already been stopped,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,10 @@ importers:
         version: link:../../packages/runtime
 
   apps/gamepads:
+    dependencies:
+      '@nx.js/constants':
+        specifier: workspace:*
+        version: link:../../packages/constants
     devDependencies:
       '@nx.js/nro':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,21 @@ importers:
         specifier: workspace:^
         version: link:../../packages/runtime
 
+  apps/gamepads:
+    devDependencies:
+      '@nx.js/nro':
+        specifier: workspace:^
+        version: link:../../packages/nro
+      '@nx.js/nsp':
+        specifier: workspace:^
+        version: link:../../packages/nsp
+      esbuild:
+        specifier: ^0.17.19
+        version: 0.17.19
+      nxjs-runtime:
+        specifier: workspace:^
+        version: link:../../packages/runtime
+
   apps/hello-world:
     devDependencies:
       '@nx.js/nro':

--- a/source/gamepad.c
+++ b/source/gamepad.c
@@ -138,6 +138,18 @@ static JSValue nx_gamepad_get_raw_buttons(JSContext *ctx, JSValueConst this_val,
     return JS_NewBigUint64(ctx, padGetButtons(&gamepad->pad));
 }
 
+static JSValue nx_gamepad_get_device_type(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
+    return JS_NewUint32(ctx, hidGetNpadDeviceType(gamepad->id));
+}
+
+static JSValue nx_gamepad_get_style_set(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
+    return JS_NewUint32(ctx, padGetStyleSet(&gamepad->pad));
+}
+
 static JSValue nx_gamepad_get_index(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
 {
     nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
@@ -147,16 +159,7 @@ static JSValue nx_gamepad_get_index(JSContext *ctx, JSValueConst this_val, int a
 static JSValue nx_gamepad_get_connected(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
 {
     nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
-    bool connected = false;
-    if (gamepad->id == 0)
-    {
-        connected = padIsNpadActive(&gamepad->pad, HidNpadIdType_Handheld);
-    }
-    if (!connected)
-    {
-        connected = padIsNpadActive(&gamepad->pad, gamepad->id);
-    }
-    return JS_NewBool(ctx, connected);
+    return JS_NewBool(ctx, padIsConnected(&gamepad->pad));
 }
 
 static JSValue nx_gamepad_button_get_pressed(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
@@ -193,7 +196,9 @@ static JSValue nx_gamepad_init_class(JSContext *ctx, JSValueConst this_val, int 
     NX_DEF_GET(proto, "connected", nx_gamepad_get_connected);
 
     // Non-standard
+    NX_DEF_GET(proto, "deviceType", nx_gamepad_get_device_type);
     NX_DEF_GET(proto, "rawButtons", nx_gamepad_get_raw_buttons);
+    NX_DEF_GET(proto, "styleSet", nx_gamepad_get_style_set);
 
     JS_FreeValue(ctx, proto);
     return JS_UNDEFINED;

--- a/source/gamepad.c
+++ b/source/gamepad.c
@@ -156,7 +156,6 @@ static JSValue nx_gamepad_get_connected(JSContext *ctx, JSValueConst this_val, i
     {
         connected = padIsNpadActive(&gamepad->pad, gamepad->id);
     }
-    // printf("nx_gamepad_get_connected: %d -> %d\n", gamepad->id, connected);
     return JS_NewBool(ctx, connected);
 }
 

--- a/source/gamepad.c
+++ b/source/gamepad.c
@@ -73,19 +73,6 @@ static JSValue nx_gamepad_new(JSContext *ctx, JSValueConst this_val, int argc, J
 
     JSValue obj = JS_NewObjectClass(ctx, nx_gamepad_class_id);
     JS_SetOpaque(obj, gamepad);
-
-    if (id == 0)
-    {
-        // Index 0 is a special case, which represents input from both
-        // the first controller as well as the handheld mode controller
-        padInitialize(gamepad->pad, id, HidNpadIdType_Handheld);
-    }
-    else
-    {
-        padInitialize(gamepad->pad, id);
-    }
-    padUpdate(gamepad->pad);
-
     return obj;
 }
 

--- a/source/gamepad.c
+++ b/source/gamepad.c
@@ -1,0 +1,240 @@
+#include "gamepad.h"
+
+static JSClassID nx_gamepad_class_id;
+static JSClassID nx_gamepad_button_class_id;
+
+static u64 standard_button_masks[] = {
+    HidNpadButton_B,
+    HidNpadButton_A,
+    HidNpadButton_Y,
+    HidNpadButton_X,
+    HidNpadButton_L,
+    HidNpadButton_R,
+    HidNpadButton_ZL,
+    HidNpadButton_ZR,
+    HidNpadButton_Minus,
+    HidNpadButton_Plus,
+    HidNpadButton_StickL,
+    HidNpadButton_StickR,
+    HidNpadButton_Up,
+    HidNpadButton_Down,
+    HidNpadButton_Left,
+    HidNpadButton_Right,
+};
+
+nx_gamepad_t *nx_get_gamepad(JSContext *ctx, JSValueConst obj)
+{
+    return JS_GetOpaque2(ctx, obj, nx_gamepad_class_id);
+}
+
+nx_gamepad_button_t *nx_get_gamepad_button(JSContext *ctx, JSValueConst obj)
+{
+    return JS_GetOpaque2(ctx, obj, nx_gamepad_button_class_id);
+}
+
+static void finalizer_gamepad(JSRuntime *rt, JSValue val)
+{
+    nx_gamepad_t *gamepad = JS_GetOpaque(val, nx_gamepad_class_id);
+    nx_context_t *nx_ctx = JS_GetRuntimeOpaque(rt);
+    if (gamepad)
+    {
+        nx_ctx->pads[gamepad->id] = NULL;
+        js_free_rt(rt, gamepad);
+    }
+}
+
+static void finalizer_gamepad_button(JSRuntime *rt, JSValue val)
+{
+    nx_gamepad_button_t *gamepad_button = JS_GetOpaque(val, nx_gamepad_button_class_id);
+    if (gamepad_button)
+    {
+        js_free_rt(rt, gamepad_button);
+    }
+}
+
+static JSValue nx_gamepad_new(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    u32 id;
+    if (JS_ToUint32(ctx, &id, argv[0]))
+    {
+        return JS_EXCEPTION;
+    }
+
+    nx_gamepad_t *gamepad = js_mallocz(ctx, sizeof(nx_gamepad_t));
+    if (!gamepad)
+    {
+        return JS_EXCEPTION;
+    }
+
+    gamepad->id = id;
+
+    JSValue obj = JS_NewObjectClass(ctx, nx_gamepad_class_id);
+    JS_SetOpaque(obj, gamepad);
+
+    nx_context_t *nx_ctx = JS_GetContextOpaque(ctx);
+    nx_ctx->pads[id] = &gamepad->pad;
+
+    if (id == 0)
+    {
+        // Index 0 is a special case, which represents input from both
+        // the first controller as well as the handheld mode controller
+        padInitialize(&gamepad->pad, id, HidNpadIdType_Handheld);
+    }
+    else
+    {
+        padInitialize(&gamepad->pad, id);
+    }
+    padUpdate(&gamepad->pad);
+
+    return obj;
+}
+
+static JSValue nx_gamepad_button_new(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_t *gamepad = nx_get_gamepad(ctx, argv[0]);
+
+    u32 index;
+    if (JS_ToUint32(ctx, &index, argv[1]))
+    {
+        return JS_EXCEPTION;
+    }
+
+    nx_gamepad_button_t *gamepad_button = js_mallocz(ctx, sizeof(nx_gamepad_button_t));
+    if (!gamepad_button)
+    {
+        return JS_EXCEPTION;
+    }
+
+    gamepad_button->gamepad = gamepad;
+    gamepad_button->mask = standard_button_masks[index];
+
+    JSValue obj = JS_NewObjectClass(ctx, nx_gamepad_button_class_id);
+    JS_SetOpaque(obj, gamepad_button);
+    return obj;
+}
+
+static JSValue nx_gamepad_get_axes(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
+    JSValue arr = JS_NewArray(ctx);
+    HidAnalogStickState analog_stick_l = padGetStickPos(&gamepad->pad, 0);
+    HidAnalogStickState analog_stick_r = padGetStickPos(&gamepad->pad, 1);
+    JS_SetPropertyUint32(ctx, arr, 0, JS_NewFloat64(ctx, (double)analog_stick_l.x / 32768.0));
+    JS_SetPropertyUint32(ctx, arr, 1, JS_NewFloat64(ctx, (double)-analog_stick_l.y / 32768.0));
+    JS_SetPropertyUint32(ctx, arr, 2, JS_NewFloat64(ctx, (double)analog_stick_r.x / 32768.0));
+    JS_SetPropertyUint32(ctx, arr, 3, JS_NewFloat64(ctx, (double)-analog_stick_r.y / 32768.0));
+    return arr;
+}
+
+static JSValue nx_gamepad_get_id(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    // nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
+    return JS_NewString(ctx, "");
+}
+
+static JSValue nx_gamepad_get_raw_buttons(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
+    return JS_NewBigUint64(ctx, padGetButtons(&gamepad->pad));
+}
+
+static JSValue nx_gamepad_get_index(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
+    return JS_NewUint32(ctx, gamepad->id);
+}
+
+static JSValue nx_gamepad_get_connected(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_t *gamepad = nx_get_gamepad(ctx, this_val);
+    bool connected = false;
+    if (gamepad->id == 0)
+    {
+        connected = padIsNpadActive(&gamepad->pad, HidNpadIdType_Handheld);
+    }
+    if (!connected)
+    {
+        connected = padIsNpadActive(&gamepad->pad, gamepad->id);
+    }
+    // printf("nx_gamepad_get_connected: %d -> %d\n", gamepad->id, connected);
+    return JS_NewBool(ctx, connected);
+}
+
+static JSValue nx_gamepad_button_get_pressed(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_button_t *gamepad_button = nx_get_gamepad_button(ctx, this_val);
+    u64 kDown = padGetButtons(&gamepad_button->gamepad->pad);
+    bool pressed = (kDown & gamepad_button->mask) != 0;
+    return JS_NewBool(ctx, pressed);
+}
+
+static JSValue nx_gamepad_button_get_touched(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_button_t *gamepad_button = nx_get_gamepad_button(ctx, this_val);
+    u64 kDown = padGetButtons(&gamepad_button->gamepad->pad);
+    bool pressed = (kDown & gamepad_button->mask) != 0;
+    return JS_NewBool(ctx, pressed);
+}
+
+static JSValue nx_gamepad_button_get_value(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    nx_gamepad_button_t *gamepad_button = nx_get_gamepad_button(ctx, this_val);
+    u64 kDown = padGetButtons(&gamepad_button->gamepad->pad);
+    bool pressed = (kDown & gamepad_button->mask) != 0;
+    return JS_NewUint32(ctx, pressed ? 1 : 0);
+}
+
+static JSValue nx_gamepad_init_class(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    JSAtom atom;
+    JSValue proto = JS_GetPropertyStr(ctx, argv[0], "prototype");
+    NX_DEF_GET(proto, "axes", nx_gamepad_get_axes);
+    NX_DEF_GET(proto, "id", nx_gamepad_get_id);
+    NX_DEF_GET(proto, "index", nx_gamepad_get_index);
+    NX_DEF_GET(proto, "connected", nx_gamepad_get_connected);
+
+    // Non-standard
+    NX_DEF_GET(proto, "rawButtons", nx_gamepad_get_raw_buttons);
+
+    JS_FreeValue(ctx, proto);
+    return JS_UNDEFINED;
+}
+
+static JSValue nx_gamepad_button_init_class(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+    JSAtom atom;
+    JSValue proto = JS_GetPropertyStr(ctx, argv[0], "prototype");
+    NX_DEF_GET(proto, "pressed", nx_gamepad_button_get_pressed);
+    NX_DEF_GET(proto, "touched", nx_gamepad_button_get_touched);
+    NX_DEF_GET(proto, "value", nx_gamepad_button_get_value);
+    JS_FreeValue(ctx, proto);
+    return JS_UNDEFINED;
+}
+
+static const JSCFunctionListEntry function_list[] = {
+    JS_CFUNC_DEF("gamepadInit", 1, nx_gamepad_init_class),
+    JS_CFUNC_DEF("gamepadNew", 1, nx_gamepad_new),
+    JS_CFUNC_DEF("gamepadButtonInit", 1, nx_gamepad_button_init_class),
+    JS_CFUNC_DEF("gamepadButtonNew", 1, nx_gamepad_button_new),
+};
+
+void nx_init_gamepad(JSContext *ctx, JSValueConst init_obj)
+{
+    JSRuntime *rt = JS_GetRuntime(ctx);
+
+    JS_NewClassID(rt, &nx_gamepad_class_id);
+    JSClassDef gamepad_class = {
+        "Gamepad",
+        .finalizer = finalizer_gamepad,
+    };
+    JS_NewClass(rt, nx_gamepad_class_id, &gamepad_class);
+
+    JS_NewClassID(rt, &nx_gamepad_button_class_id);
+    JSClassDef gamepad_button_class = {
+        "GamepadButton",
+        .finalizer = finalizer_gamepad_button,
+    };
+    JS_NewClass(rt, nx_gamepad_button_class_id, &gamepad_button_class);
+
+    JS_SetPropertyFunctionList(ctx, init_obj, function_list, countof(function_list));
+}

--- a/source/gamepad.h
+++ b/source/gamepad.h
@@ -4,7 +4,7 @@
 typedef struct
 {
     HidNpadIdType id;
-    PadState pad;
+    PadState *pad;
 } nx_gamepad_t;
 
 typedef struct

--- a/source/gamepad.h
+++ b/source/gamepad.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "types.h"
+
+typedef struct
+{
+    HidNpadIdType id;
+    HidAnalogStickState stick_left;
+    HidAnalogStickState stick_right;
+    PadState pad;
+} nx_gamepad_t;
+
+typedef struct
+{
+    nx_gamepad_t *gamepad;
+    u64 mask;
+} nx_gamepad_button_t;
+
+nx_gamepad_t *nx_get_gamepad(JSContext *ctx, JSValueConst obj);
+
+void nx_init_gamepad(JSContext *ctx, JSValueConst init_obj);

--- a/source/gamepad.h
+++ b/source/gamepad.h
@@ -4,8 +4,6 @@
 typedef struct
 {
     HidNpadIdType id;
-    HidAnalogStickState stick_left;
-    HidAnalogStickState stick_right;
     PadState pad;
 } nx_gamepad_t;
 

--- a/source/main.c
+++ b/source/main.c
@@ -683,29 +683,33 @@ main_loop:
 			nx_process_pending_jobs(rt);
 
 		// Update controller pad states
-		for (int i = 0; i < 8; i++)
-		{
-			if (nx_ctx->pads[i])
-			{
-				padUpdate(nx_ctx->pads[i]);
-			}
-		}
+		padUpdate(&nx_ctx->pads[0]);
+		padUpdate(&nx_ctx->pads[1]);
+		padUpdate(&nx_ctx->pads[2]);
+		padUpdate(&nx_ctx->pads[3]);
+		padUpdate(&nx_ctx->pads[4]);
+		padUpdate(&nx_ctx->pads[5]);
+		padUpdate(&nx_ctx->pads[6]);
+		padUpdate(&nx_ctx->pads[7]);
+
+		u64 kDown = padGetButtonsDown(&nx_ctx->pads[0]);
+		bool plusDown = kDown & HidNpadButton_Plus;
 
 		if (nx_ctx->had_error)
 		{
-			// if (kDown & HidNpadButton_Plus)
-			//{
-			//	// When an initialization or unhandled error occurs,
-			//	// wait until the user presses "+" to fully exit so
-			//	// the user has a chance to read the error message.
-			//	break;
-			// }
+			if (plusDown)
+			{
+				// When an initialization or unhandled error occurs,
+				// wait until the user presses "+" to fully exit so
+				// the user has a chance to read the error message.
+				break;
+			}
 		}
 		else
 		{
 			// Call frame handler
-			// JSValueConst args[] = {JS_NewUint32(ctx, kDown)};
-			JSValue ret_val = JS_Call(ctx, nx_ctx->frame_handler, JS_NULL, 0, NULL);
+			JSValueConst args[] = {JS_NewBool(ctx, plusDown)};
+			JSValue ret_val = JS_Call(ctx, nx_ctx->frame_handler, JS_NULL, 1, args);
 
 			if (JS_IsException(ret_val))
 			{

--- a/source/main.c
+++ b/source/main.c
@@ -486,7 +486,7 @@ int main(int argc, char *argv[])
 
 	FILE *debug_fd = freopen(LOG_FILENAME, "w", stderr);
 
-	padConfigureInput(8, HidNpadStyleSet_NpadStandard);
+	padConfigureInput(8, HidNpadStyleSet_NpadStandard | HidNpadStyleTag_NpadGc);
 
 	JSRuntime *rt = JS_NewRuntime();
 	JSContext *ctx = JS_NewContext(rt);

--- a/source/main.c
+++ b/source/main.c
@@ -486,8 +486,6 @@ int main(int argc, char *argv[])
 
 	FILE *debug_fd = freopen(LOG_FILENAME, "w", stderr);
 
-	padConfigureInput(8, HidNpadStyleSet_NpadStandard | HidNpadStyleTag_NpadGc);
-
 	JSRuntime *rt = JS_NewRuntime();
 	JSContext *ctx = JS_NewContext(rt);
 
@@ -503,6 +501,16 @@ int main(int argc, char *argv[])
 	JS_SetContextOpaque(ctx, nx_ctx);
 	JS_SetRuntimeOpaque(rt, nx_ctx);
 	JS_SetHostPromiseRejectionTracker(rt, nx_promise_rejection_handler, ctx);
+
+	padConfigureInput(8, HidNpadStyleSet_NpadStandard | HidNpadStyleTag_NpadGc);
+	padInitializeDefault(&nx_ctx->pads[0]);
+	padInitialize(&nx_ctx->pads[1], HidNpadIdType_No2);
+	padInitialize(&nx_ctx->pads[2], HidNpadIdType_No3);
+	padInitialize(&nx_ctx->pads[3], HidNpadIdType_No4);
+	padInitialize(&nx_ctx->pads[4], HidNpadIdType_No5);
+	padInitialize(&nx_ctx->pads[5], HidNpadIdType_No6);
+	padInitialize(&nx_ctx->pads[6], HidNpadIdType_No7);
+	padInitialize(&nx_ctx->pads[7], HidNpadIdType_No8);
 
 	// First try the `main.js` file on the RomFS
 	size_t user_code_size;

--- a/source/types.h
+++ b/source/types.h
@@ -84,6 +84,7 @@ typedef struct nx_context_s
 	JSValue exit_handler;
 	JSValue error_handler;
 	JSValue unhandled_rejection_handler;
+	PadState *pads[8];
 
 	// mbedtls structures shared by all TLS connections
 	bool mbedtls_initialized;

--- a/source/types.h
+++ b/source/types.h
@@ -84,7 +84,7 @@ typedef struct nx_context_s
 	JSValue exit_handler;
 	JSValue error_handler;
 	JSValue unhandled_rejection_handler;
-	PadState *pads[8];
+	PadState pads[8];
 
 	// mbedtls structures shared by all TLS connections
 	bool mbedtls_initialized;


### PR DESCRIPTION
 - Allows for up to 8 gamepads to be individually controlled
 - Adds support for l/r analog stick positions to be utilzed
 - Removes non-standard `buttondown` and `buttonup` events
 - Use `preventDefault()` on "beforeunload" event to prevent exiting

Closes #46.