### PR TITLE
Support arbitrary key name length in `localStorage`

### DIFF
--- a/.changeset/tender-hairs-grab.md
+++ b/.changeset/tender-hairs-grab.md
@@ -1,0 +1,5 @@
+---
+"nxjs-runtime": patch
+---
+
+Support arbitrary key name length in `localStorage`

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -118,6 +118,7 @@ export interface Init {
 	// crypto.c
 	cryptoDigest(algorithm: string, buf: ArrayBuffer): Promise<ArrayBuffer>;
 	cryptoRandomBytes(buf: ArrayBuffer, offset: number, length: number): void;
+	sha256Hex(str: string): string;
 
 	// dommatrix.c
 	dommatrixNew(values?: number[]): DOMMatrix | DOMMatrixReadOnly;

--- a/packages/runtime/src/storage.ts
+++ b/packages/runtime/src/storage.ts
@@ -157,9 +157,9 @@ Object.defineProperty(globalThis, 'localStorage', {
 			key(index: number): string | null {
 				if (index < 0) return null;
 				const i = index % 0x100000000;
-				const keys = Object.keys(keyMap);
-				if (i >= keys.length) return null;
-				return keyMap[keys[i]] ?? null;
+				const v = Object.values(keyMap);
+				if (i >= v.length) return null;
+				return v[i] ?? null;
 			},
 			removeItem(key: string): void {
 				const d = keyDigest(key);

--- a/source/crypto.c
+++ b/source/crypto.c
@@ -109,7 +109,7 @@ static JSValue nx_crypto_sha256_hex(JSContext *ctx, JSValueConst this_val,
 	}
 	sha256CalculateHash(digest, str, size);
 	JS_FreeCString(ctx, str);
-	char *hex = js_malloc(ctx, SHA256_HASH_SIZE * 2);
+	char *hex = js_malloc(ctx, (SHA256_HASH_SIZE * 2) + 1);
 	for (int i = 0; i < SHA256_HASH_SIZE; i++) {
 		snprintf(hex + i * 2, 3, "%02x", digest[i]);
 	}

--- a/source/crypto.c
+++ b/source/crypto.c
@@ -109,12 +109,11 @@ static JSValue nx_crypto_sha256_hex(JSContext *ctx, JSValueConst this_val,
 	}
 	sha256CalculateHash(digest, str, size);
 	JS_FreeCString(ctx, str);
-	char *hex = js_malloc(ctx, (SHA256_HASH_SIZE * 2) + 1);
+	char hex[SHA256_HASH_SIZE * 2 + 1];
 	for (int i = 0; i < SHA256_HASH_SIZE; i++) {
 		snprintf(hex + i * 2, 3, "%02x", digest[i]);
 	}
 	JSValue hex_val = JS_NewString(ctx, hex);
-	js_free(ctx, hex);
 	js_free(ctx, digest);
 	return hex_val;
 }

--- a/source/crypto.c
+++ b/source/crypto.c
@@ -96,9 +96,33 @@ static JSValue nx_crypto_random_bytes(JSContext *ctx, JSValueConst this_val,
 	return JS_UNDEFINED;
 }
 
+static JSValue nx_crypto_sha256_hex(JSContext *ctx, JSValueConst this_val,
+									int argc, JSValueConst *argv) {
+	size_t size;
+	const char *str = JS_ToCStringLen(ctx, &size, argv[0]);
+	if (!str) {
+		return JS_EXCEPTION;
+	}
+	u8 *digest = js_mallocz(ctx, SHA256_HASH_SIZE);
+	if (!digest) {
+		return JS_EXCEPTION;
+	}
+	sha256CalculateHash(digest, str, size);
+	JS_FreeCString(ctx, str);
+	char *hex = js_malloc(ctx, SHA256_HASH_SIZE * 2);
+	for (int i = 0; i < SHA256_HASH_SIZE; i++) {
+		snprintf(hex + i * 2, 3, "%02x", digest[i]);
+	}
+	JSValue hex_val = JS_NewString(ctx, hex);
+	js_free(ctx, hex);
+	js_free(ctx, digest);
+	return hex_val;
+}
+
 static const JSCFunctionListEntry function_list[] = {
 	JS_CFUNC_DEF("cryptoDigest", 0, nx_crypto_digest),
 	JS_CFUNC_DEF("cryptoRandomBytes", 0, nx_crypto_random_bytes),
+	JS_CFUNC_DEF("sha256Hex", 0, nx_crypto_sha256_hex),
 };
 
 void nx_init_crypto(JSContext *ctx, JSValueConst init_obj) {


### PR DESCRIPTION
Previously the arrangement of the `localStorage` save data was the key filenames were encoded as hex strings of the binary name, with underscores i.e. "foo" -> `_66_6f_6f`. This leads to unpredictable filename sizes, which might exceed the max file path length on the save data filesystem.

Now, the key filenames are a stable length, due to being a sha256 digest of the key name. So the max file path issue should never arise. However, because sha265 digests are non-reversible, a `keys.json` file is also introduced which maintains the mapping between digests and key names, for the enumeration functions (`key()`, `length`, `has`, `ownKeys`).

Fixes #144.