### PR TITLE
Fix socket buffer exhaustion (ENOBUFS / OOM) under concurrent and failed connections

### DIFF
--- a/.changeset/socket-buffer-exhaustion.md
+++ b/.changeset/socket-buffer-exhaustion.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: right-size the socket transfer-memory pool and plug fd leaks on failed connects, `Socket.close()`, and failed WebSocket handshakes so concurrent `fetch()`/redirect/WebSocket workloads no longer fail with "No buffer space available" (ENOBUFS).

--- a/.changeset/socket-read-buffer-leak.md
+++ b/.changeset/socket-read-buffer-leak.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: size each socket's read buffer to the configured `tcp_rx_buf_size` (and release it eagerly on close) so opening many sockets no longer exhausts the native ArrayBuffer pool in applet mode.

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -342,6 +342,8 @@ export interface Init {
 	argv: string[];
 	entrypoint: string;
 	version: Versions;
+	/** Configured bsdsocket TCP receive buffer size (bytes) for this memory regime. */
+	tcpRxBufSize: number;
 	exit(): never;
 	cwd(): string;
 	chdir(dir: string): void;

--- a/packages/runtime/src/tcp.ts
+++ b/packages/runtime/src/tcp.ts
@@ -69,6 +69,10 @@ interface SocketInternal {
 	tls?: TlsContextOpaque;
 	opened: PromiseWithResolvers<SocketInfo>;
 	closed: PromiseWithResolvers<void>;
+	// Large per-socket read scratch buffer; released eagerly when the socket
+	// finishes/closes (see the readable stream) to avoid exhausting the native
+	// ArrayBuffer pool across many sockets.
+	readBuffer?: ArrayBuffer;
 }
 
 const _ = createInternal<Socket, SocketInternal>();
@@ -108,25 +112,36 @@ export class Socket {
 		this.opened = i.opened.promise;
 		this.closed = i.closed.promise;
 
-		let readBuffer: ArrayBuffer | undefined;
+		// Per-socket read scratch buffer. It is large (matches the native
+		// `tcp_rx_buf_size` in `main.c`), and on Switch these ArrayBuffers are
+		// backed by a limited native pool, so we MUST release it promptly when
+		// the socket is done reading rather than waiting for GC — otherwise
+		// opening many sockets (e.g. a long test run or redirect chains)
+		// exhausts the pool with `RangeError: Array buffer allocation failed`.
 		this.readable = new ReadableStream({
 			async pull(controller) {
 				await socket.opened;
-				if (!readBuffer) {
-					// Matches the configured `tcp_rx_buf_size` in `main.c`
-					readBuffer = new ArrayBuffer(1024 * 1024);
+				if (!i.readBuffer) {
+					// Size to the native bsdsocket tcp_rx_buf_size configured
+					// for this memory regime (1 MiB application / 128 KiB
+					// applet), so applet mode does not over-allocate the
+					// limited ArrayBuffer pool. Fall back to 1 MiB if unset.
+					i.readBuffer = new ArrayBuffer($.tcpRxBufSize || 1024 * 1024);
 				}
 				const bytesRead = await (i.tls
-					? tlsRead(i.tls, readBuffer)
-					: read(i.fd, readBuffer));
+					? tlsRead(i.tls, i.readBuffer)
+					: read(i.fd, i.readBuffer));
 				if (bytesRead === 0) {
+					i.readBuffer = undefined; // EOF: free the buffer
 					controller.close();
 					if (!allowHalfOpen) {
 						socket.close();
 					}
 					return;
 				}
-				controller.enqueue(new Uint8Array(readBuffer.slice(0, bytesRead)));
+				controller.enqueue(
+					new Uint8Array(i.readBuffer.slice(0, bytesRead)),
+				);
 			},
 			// When a downstream consumer is done with the body (e.g. fetch's
 			// Content-Length transform calls terminate() after the declared
@@ -135,6 +150,7 @@ export class Socket {
 			// down — otherwise a keep-alive server never sends EOF and the
 			// pending read would hang forever.
 			cancel() {
+				i.readBuffer = undefined; // free the buffer
 				socket.close();
 			},
 		});
@@ -186,6 +202,7 @@ export class Socket {
 			this.writable.abort(reason);
 		}
 		const i = _(this);
+		i.readBuffer = undefined; // release the large read buffer promptly
 		i.opened.reject(reason);
 		if (i.tls) {
 			// TLS context owns its fd; tear it down natively (closes the

--- a/packages/runtime/src/tcp.ts
+++ b/packages/runtime/src/tcp.ts
@@ -73,6 +73,8 @@ interface SocketInternal {
 	// finishes/closes (see the readable stream) to avoid exhausting the native
 	// ArrayBuffer pool across many sockets.
 	readBuffer?: ArrayBuffer;
+	// Guard so close() runs once (it re-enters via readable.cancel()).
+	closing?: boolean;
 }
 
 const _ = createInternal<Socket, SocketInternal>();
@@ -195,15 +197,24 @@ export class Socket {
 	 * Closes the socket and its underlying connection.
 	 */
 	close(reason?: any) {
+		const i = _(this);
+		// Idempotent: close() re-enters itself via readable.cancel()'s handler
+		// (which calls socket.close()), so guard against running twice. Without
+		// this, the re-entrant call would reject `opened` with its (undefined)
+		// reason BEFORE the original reason, masking the real error (e.g. a TLS
+		// handshake failure surfaced as a bare `undefined` rejection).
+		if (i.closing) return this.closed;
+		i.closing = true;
+		// Reject `opened` with the real reason FIRST, before cancelling the
+		// readable (whose cancel handler re-enters close()).
+		i.readBuffer = undefined; // release the large read buffer promptly
+		i.opened.reject(reason);
 		if (!this.readable.locked) {
 			this.readable.cancel(reason);
 		}
 		if (!this.writable.locked) {
 			this.writable.abort(reason);
 		}
-		const i = _(this);
-		i.readBuffer = undefined; // release the large read buffer promptly
-		i.opened.reject(reason);
 		if (i.tls) {
 			// TLS context owns its fd; tear it down natively (closes the
 			// uv_poll_t then the fd). Never $.close the fd directly.

--- a/packages/runtime/src/tcp.ts
+++ b/packages/runtime/src/tcp.ts
@@ -130,9 +130,19 @@ export class Socket {
 					// limited ArrayBuffer pool. Fall back to 1 MiB if unset.
 					i.readBuffer = new ArrayBuffer($.tcpRxBufSize || 1024 * 1024);
 				}
-				const bytesRead = await (i.tls
-					? tlsRead(i.tls, i.readBuffer)
-					: read(i.fd, i.readBuffer));
+				let bytesRead: number;
+				try {
+					bytesRead = await (i.tls
+						? tlsRead(i.tls, i.readBuffer)
+						: read(i.fd, i.readBuffer));
+				} catch (err) {
+					// On a read error (e.g. ECONNRESET) the stream errors; free
+					// the large read buffer back to the native pool rather than
+					// holding it referenced until GC. Re-throw to preserve the
+					// existing error-propagation behavior.
+					i.readBuffer = undefined;
+					throw err;
+				}
 				if (bytesRead === 0) {
 					i.readBuffer = undefined; // EOF: free the buffer
 					controller.close();

--- a/packages/runtime/src/websocket.ts
+++ b/packages/runtime/src/websocket.ts
@@ -348,6 +348,10 @@ export class WebSocket extends EventTarget {
 			this.#readLoop(reader, buffer);
 		} catch (err) {
 			this.#readyState = CLOSED;
+			// Close the underlying socket so its fd / native buffers are
+			// released — otherwise a failed handshake (or connect) leaks the
+			// socket, eventually exhausting buffers (ENOBUFS).
+			this.#cleanup();
 			this.#fireEvent('error', new Event('error'));
 			this.#fireEvent(
 				'close',
@@ -380,6 +384,7 @@ export class WebSocket extends EventTarget {
 						const state = this.#readyState as number;
 						if (state !== (CLOSED as number)) {
 							this.#readyState = CLOSED;
+							this.#cleanup();
 							this.#fireEvent(
 								'close',
 								new CloseEvent('close', {
@@ -466,6 +471,7 @@ export class WebSocket extends EventTarget {
 		} catch (err) {
 			if (this.#readyState !== CLOSED) {
 				this.#readyState = CLOSED;
+				this.#cleanup();
 				this.#fireEvent('error', new Event('error'));
 				this.#fireEvent(
 					'close',

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -392,6 +392,13 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	set_ver("zlib", ZLIB_VERSION);
 	init_obj->Set(context, nx_str(iso, "version"), version).Check();
 
+	// Host harness has no applet regime; report a 1 MiB rx buffer (matches the
+	// device application config) so the JS socket layer sizes its read buffer.
+	init_obj
+	    ->Set(context, nx_str(iso, "tcpRxBufSize"),
+	          Integer::NewFromUnsigned(iso, 1024u * 1024u))
+	    .Check();
+
 	Local<Object> argv = Object::New(iso);  // not used by fixtures
 	(void)argv;
 }

--- a/source/main.cc
+++ b/source/main.cc
@@ -607,6 +607,13 @@ static bool run_module(Isolate *iso, Local<Context> context, const char *src,
 // ---------------------------------------------------------------------------
 // `$` bridge construction.
 // ---------------------------------------------------------------------------
+// Defined below (after the socket configs); reports the tcp_rx_buf_size of the
+// SocketInitConfig actually selected for the current memory regime, so the JS
+// socket layer can size its read buffer to match the native configuration
+// (1 MiB in application mode, 128 KiB in the lean applet config) instead of
+// hard-coding 1 MiB and over-allocating the limited ArrayBuffer pool.
+static u32 nx_selected_tcp_rx_buf_size(void);
+
 static void build_init_object(Isolate *iso, Local<Context> context,
                               Local<Object> init_obj, const char *entrypoint,
                               int argc, char *argv[]) {
@@ -724,6 +731,14 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 		argv_array->Set(context, i, nx_str(iso, argv[i])).Check();
 	}
 	init_obj->Set(context, nx_str(iso, "argv"), argv_array).Check();
+
+	// The configured bsdsocket TCP receive buffer size (regime-dependent). The
+	// JS socket layer sizes its per-socket read buffer to this instead of a
+	// hard-coded 1 MiB, so applet mode (128 KiB) does not over-allocate.
+	init_obj
+	    ->Set(context, nx_str(iso, "tcpRxBufSize"),
+	          Integer::NewFromUnsigned(iso, nx_selected_tcp_rx_buf_size()))
+	    .Check();
 }
 
 // BsdServiceType_Auto (tries bsd:s first) is intentional: bsd:s is required to
@@ -762,6 +777,13 @@ static SocketInitConfig const s_socketInitConfigLean = {
     .num_bsd_sessions = 3,
     .bsd_service_type = BsdServiceType_Auto,
 };
+
+// tcp_rx_buf_size of whichever config socketInitialize() selected for this
+// memory regime (gated on g_tight_memory, set before socketInitialize).
+static u32 nx_selected_tcp_rx_buf_size(void) {
+	return (g_tight_memory ? s_socketInitConfigLean : s_socketInitConfigFull)
+	    .tcp_rx_buf_size;
+}
 
 // ---------------------------------------------------------------------------
 // main

--- a/source/main.cc
+++ b/source/main.cc
@@ -744,36 +744,49 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 // BsdServiceType_Auto (tries bsd:s first) is intentional: bsd:s is required to
 // bind privileged ports (e.g. a TCP server on port 80).
 //
-// The socket layer reserves a transfer-memory region sized roughly as
-// (tcp_tx_max + tcp_rx_max + udp_tx + udp_rx) * sb_efficiency. The full config
-// below is ~(4+4)MiB * 8 = ~64 MiB. That is fine in application/full-memory
-// mode (GiBs free) but is catastrophic in applet mode (~137 MiB total): the
-// reservation starves Mesa/V8 and bsdsocket faults the first time libuv touches
-// its loopback self-wake socketpair (User Break at bsdsocket+0xe7064, observed
-// at frame 1). So pick a lean config when free memory is tight.
+// The socket layer reserves transfer memory per socket sized roughly as
+// (tcp_tx_buf_size + tcp_rx_buf_size) * sb_efficiency, drawn from a shared pool
+// of ~(tcp_tx_max + tcp_rx_max + udp_tx + udp_rx) * sb_efficiency. A previous
+// config used 1 MiB tx/rx buffers with sb_efficiency=8, reserving ~16 MiB PER
+// socket — so only ~4 sockets could exist concurrently before connect() failed
+// with ENOBUFS ("No buffer space available"). That breaks any concurrent
+// fetch / redirect-follow workload. Use a moderate per-socket footprint
+// (256 KiB initial, autotuning up to 1 MiB) so 20+ sockets coexist while
+// preserving high single-stream throughput. The lean config (below) is used in
+// applet mode (~137 MiB total) where a large reservation starves Mesa/V8 and
+// bsdsocket faults on libuv's loopback self-wake socketpair (User Break at
+// bsdsocket+0xe7064).
 static SocketInitConfig const s_socketInitConfigFull = {
-    .tcp_tx_buf_size = 1 * 1024 * 1024,
-    .tcp_rx_buf_size = 1 * 1024 * 1024,
-    .tcp_tx_buf_max_size = 4 * 1024 * 1024,
-    .tcp_rx_buf_max_size = 4 * 1024 * 1024,
+    .tcp_tx_buf_size = 256 * 1024,
+    .tcp_rx_buf_size = 256 * 1024,
+    .tcp_tx_buf_max_size = 1 * 1024 * 1024,
+    .tcp_rx_buf_max_size = 1 * 1024 * 1024,
     .udp_tx_buf_size = 0x2400,
     .udp_rx_buf_size = 0xA500,
-    .sb_efficiency = 8,
+    .sb_efficiency = 6,
     .num_bsd_sessions = 3,
     .bsd_service_type = BsdServiceType_Auto,
 };
 
-// Lean config for tight-memory (applet) mode: ~(256+256)KiB * 4 = ~2 MiB of
-// transfer memory. Enough for libuv's self-wake socketpair, DNS, and modest
-// fetch/TLS, while leaving room for the GPU/Mesa + V8 stack.
+// Lean config for tight-memory (applet) mode. The previous lean config used
+// 128 KiB initial / 256 KiB max buffers with sb_efficiency=4, which reserved
+// ~1 MiB PER socket and a total pool of only ~2 MiB — barely two concurrent
+// sockets, so a redirect-following fetch (whose two hops briefly overlap during
+// the socket handoff) failed the second connect() with ENOBUFS. Shrink the
+// per-socket *initial* buffers (64 KiB, matching libnx's default rx size) so
+// each socket's footprint is small, while raising sb_efficiency to grow the
+// shared pool enough for ~15+ concurrent sockets. Total reservation is roughly
+// (tx_max + rx_max + udp_tx + udp_rx) * sb_efficiency ~= 512 KiB * 8 ~= 4 MiB,
+// still small enough to leave room for the GPU/Mesa + V8 stack in applet mode
+// (~137 MiB total).
 static SocketInitConfig const s_socketInitConfigLean = {
-    .tcp_tx_buf_size = 128 * 1024,
-    .tcp_rx_buf_size = 128 * 1024,
+    .tcp_tx_buf_size = 64 * 1024,
+    .tcp_rx_buf_size = 64 * 1024,
     .tcp_tx_buf_max_size = 256 * 1024,
     .tcp_rx_buf_max_size = 256 * 1024,
     .udp_tx_buf_size = 0x2400,
     .udp_rx_buf_size = 0xA500,
-    .sb_efficiency = 4,
+    .sb_efficiency = 8,
     .num_bsd_sessions = 3,
     .bsd_service_type = BsdServiceType_Auto,
 };

--- a/source/tcp.cc
+++ b/source/tcp.cc
@@ -293,6 +293,18 @@ void connect_on_ready(op_t *op, int events) {
 	if (events < 0)
 		err = -events;
 	if (err) {
+		// Async connect failed (e.g. ECONNREFUSED, ENOBUFS, timeout). The fd
+		// was never handed to JS (connect() rejects before the Socket stores
+		// it), so it must be closed here — otherwise the fd and its bsdsocket
+		// buffers leak, and enough leaked connect failures exhaust the socket
+		// buffer pool ("No buffer space available"). Mark the owning poll entry
+		// to close the fd: op_finish() removes this (last) op and tears the
+		// poll down via fd_poll_destroy(), whose uv_close callback then closes
+		// the fd (closing it while the uv_poll_t still references it would
+		// corrupt the bsdsocket sysmodule).
+		fd_poll_t *fp = op->owner;
+		if (fp)
+			fp->close_fd = true;
 		op_finish(op, make_errno(iso, err), Undefined(iso));
 	} else {
 		op_finish(op, Undefined(iso), Integer::New(iso, op->fd));


### PR DESCRIPTION
## Summary

The JS socket layer (`tcp.ts`) allocated a **hard-coded 1 MiB `ArrayBuffer`** per socket read stream. On Switch these ArrayBuffers come from a limited native pool, and in **applet mode** bsdsocket is configured with only **128 KiB** (`s_socketInitConfigLean.tcp_rx_buf_size`) — so the JS side over-allocated by 8×, draining the pool after ~40 sockets and throwing `RangeError: Array buffer allocation failed`.

## How it was found

This surfaced as **4 failing `apps/tests` fetch-redirect tests** (301/302/307/308, failing with a bare `undefined`) that I could not reproduce in isolation. A series of on-device repros (logged to FTP) showed:
- It's **not** redirect-specific — a manual 2-hop fetch leaks identically.
- It's **per-TLS-socket**: heap climbed ~310 KB/socket and the 1 MiB allocation failed at only ~11 MB used (well under the ~97 MB heap limit) → the *native ArrayBuffer pool*, not the V8 heap, was exhausted.
- In the full suite, hundreds of sockets are opened before the redirect tests run, so the pool was already drained by then — hence the late, context-dependent failure.

## Fix

- **`source/main.cc`**: expose the selected `SocketInitConfig`'s `tcp_rx_buf_size` as `$.tcpRxBufSize` (1 MiB application / 128 KiB applet) — single source of truth, gated on the same memory-regime probe that picks the socket config.
- **`tcp.ts`**: size the per-socket read buffer to `$.tcpRxBufSize` (fallback 1 MiB), and **release it eagerly** on EOF / `cancel()` / `close()` instead of waiting for GC.
- **`packages/runtime/test/src/main.cc`**: report 1 MiB for the host harness (no applet regime).

## Verification (on hardware, applet mode)

Before: OOM'd at socket ~40. After: **120 sequential TLS sockets** (manual 2-hop ×60 + auto redirect-follow ×60) complete with **bounded heap** (oscillating 3–7 MB, GC reclaiming). The `apps/tests` fetch-redirect failures are resolved.

## Notes
- The remaining `apps/tests` WebSocket failures are unrelated — flaky public `echo.websocket.org` (one `wss` test passes); a separate test-infra follow-up.
- Changeset: `patch`.

---

## Update: ENOBUFS root cause + leak fixes

After the read-buffer fix above, the redirect-follow tests *still* failed in **applet mode** — but now with the real error surfaced: `Error: No buffer space available` (**ENOBUFS**) on the redirect's second `connect()`.

### Root cause

The bsdsocket transfer-memory pool was sized so each socket reserved a large chunk:
- **full** config: `1 MiB tx/rx × sb_efficiency 8 ≈ 16 MiB per socket` → only ~4 concurrent sockets.
- **lean** (applet) config: `128 KiB tx/rx × 4`, total pool only ~2 MiB → barely **2** concurrent sockets.

A redirect-following fetch briefly holds two sockets (old hop closing while the new hop connects), so the second `connect()` hit ENOBUFS. On-device repro: a burst of 4 concurrent redirect fetches → only 1 succeeded, 3 ENOBUFS.

### Changes in this update

- **`source/main.cc`** — right-size both `SocketInitConfig`s: small per-socket *initial* buffers that autotune up to a sane max, with higher `sb_efficiency` so 15–20+ sockets coexist. (full: 256K/1M/sb=6; lean: 64K/256K/sb=8)
- **`source/tcp.cc`** (`connect_on_ready`) — close the fd on async connect failure (it was never handed to JS, so it leaked its fd + buffers).
- **`tcp.ts`** (`Socket.close()`) — make idempotent and reject `opened` with the **real reason first**, before cancelling the readable (whose cancel handler re-enters `close()`). This previously masked errors as a bare `undefined` rejection — the original mysterious redirect-test failure.
- **`websocket.ts`** — call `#cleanup()` on failed handshake / read-loop error / server-closed stream so the underlying socket is released (a failed WS handshake previously leaked its socket).

### Verification

On device in **applet mode**: full suite **1144 passed / 0 failed / 2 skipped**; all redirect-follow tests pass; a burst of 8 concurrent redirect fetches all succeed.