### PR TITLE
Restore global queueMicrotask() under V8

### DIFF
--- a/.changeset/queue-microtask.md
+++ b/.changeset/queue-microtask.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: restore the global `queueMicrotask()` function (a native QuickJS builtin that was missing under V8), implemented via `Isolate::EnqueueMicrotask` with callback exceptions reported through the global `error` event.

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -345,6 +345,7 @@ export interface Init {
 	/** Configured bsdsocket TCP receive buffer size (bytes) for this memory regime. */
 	tcpRxBufSize: number;
 	exit(): never;
+	queueMicrotask(callback: () => void): void;
 	cwd(): string;
 	chdir(dir: string): void;
 	print(v: string): void;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -94,6 +94,7 @@ def(setTimeout);
 def(setInterval);
 def(clearTimeout);
 def(clearInterval);
+def($.queueMicrotask, 'queueMicrotask');
 
 import './navigator';
 

--- a/packages/runtime/test/fixtures/queue-microtask.ts
+++ b/packages/runtime/test/fixtures/queue-microtask.ts
@@ -1,0 +1,69 @@
+import { test } from '../src/tap';
+
+// Regression: raw V8 does not install a `queueMicrotask` global (it is a
+// Blink/Node binding), so after the QuickJS -> V8 migration the global was
+// missing even though QuickJS had provided it natively. It is now bound in C
+// via Isolate::EnqueueMicrotask.
+
+test('queueMicrotask is a global function', (t) => {
+	t.equal(typeof queueMicrotask, 'function', 'queueMicrotask is a function');
+});
+
+test('queueMicrotask runs the callback', async (t) => {
+	const ran = await new Promise<boolean>((resolve) => {
+		queueMicrotask(() => resolve(true));
+	});
+	t.ok(ran, 'callback was invoked');
+});
+
+test('queueMicrotask runs after the current synchronous task', async (t) => {
+	const order: string[] = [];
+	await new Promise<void>((resolve) => {
+		queueMicrotask(() => {
+			order.push('microtask');
+			resolve();
+		});
+		order.push('sync');
+	});
+	t.deepEqual(order, ['sync', 'microtask'], 'sync code runs before microtask');
+});
+
+test('queueMicrotask runs before setTimeout (macrotask)', async (t) => {
+	const order: string[] = [];
+	await new Promise<void>((resolve) => {
+		setTimeout(() => {
+			order.push('timeout');
+			resolve();
+		}, 0);
+		queueMicrotask(() => {
+			order.push('microtask');
+		});
+	});
+	t.deepEqual(
+		order,
+		['microtask', 'timeout'],
+		'microtask drains before the next macrotask',
+	);
+});
+
+test('queueMicrotask preserves FIFO order', async (t) => {
+	const order: number[] = [];
+	await new Promise<void>((resolve) => {
+		queueMicrotask(() => order.push(1));
+		queueMicrotask(() => order.push(2));
+		queueMicrotask(() => {
+			order.push(3);
+			resolve();
+		});
+	});
+	t.deepEqual(order, [1, 2, 3], 'microtasks run in enqueue order');
+});
+
+test('queueMicrotask throws on a non-function argument', (t) => {
+	t.throws(
+		// @ts-expect-error intentionally wrong argument type
+		() => queueMicrotask(123),
+		/Function/,
+		'throws a TypeError-like message when arg is not callable',
+	);
+});

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -82,6 +82,38 @@ static void js_exit(const FunctionCallbackInfo<Value> &info) {
 	(void)info;
 	is_running = 0;
 }
+
+// queueMicrotask(callback) — mirrors source/main.cc (raw V8 has no such global).
+static void nx_microtask_run(void *data) {
+	Isolate *iso = Isolate::GetCurrent();
+	HandleScope scope(iso);
+	Local<Context> context = iso->GetCurrentContext();
+	Context::Scope ctx_scope(context);
+
+	Global<Function> *gfn = static_cast<Global<Function> *>(data);
+	Local<Function> fn = gfn->Get(iso);
+
+	TryCatch try_catch(iso);
+	Local<Value> ret;
+	if (!fn->Call(context, Undefined(iso), 0, nullptr).ToLocal(&ret)) {
+		nx_emit_error_event(iso, &try_catch);
+	}
+
+	gfn->Reset();
+	delete gfn;
+}
+
+static void js_queue_microtask(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	if (info.Length() < 1 || !info[0]->IsFunction()) {
+		nx_throw(iso,
+		         "Failed to execute 'queueMicrotask': parameter 1 is not of "
+		         "type 'Function'.");
+		return;
+	}
+	Global<Function> *gfn = new Global<Function>(iso, info[0].As<Function>());
+	iso->EnqueueMicrotask(nx_microtask_run, gfn);
+}
 static void js_cwd(const FunctionCallbackInfo<Value> &info) {
 	Isolate *iso = info.GetIsolate();
 	char cwd[4096];
@@ -332,6 +364,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	nx_init_web(iso, init_obj);
 	nx_init_window(iso, init_obj);
 	NX_SET_FUNC(init_obj, "exit", js_exit);
+	NX_SET_FUNC(init_obj, "queueMicrotask", js_queue_microtask);
 	NX_SET_FUNC(init_obj, "cwd", js_cwd);
 	NX_SET_FUNC(init_obj, "chdir", js_chdir);
 	NX_SET_FUNC(init_obj, "print", js_print);

--- a/source/main.cc
+++ b/source/main.cc
@@ -136,6 +136,47 @@ static void js_exit(const FunctionCallbackInfo<Value> &info) {
 	is_running = 0;
 }
 
+// queueMicrotask(callback): schedule `callback` to run as a V8 microtask (i.e.
+// before control returns to the event loop, after the current task). Raw V8
+// does not install a `queueMicrotask` global (it's a Blink/Node binding), so we
+// provide it here to match the WHATWG `queueMicrotask()` and restore the
+// QuickJS-era global. The retained callback is stored in a heap Global<Function>
+// that the microtask frees after invocation.
+static void nx_microtask_run(void *data) {
+	Isolate *iso = Isolate::GetCurrent();
+	HandleScope scope(iso);
+	Local<Context> context = iso->GetCurrentContext();
+	Context::Scope ctx_scope(context);
+
+	Global<Function> *gfn = static_cast<Global<Function> *>(data);
+	Local<Function> fn = gfn->Get(iso);
+
+	TryCatch try_catch(iso);
+	Local<Value> ret;
+	if (!fn->Call(context, Undefined(iso), 0, nullptr).ToLocal(&ret)) {
+		// WHATWG: "If the callback throws an exception, report the exception."
+		// nx_emit_error_event dispatches the global `error` event (and falls
+		// back to printing + flagging had_error if no handler prevents it).
+		nx_emit_error_event(iso, &try_catch);
+	}
+
+	gfn->Reset();
+	delete gfn;
+}
+
+static void js_queue_microtask(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	if (info.Length() < 1 || !info[0]->IsFunction()) {
+		nx_throw(iso,
+		         "Failed to execute 'queueMicrotask': parameter 1 is not of "
+		         "type 'Function'.");
+		return;
+	}
+	Global<Function> *gfn =
+	    new Global<Function>(iso, info[0].As<Function>());
+	iso->EnqueueMicrotask(nx_microtask_run, gfn);
+}
+
 static void js_print(const FunctionCallbackInfo<Value> &info) {
 	Isolate *iso = info.GetIsolate();
 	nx_context_t *ctx = nx_ctx(iso);
@@ -648,6 +689,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	nx_init_window(iso, init_obj);
 
 	NX_SET_FUNC(init_obj, "exit", js_exit);
+	NX_SET_FUNC(init_obj, "queueMicrotask", js_queue_microtask);
 	NX_SET_FUNC(init_obj, "cwd", js_cwd);
 	NX_SET_FUNC(init_obj, "chdir", js_chdir);
 	NX_SET_FUNC(init_obj, "print", js_print);


### PR DESCRIPTION
## Summary

`queueMicrotask()` was a **native QuickJS builtin**, but raw V8 does not install it (it's a Blink/Node-provided binding, not part of the core V8 API). After the QuickJS → V8 migration the global regressed to `undefined`, even though the runtime still carried a `queueMicrotask` type declaration (and internal code in `websocket.ts` / `@nx.js/ws` relies on it).

## Fix

- **`source/main.cc`** (+ the host test binary `packages/runtime/test/src/main.cc`): bind `queueMicrotask` natively via `Isolate::EnqueueMicrotask`. The retained callback is held in a heap `Global<Function>` that the microtask frees after invocation.
- Per WHATWG, an exception thrown by the callback is reported via the global **`error`** event (reusing `nx_emit_error_event`, the same path as other uncaught errors).
- A non-function argument throws (`Failed to execute 'queueMicrotask': parameter 1 is not of type 'Function'.`).
- **`index.ts`**: install `$.queueMicrotask` as the global. **`$.ts`**: add the type.

## Tests

New conformance fixture `queue-microtask.ts` covering:
- `queueMicrotask` is a global function
- callback runs after the current synchronous task
- microtasks drain **before** the next `setTimeout` macrotask
- FIFO ordering across multiple microtasks
- non-function argument throws

## Verification

Device-verified (hello-world repro):
```
typeof queueMicrotask = function
order = ["sync","micro-1","micro-2","timeout"]
error event reported = "boom-in-microtask"
non-function threw = "Failed to execute 'queueMicrotask': parameter 1 is not of type 'Function'."
```
Native Switch build (`make`) compiles clean; runtime type-check + bundle pass.