### PR TITLE
fix: URLSearchParams.get() returns null for missing keys

### DIFF
--- a/.changeset/fix-urlsearchparams-get-null.md
+++ b/.changeset/fix-urlsearchparams-get-null.md
@@ -1,0 +1,5 @@
+---
+'@nx.js/runtime': patch
+---
+
+Fix `URLSearchParams.get()` to return `null` for missing keys instead of `""`

--- a/packages/runtime/test/fixtures/url.ts
+++ b/packages/runtime/test/fixtures/url.ts
@@ -44,9 +44,7 @@ test('URLSearchParams basics', (t) => {
 	t.equal(params.get('a'), '1', 'get a');
 	t.equal(params.get('b'), '2', 'get b');
 	t.equal(params.get('c'), '3', 'get c');
-	// NOTE: params.get() for a missing key should return null per spec,
-	// but nx.js currently returns "". Tracked as a known issue.
-	// t.equal(params.get('d'), null, 'get missing');
+	t.equal(params.get('d'), null, 'get missing returns null');
 	t.equal(params.has('a'), true, 'has a');
 	t.equal(params.has('d'), false, 'has d');
 	t.equal(params.size, 3, 'size');

--- a/source/url.c
+++ b/source/url.c
@@ -349,6 +349,9 @@ static JSValue nx_url_search_params_get(JSContext *ctx, JSValueConst this_val,
 	STR(key, 0);
 	ada_string val = ada_search_params_get(data->params, key, key_length);
 	JS_FreeCString(ctx, key);
+	if (val.data == NULL) {
+		return JS_NULL;
+	}
 	return JS_NewStringLen(ctx, val.data, val.length);
 }
 


### PR DESCRIPTION
## Summary

- Fixes `URLSearchParams.get()` to return `null` for missing keys instead of `""`
- One-line fix in `source/url.c`: check `ada_string.data == NULL` before creating a JS string

## Root cause

The `ada` C library's `ada_search_params_get()` returns `{data=NULL, length=0}` when a key is not found. The nx.js binding `nx_url_search_params_get()` unconditionally called `JS_NewStringLen(ctx, val.data, val.length)` which turned `NULL` into an empty string `""`. Now it checks for `val.data == NULL` and returns `JS_NULL`.

## Test

Restores the previously-skipped conformance test assertion in `url.ts`:
```typescript
t.equal(params.get('d'), null, 'get missing returns null');
```

This was identified by the TAP conformance framework (nxjs-test vs Chrome comparison).