### PR TITLE
perf(fetch): use array join for header serialization

### DIFF
--- a/packages/runtime/src/fetch/fetch.ts
+++ b/packages/runtime/src/fetch/fetch.ts
@@ -176,11 +176,12 @@ async function fetchHttp(req: Request, url: URL): Promise<Response> {
 		req.headers.set('transfer-encoding', 'chunked');
 	}
 
-	let header = `${req.method} ${url.pathname}${url.search} HTTP/1.1\r\n`;
+	const headerParts = [`${req.method} ${url.pathname}${url.search} HTTP/1.1`];
 	for (const [name, value] of req.headers) {
-		header += `${name}: ${value}\r\n`;
+		headerParts.push(`${name}: ${value}`);
 	}
-	header += '\r\n';
+	headerParts.push('', '');
+	const header = headerParts.join('\r\n');
 	const w = socket.writable.getWriter();
 	await w.write(encoder.encode(header));
 


### PR DESCRIPTION
## Problem

String concatenation in a loop creates O(n²) intermediate strings during HTTP request header construction. For requests with many headers, this causes unnecessary memory pressure and GC overhead.

From issue #268:
> String concatenation in a loop creates O(n²) intermediate strings.

## Analysis

The current implementation in `packages/runtime/src/fetch/fetch.ts` builds the HTTP request header line-by-line:

```typescript
let header = `${req.method} ${url.pathname}${url.search} HTTP/1.1\r\n`;
for (const [name, value] of req.headers) {
    header += `${name}: ${value}\r\n`;
}
header += '\r\n';
```

Each `+=` operation creates a new intermediate string, copying all previous content.

## Solution

Use array accumulation with a single `join()` call:

```typescript
const headerParts = [`${req.method} ${url.pathname}${url.search} HTTP/1.1`];
for (const [name, value] of req.headers) {
    headerParts.push(`${name}: ${value}`);
}
headerParts.push('', '');
const header = headerParts.join('\r\n');
```

This reduces allocations from O(n²) to O(n) intermediate objects.

## Notes

- No behavioral changes — output is byte-identical
- Addresses audit finding #268 point 1
- Follows the same pattern suggested in the issue description

Refs: #268