### PR TITLE
fix: streaming decompression OOM on memory-constrained systems

### DIFF
--- a/packages/runtime/src/compression-streams.ts
+++ b/packages/runtime/src/compression-streams.ts
@@ -1,4 +1,5 @@
 import { $ } from './$';
+import { kNativeRead, kNativeSetup } from './polyfills/streams';
 import { def } from './utils';
 
 /**
@@ -13,6 +14,11 @@ export class CompressionStream
 	extends TransformStream<Uint8Array, Uint8Array>
 	implements globalThis.CompressionStream
 {
+	/** @internal */
+	[kNativeSetup]?: (
+		source: ReadableStream<Uint8Array>,
+	) => ReadableStream<Uint8Array>;
+
 	constructor(format: CompressionFormat) {
 		const h = $.compressNew(format);
 		super({
@@ -27,6 +33,40 @@ export class CompressionStream
 				}
 			},
 		});
+		this[kNativeSetup] = (source) => {
+			const nativeRead = (source as any)[kNativeRead] as
+				| (() => Promise<IteratorResult<Uint8Array, undefined>>)
+				| undefined;
+			const reader = nativeRead ? null : source.getReader();
+			const readNext = nativeRead ? nativeRead : () => reader!.read();
+
+			let isDone = false;
+			return new ReadableStream<Uint8Array>({
+				async pull(controller) {
+					while (!isDone) {
+						const result = await readNext();
+						if (result.done) {
+							const flushed = await $.compressFlush(h);
+							if (flushed && flushed.byteLength > 0) {
+								controller.enqueue(new Uint8Array(flushed));
+							}
+							controller.close();
+							isDone = true;
+							return;
+						}
+						const b = await $.compressWrite(h, result.value!);
+						if (b.byteLength > 0) {
+							controller.enqueue(new Uint8Array(b));
+							return;
+						}
+					}
+					controller.close();
+				},
+				cancel() {
+					if (reader) reader.cancel();
+				},
+			});
+		};
 	}
 }
 def(CompressionStream);
@@ -38,12 +78,32 @@ export class DecompressionStream
 	extends TransformStream<Uint8Array, Uint8Array>
 	implements globalThis.DecompressionStream
 {
+	/** @internal */
+	[kNativeSetup]?: (
+		source: ReadableStream<Uint8Array>,
+	) => ReadableStream<Uint8Array>;
+
 	constructor(format: CompressionFormat) {
 		const h = $.decompressNew(format);
 		super({
 			async transform(chunk, controller) {
-				const b = await $.decompressWrite(h, chunk);
-				controller.enqueue(new Uint8Array(b));
+				if (format === 'zstd') {
+					let offset = 0;
+					while (offset < chunk.length) {
+						const b = await $.decompressWrite(h, chunk.subarray(offset));
+						if (b.byteLength > 0) {
+							controller.enqueue(new Uint8Array(b));
+						}
+						const consumed = (h as any).inputConsumed as number;
+						offset += consumed;
+						if (consumed === 0) break;
+					}
+				} else {
+					const b = await $.decompressWrite(h, chunk);
+					if (b.byteLength > 0) {
+						controller.enqueue(new Uint8Array(b));
+					}
+				}
 			},
 			async flush(controller) {
 				const b = await $.decompressFlush(h);
@@ -52,6 +112,57 @@ export class DecompressionStream
 				}
 			},
 		});
+		this[kNativeSetup] = (source) => {
+			const nativeRead = (source as any)[kNativeRead] as
+				| (() => Promise<IteratorResult<Uint8Array, undefined>>)
+				| undefined;
+			const reader = nativeRead ? null : source.getReader();
+			const readNext = nativeRead ? nativeRead : () => reader!.read();
+
+			let isDone = false;
+			return new ReadableStream<Uint8Array>({
+				async pull(controller) {
+					while (!isDone) {
+						const result = await readNext();
+						if (result.done) {
+							const flushed = await $.decompressFlush(h);
+							if (flushed && flushed.byteLength > 0) {
+								controller.enqueue(new Uint8Array(flushed));
+							}
+							controller.close();
+							isDone = true;
+							return;
+						}
+						const chunk = result.value!;
+						let enqueued = false;
+						if (format === 'zstd') {
+							let offset = 0;
+							while (offset < chunk.length) {
+								const b = await $.decompressWrite(h, chunk.subarray(offset));
+								if (b.byteLength > 0) {
+									controller.enqueue(new Uint8Array(b));
+									enqueued = true;
+								}
+								const consumed = (h as any).inputConsumed as number;
+								offset += consumed;
+								if (consumed === 0) break;
+							}
+						} else {
+							const b = await $.decompressWrite(h, chunk);
+							if (b.byteLength > 0) {
+								controller.enqueue(new Uint8Array(b));
+								enqueued = true;
+							}
+						}
+						if (enqueued) return;
+					}
+					controller.close();
+				},
+				cancel() {
+					if (reader) reader.cancel();
+				},
+			});
+		};
 	}
 }
 def(DecompressionStream);

--- a/packages/runtime/src/fs.ts
+++ b/packages/runtime/src/fs.ts
@@ -1,10 +1,11 @@
 import { $ } from './$';
-import { bufferSourceToArrayBuffer, pathToString } from './utils';
 import { File } from './polyfills/file';
+import { kNativeRead } from './polyfills/streams';
 import { decoder } from './polyfills/text-decoder';
 import { encoder } from './polyfills/text-encoder';
 import type { PathLike } from './switch';
 import type { BufferSource } from './types';
+import { bufferSourceToArrayBuffer, pathToString } from './utils';
 
 export interface ReadFileOptions {
 	/**
@@ -266,39 +267,103 @@ export class FsFile extends File {
 		return JSON.parse(await this.text());
 	}
 
+	/**
+	 * Returns an async iterator that reads the file in chunks using a
+	 * single reusable buffer. This is more memory-efficient than
+	 * `stream()` for large files because it avoids the overhead of
+	 * the ReadableStream internal queue.
+	 *
+	 * **Important:** The yielded `Uint8Array` is a view into a shared
+	 * buffer that is overwritten on each iteration. If you need to
+	 * retain the data, copy it with `slice()` before the next iteration.
+	 */
+	async *[Symbol.asyncIterator](
+		opts?: FsFileStreamOptions,
+	): AsyncGenerator<Uint8Array, void, undefined> {
+		const chunkSize = opts?.chunkSize || 65536;
+		const readBuf = new ArrayBuffer(chunkSize);
+		let offset = this.start ?? 0;
+		const end = this.end;
+		const h = await $.fopen(this.name, 'rb', this.start);
+		try {
+			while (true) {
+				const remaining = end ? end - offset : Infinity;
+				if (remaining <= 0) break;
+				const n = await $.fread(h, readBuf);
+				if (n === null) break;
+				if (n > 0) {
+					const clamped = Math.min(n, remaining);
+					offset += clamped;
+					yield new Uint8Array(readBuf, 0, clamped);
+				}
+			}
+		} finally {
+			await $.fclose(h);
+		}
+	}
+
 	stream(opts?: FsFileStreamOptions): ReadableStream<Uint8Array> {
 		const { name, start, end } = this;
 		let offset = start ?? 0;
 		const chunkSize = opts?.chunkSize || 65536;
 		let h: Awaited<ReturnType<typeof $.fopen>> | undefined | null;
-		return new ReadableStream({
-			type: 'bytes',
+		let closed = false;
+		// Single reusable read buffer — avoids per-read allocations.
+		const readBuf = new ArrayBuffer(chunkSize);
+		const done = { done: true, value: undefined } as const;
+
+		async function nextChunk(): Promise<IteratorResult<Uint8Array, undefined>> {
+			if (closed) return done;
+			if (!h) h = await $.fopen(name, 'rb', start);
+			const remaining = end ? end - offset : Infinity;
+			if (remaining <= 0) {
+				await $.fclose(h);
+				h = null;
+				closed = true;
+				return done;
+			}
+			const n = await $.fread(h, readBuf);
+			if (n === null) {
+				await $.fclose(h);
+				h = null;
+				closed = true;
+				return done;
+			}
+			if (n > 0) {
+				const clamped = Math.min(n, remaining);
+				offset += clamped;
+				return {
+					done: false,
+					value: new Uint8Array(readBuf.slice(0, clamped)),
+				};
+			}
+			return done;
+		}
+
+		// Return a ReadableStream backed by a pull source that uses
+		// the reusable buffer. The stream only pulls when the consumer
+		// reads, providing natural backpressure.
+		const rs = new ReadableStream({
 			async pull(controller) {
-				if (!h) h = await $.fopen(name, 'rb', start);
-				const remaining = end ? end - offset : Infinity;
-				if (remaining <= 0) {
+				const result = await nextChunk();
+				if (result.done) {
 					controller.close();
-					await $.fclose(h);
-					h = null;
-					return;
-				}
-				const b = new Uint8Array(Math.min(chunkSize, remaining));
-				const n = await $.fread(h, b.buffer);
-				if (n === null) {
-					controller.close();
-					await $.fclose(h);
-					h = null;
-				} else if (n > 0) {
-					offset += n;
-					controller.enqueue(n < b.length ? b.subarray(0, n) : b);
+				} else {
+					controller.enqueue(result.value);
 				}
 			},
 			async cancel() {
+				closed = true;
 				if (h) {
 					await $.fclose(h);
+					h = null;
 				}
 			},
 		});
+		// Attach native read function so pipeThrough can bypass
+		// the polyfill's reader.read() Promise chains.
+		(rs as any)[kNativeRead] = nextChunk;
+		return rs;
 	}
 
 	get writable() {

--- a/packages/runtime/src/polyfills/streams.ts
+++ b/packages/runtime/src/polyfills/streams.ts
@@ -1,10 +1,45 @@
-import { def } from '../utils';
 import * as streams from 'web-streams-polyfill';
+import { def } from '../utils';
 import type { AbortSignal } from './abort-controller';
 
 for (const k of Object.keys(streams)) {
 	def(streams[k as keyof typeof streams], k);
 }
+
+// Override pipeThrough to bypass TransformStream internals when piping
+// through a CompressionStream or DecompressionStream. The polyfill's
+// pipeTo creates ~10 Promise objects per chunk forming reference cycles
+// that QuickJS's reference-counting GC cannot collect, causing OOM.
+// When a native stream is detected via kNativeSetup, we bypass pipeTo
+// entirely and connect the source directly to the native C API.
+// The kNativeSetup symbol is defined here (not in compression-streams.ts)
+// to avoid a circular dependency. compression-streams.ts imports it from here.
+export const kNativeSetup = Symbol('nativeSetup');
+// Symbol for native read function on ReadableStreams backed by file I/O.
+// When present, pipeThrough uses it instead of reader.read() to avoid
+// the polyfill's Promise chains that leak on QuickJS.
+export const kNativeRead = Symbol('nativeRead');
+
+const origPipeThrough = streams.ReadableStream.prototype.pipeThrough;
+(streams.ReadableStream.prototype as any).pipeThrough = function pipeThrough(
+	this: ReadableStream,
+	transform: { readable: ReadableStream; writable: WritableStream },
+	options?: StreamPipeOptions,
+): ReadableStream {
+	const setup = (transform as any)[kNativeSetup];
+	if (typeof setup === 'function' && !options?.signal) {
+		const nativeReadable = setup(this);
+		// Override the `readable` property on the transform instance.
+		// TransformStream defines `readable` as a getter on the prototype,
+		// so a simple assignment would fail. Use defineProperty to shadow it.
+		Object.defineProperty(transform, 'readable', {
+			value: nativeReadable,
+			configurable: true,
+		});
+		return nativeReadable;
+	}
+	return (origPipeThrough as any).call(this, transform, options);
+};
 
 export type ReadableStreamController<T> =
 	| ReadableStreamDefaultController<T>

--- a/packages/runtime/test/src/main.c
+++ b/packages/runtime/test/src/main.c
@@ -126,6 +126,59 @@ void nx_exit_event_loop(void) {
 }
 
 // ============================================================================
+// Debug / instrumentation functions (test binary only)
+// ============================================================================
+
+static JSValue js_gc(JSContext *ctx, JSValueConst this_val, int argc,
+                     JSValueConst *argv) {
+	(void)this_val;
+	(void)argc;
+	(void)argv;
+	JS_RunGC(JS_GetRuntime(ctx));
+	return JS_UNDEFINED;
+}
+
+static JSValue js_memory_usage(JSContext *ctx, JSValueConst this_val,
+                               int argc, JSValueConst *argv) {
+	(void)this_val;
+	(void)argc;
+	(void)argv;
+	JSMemoryUsage stats;
+	JS_ComputeMemoryUsage(JS_GetRuntime(ctx), &stats);
+
+	JSValue obj = JS_NewObject(ctx);
+	JS_SetPropertyStr(ctx, obj, "mallocSize",
+	                  JS_NewInt64(ctx, stats.malloc_size));
+	JS_SetPropertyStr(ctx, obj, "mallocCount",
+	                  JS_NewInt64(ctx, stats.malloc_count));
+	JS_SetPropertyStr(ctx, obj, "memoryUsedSize",
+	                  JS_NewInt64(ctx, stats.memory_used_size));
+	JS_SetPropertyStr(ctx, obj, "memoryUsedCount",
+	                  JS_NewInt64(ctx, stats.memory_used_count));
+	JS_SetPropertyStr(ctx, obj, "objCount",
+	                  JS_NewInt64(ctx, stats.obj_count));
+	JS_SetPropertyStr(ctx, obj, "objSize",
+	                  JS_NewInt64(ctx, stats.obj_size));
+	JS_SetPropertyStr(ctx, obj, "strCount",
+	                  JS_NewInt64(ctx, stats.str_count));
+	JS_SetPropertyStr(ctx, obj, "strSize",
+	                  JS_NewInt64(ctx, stats.str_size));
+	JS_SetPropertyStr(ctx, obj, "binaryObjectCount",
+	                  JS_NewInt64(ctx, stats.binary_object_count));
+	JS_SetPropertyStr(ctx, obj, "binaryObjectSize",
+	                  JS_NewInt64(ctx, stats.binary_object_size));
+	JS_SetPropertyStr(ctx, obj, "propCount",
+	                  JS_NewInt64(ctx, stats.prop_count));
+	JS_SetPropertyStr(ctx, obj, "shapeCount",
+	                  JS_NewInt64(ctx, stats.shape_count));
+	JS_SetPropertyStr(ctx, obj, "jsFuncCount",
+	                  JS_NewInt64(ctx, stats.js_func_count));
+	JS_SetPropertyStr(ctx, obj, "arrayCount",
+	                  JS_NewInt64(ctx, stats.array_count));
+	return obj;
+}
+
+// ============================================================================
 // Print functions
 // ============================================================================
 
@@ -726,6 +779,8 @@ int main(int argc, char *argv[]) {
 	// Inline functions (from source/main.c — portable on host)
 	const JSCFunctionListEntry init_function_list[] = {
 	    JS_CFUNC_DEF("exit", 0, js_exit),
+	    JS_CFUNC_DEF("gc", 0, js_gc),
+	    JS_CFUNC_DEF("memoryUsage", 0, js_memory_usage),
 	    JS_CFUNC_DEF("cwd", 0, js_cwd),
 	    JS_CFUNC_DEF("chdir", 1, js_chdir),
 	    JS_CFUNC_DEF("print", 1, js_print),
@@ -790,6 +845,16 @@ int main(int argc, char *argv[]) {
 
 	// Expose $ as global
 	JS_SetPropertyStr(ctx, global_obj, "$", nx_ctx->init_obj);
+
+	// Expose debug/instrumentation functions as globals (test binary only).
+	// These survive the `delete globalThis.$` in the runtime and are
+	// available to test scripts for memory leak investigation.
+	JS_SetPropertyStr(
+	    ctx, global_obj, "__gc",
+	    JS_NewCFunction(ctx, js_gc, "__gc", 0));
+	JS_SetPropertyStr(
+	    ctx, global_obj, "__memoryUsage",
+	    JS_NewCFunction(ctx, js_memory_usage, "__memoryUsage", 0));
 
 	// Install the Proxy stub so runtime.js can load without crashing
 	// even for modules whose native bindings are no-ops

--- a/packages/runtime/test/src/main.c
+++ b/packages/runtime/test/src/main.c
@@ -651,6 +651,19 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
+	// Set JS heap memory limit. Use NXJS_MEMORY_LIMIT env var (in bytes)
+	// to simulate constrained environments like Nintendo Switch hardware.
+	// Default: unlimited. Example: NXJS_MEMORY_LIMIT=268435456 (256 MB)
+	const char *mem_limit_str = getenv("NXJS_MEMORY_LIMIT");
+	if (mem_limit_str) {
+		size_t mem_limit = (size_t)strtoull(mem_limit_str, NULL, 10);
+		if (mem_limit > 0) {
+			JS_SetMemoryLimit(rt, mem_limit);
+			fprintf(stderr, "JS memory limit set to %zu bytes (%.1f MB)\n",
+			        mem_limit, (double)mem_limit / (1024 * 1024));
+		}
+	}
+
 	JSContext *ctx = JS_NewContext(rt);
 	if (!ctx) {
 		fprintf(stderr, "Failed to create JS context\n");

--- a/source/compression.c
+++ b/source/compression.c
@@ -25,14 +25,23 @@ typedef struct {
 	size_t result_size;
 } nx_compress_flush_async_t;
 
+#define DECOMPRESS_OUT_SIZE 131072 // ZSTD_DStreamOutSize() = 128KB
+
 typedef struct {
 	int err;
+	const char *err_msg; // ZSTD error name (static string, do not free)
 	nx_decompress_t *context;
+	JSValue handle_val; // reference to the handle JS object
 	JSValue data_val;
 	uint8_t *data;
 	size_t size;
-	uint8_t *result;
-	size_t result_size;
+	// zlib path: heap-allocated result via realloc (caller must free)
+	uint8_t *zlib_result;
+	size_t zlib_result_size;
+	// zstd path: fixed output buffer, no malloc needed
+	size_t input_consumed;
+	uint8_t zstd_result[DECOMPRESS_OUT_SIZE];
+	size_t zstd_result_size;
 } nx_decompress_write_async_t;
 
 typedef struct {
@@ -236,34 +245,43 @@ void nx_compress_write_do(nx_work_t *req) {
 	} else if (data->context->format == NX_COMPRESSION_FORMAT_ZSTD) {
 		ZSTD_inBuffer input = {.src = data->data, .size = data->size, .pos = 0};
 
-		// compress chunks until done
+		size_t capacity = ZSTD_CStreamOutSize();
+		data->result = malloc(capacity);
+		if (!data->result) {
+			ZSTD_freeCCtx(data->context->cctx);
+			data->context->cctx = NULL;
+			data->err = ENOMEM;
+			return;
+		}
+
+		// Compress chunks until done
 		while (input.pos < input.size) {
-			// Allocate or expand result buffer
-			size_t size = ZSTD_CStreamOutSize();
-			void *new_result = realloc(data->result, data->result_size + size);
-			if (!new_result) {
-				if (data->result) {
+			if (data->result_size >= capacity) {
+				size_t new_capacity = capacity * 2;
+				void *new_result = realloc(data->result, new_capacity);
+				if (!new_result) {
 					free(data->result);
+					data->result = NULL;
+					ZSTD_freeCCtx(data->context->cctx);
+					data->context->cctx = NULL;
+					data->err = ENOMEM;
+					return;
 				}
-				ZSTD_freeCCtx(data->context->cctx);
-				data->context->cctx = NULL;
-				data->err = ENOMEM;
-				return;
+				data->result = new_result;
+				capacity = new_capacity;
 			}
-			data->result = new_result;
 
 			ZSTD_outBuffer output = {.dst = (char *)data->result +
 											data->result_size,
-									 .size = size,
+									 .size = capacity - data->result_size,
 									 .pos = 0};
 
 			size_t ret =
 				ZSTD_compressStream(data->context->cctx, &output, &input);
 
 			if (ZSTD_isError(ret)) {
-				if (data->result) {
-					free(data->result);
-				}
+				free(data->result);
+				data->result = NULL;
 				ZSTD_freeCCtx(data->context->cctx);
 				data->context->cctx = NULL;
 				data->err = -4;
@@ -273,13 +291,15 @@ void nx_compress_write_do(nx_work_t *req) {
 			data->result_size += output.pos;
 		}
 
-		// Shrink buffer to actual size
-		// TODO: remove?
-		if (data->result_size > 0) {
+		// Shrink buffer to actual size to free unused capacity
+		if (data->result_size > 0 && data->result_size < capacity) {
 			void *final_result = realloc(data->result, data->result_size);
 			if (final_result) {
 				data->result = final_result;
 			}
+		} else if (data->result_size == 0) {
+			free(data->result);
+			data->result = NULL;
 		}
 	}
 }
@@ -528,8 +548,10 @@ static JSValue nx_decompress_new(JSContext *ctx, JSValueConst this_val,
 void nx_decompress_write_do(nx_work_t *req) {
 	nx_decompress_write_async_t *data =
 		(nx_decompress_write_async_t *)req->data;
-	data->result = NULL;
-	data->result_size = 0;
+	data->zlib_result = NULL;
+	data->zlib_result_size = 0;
+	data->zstd_result_size = 0;
+	data->input_consumed = 0;
 
 	if (data->context->format == NX_COMPRESSION_FORMAT_GZIP ||
 		data->context->format == NX_COMPRESSION_FORMAT_DEFLATE ||
@@ -541,91 +563,62 @@ void nx_decompress_write_do(nx_work_t *req) {
 		stream->avail_in = data->size;
 		stream->next_in = data->data;
 
-		// Decompress until deflate stream ends
 		do {
 			stream->avail_out = CHUNK;
 			stream->next_out = out;
 
 			ret = inflate(stream, Z_NO_FLUSH);
 
-			// Z_BUF_ERROR (-5) means we need more input data
-			// This is not a fatal error, just break the loop
 			if (ret == Z_BUF_ERROR) {
 				break;
 			}
 
 			if (ret != Z_OK && ret != Z_STREAM_END) {
-				if (data->result) {
-					free(data->result);
+				if (data->zlib_result) {
+					free(data->zlib_result);
 				}
 				data->err = ret;
 				return;
 			}
 
-			// Calculate how many bytes we got
 			int have = CHUNK - stream->avail_out;
 
-			// Reallocate our result buffer and append new data
-			unsigned char *new_result =
-				realloc(data->result, data->result_size + have);
-			if (new_result == NULL) {
-				free(data->result);
-				inflateEnd(stream);
-				data->err = Z_MEM_ERROR;
-				return;
+			if (have > 0) {
+				unsigned char *new_result =
+					realloc(data->zlib_result, data->zlib_result_size + have);
+				if (new_result == NULL) {
+					free(data->zlib_result);
+					inflateEnd(stream);
+					data->err = Z_MEM_ERROR;
+					return;
+				}
+				data->zlib_result = new_result;
+				memcpy(data->zlib_result + data->zlib_result_size, out, have);
+				data->zlib_result_size += have;
 			}
-			data->result = new_result;
-			memcpy(data->result + data->result_size, out, have);
-			data->result_size += have;
 		} while (ret != Z_STREAM_END);
 	} else if (data->context->format == NX_COMPRESSION_FORMAT_ZSTD) {
+		// Single ZSTD_decompressStream call into the fixed output buffer.
+		// No malloc/realloc — output is bounded to DECOMPRESS_OUT_SIZE.
+		// The JS side loops calling decompressWrite until all input is
+		// consumed, keeping memory usage constant.
 		ZSTD_inBuffer input = {.src = data->data, .size = data->size, .pos = 0};
+		ZSTD_outBuffer output = {
+			.dst = data->zstd_result, .size = DECOMPRESS_OUT_SIZE, .pos = 0};
 
-		// Decompress chunks until done
-		while (input.pos < input.size) {
-			// Allocate or expand result buffer
-			size_t size = ZSTD_DStreamOutSize();
-			void *new_result = realloc(data->result, data->result_size + size);
-			if (!new_result) {
-				if (data->result) {
-					free(data->result);
-				}
-				ZSTD_freeDCtx(data->context->dctx);
-				data->context->dctx = NULL;
-				data->err = ENOMEM;
-				return;
-			}
-			data->result = new_result;
+		size_t ret =
+			ZSTD_decompressStream(data->context->dctx, &output, &input);
 
-			ZSTD_outBuffer output = {.dst = (char *)data->result +
-											data->result_size,
-									 .size = size,
-									 .pos = 0};
-
-			size_t ret =
-				ZSTD_decompressStream(data->context->dctx, &output, &input);
-
-			if (ZSTD_isError(ret)) {
-				if (data->result) {
-					free(data->result);
-				}
-				ZSTD_freeDCtx(data->context->dctx);
-				data->context->dctx = NULL;
-				data->err = -4;
-				return;
-			}
-
-			data->result_size += output.pos;
+		if (ZSTD_isError(ret)) {
+			data->err_msg = ZSTD_getErrorName(ret);
+			ZSTD_freeDCtx(data->context->dctx);
+			data->context->dctx = NULL;
+			data->err = -1;
+			return;
 		}
 
-		// Shrink buffer to actual size
-		// TODO: remove?
-		if (data->result_size > 0) {
-			void *final_result = realloc(data->result, data->result_size);
-			if (final_result) {
-				data->result = final_result;
-			}
-		}
+		data->zstd_result_size = output.pos;
+		data->input_consumed = input.pos;
 	}
 }
 
@@ -635,15 +628,35 @@ JSValue nx_decompress_write_cb(JSContext *ctx, nx_work_t *req) {
 	JS_FreeValue(ctx, data->data_val);
 
 	if (data->err) {
+		JS_FreeValue(ctx, data->handle_val);
+		if (data->zlib_result) {
+			free(data->zlib_result);
+		}
+		const char *msg =
+			data->err_msg ? data->err_msg : strerror(data->err);
 		JSValue err = JS_NewError(ctx);
 		JS_DefinePropertyValueStr(ctx, err, "message",
-								  JS_NewString(ctx, strerror(data->err)),
+								  JS_NewString(ctx, msg),
 								  JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
 		return JS_Throw(ctx, err);
 	}
 
-	return JS_NewArrayBuffer(ctx, data->result, data->result_size,
-							 free_array_buffer, NULL, false);
+	if (data->context->format == NX_COMPRESSION_FORMAT_ZSTD) {
+		// Store inputConsumed on the handle object — avoids allocating
+		// a wrapper array per call, which adds GC pressure.
+		JS_SetPropertyStr(ctx, data->handle_val, "inputConsumed",
+						  JS_NewInt64(ctx, data->input_consumed));
+		JS_FreeValue(ctx, data->handle_val);
+		return JS_NewArrayBufferCopy(
+			ctx, data->zstd_result, data->zstd_result_size);
+	}
+
+	JS_FreeValue(ctx, data->handle_val);
+	// zlib: all input consumed in one call, heap-allocated result
+	JSValue ab = JS_NewArrayBufferCopy(
+		ctx, data->zlib_result, data->zlib_result_size);
+	free(data->zlib_result);
+	return ab;
 }
 
 static JSValue nx_decompress_write(JSContext *ctx, JSValueConst this_val,
@@ -659,6 +672,7 @@ static JSValue nx_decompress_write(JSContext *ctx, JSValueConst this_val,
 		js_free(ctx, data);
 		return JS_EXCEPTION;
 	}
+	data->handle_val = JS_DupValue(ctx, argv[0]);
 	data->data_val = JS_DupValue(ctx, argv[1]);
 	return nx_queue_async(ctx, req, nx_decompress_write_do,
 						  nx_decompress_write_cb);


### PR DESCRIPTION
## Summary

- Fixes out-of-memory errors when piping large compressed data through `DecompressionStream` on the Nintendo Switch
- Root cause: the `web-streams-polyfill`'s `pipeTo` creates ~10 Promise objects per chunk forming reference cycles that QuickJS's reference-counting GC cannot collect during streaming
- Bypasses the polyfill's pipe machinery for `CompressionStream`/`DecompressionStream` by connecting the source directly to the native C API
- Tested successfully on real Switch hardware: 727 MB decompressed through `file.stream().pipeThrough(new DecompressionStream('zstd'))` without OOM

## What changed

### `packages/runtime/src/polyfills/streams.ts`
- Overrides `ReadableStream.prototype.pipeThrough` to detect native compression/decompression streams (via `kNativeSetup` symbol) and bypass `pipeTo` entirely
- Exports `kNativeRead` symbol for tagging streams with native read functions

### `packages/runtime/src/compression-streams.ts`
- `CompressionStream` and `DecompressionStream` now set `kNativeSetup` on construction — a function that creates a direct native pipe ReadableStream
- When `pipeThrough` is called, the native pipe reads from the source (using `kNativeRead` if available, falling back to `reader.read()`) and drives decompression directly in `pull()`, producing bounded output chunks
- The `TransformStream` base class and `transform`/`flush` callbacks are retained for the `writer.write()`/`reader.read()` pattern (non-pipe usage)

### `packages/runtime/src/fs.ts`
- `FsFile.stream()` now tags the returned `ReadableStream` with `kNativeRead` — a function that reads via `$.fread` directly, avoiding polyfill Promise chains
- Adds `FsFile[Symbol.asyncIterator]()` — an async generator for memory-efficient file reading with a single reusable buffer

### `source/compression.c`
- zstd `decompressWrite`: single `ZSTD_decompressStream` call per invocation into a fixed 128KB buffer (zero malloc in worker). JS loops until all input consumed via `h.inputConsumed`
- zstd `compressWrite`: exponential buffer growth instead of linear realloc
- Both paths use `JS_NewArrayBufferCopy` so QuickJS GC tracks memory pressure
- ZSTD errors report actual error name via `ZSTD_getErrorName()` instead of meaningless `strerror(-4)`

### `packages/runtime/test/src/main.c`
- Adds `NXJS_MEMORY_LIMIT` env var to simulate constrained heaps (e.g. `NXJS_MEMORY_LIMIT=268435456` for 256 MB)

## Investigation trail

The debugging process systematically isolated the leak:
1. Raw `$.fopen`/`$.fread` + `$.decompressWrite` → **works** (727 MB)
2. `FsFile.stream()` read-only (no decompression) → **works** (476 MB)
3. `FsFile.stream()` + `$.decompressWrite` (no `TransformStream`) → **OOM at 150 MB**
4. Output `ReadableStream` wrapping raw `$.fread` + `$.decompressWrite` in `pull()` → **works**
5. `pipeThrough` with native pipe using `reader.read()` on source → **OOM at 150 MB**
6. `pipeThrough` with native pipe using `kNativeRead` (raw `$.fread`) → **works** (727 MB)

Conclusion: the polyfill's `ReadableStream.reader.read()` creates Promise chains that leak when called from `pull()` of another ReadableStream with async work. The fix avoids this by using native file I/O directly.

## Test results

All 8 conformance test suites pass.