### PR TITLE
Don't crash when entrypoint source exceeds V8's max string length

### DIFF
--- a/.changeset/run-module-graceful-oversize.md
+++ b/.changeset/run-module-graceful-oversize.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: fail gracefully with a clear error instead of hard-crashing (V8 `OS::Abort`) when the entrypoint source exceeds V8's maximum string length.

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -264,9 +264,15 @@ static bool run_script(Isolate *iso, Local<Context> context, const char *src,
                        size_t len, const char *name) {
 	HandleScope scope(iso);
 	TryCatch try_catch(iso);
-	Local<String> source =
-	    String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
-	        .ToLocalChecked();
+	Local<String> source;
+	if (!String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
+	         .ToLocal(&source)) {
+		fprintf(stderr,
+		        "Failed to load %s: source is %zu bytes, which exceeds V8's "
+		        "maximum string length\n",
+		        name, len);
+		return false;
+	}
 	ScriptOrigin origin(nx_str(iso, name));
 	Local<Script> script;
 	if (!Script::Compile(context, source, &origin).ToLocal(&script)) {
@@ -305,9 +311,15 @@ static bool run_module(Isolate *iso, Local<Context> context, const char *src,
 	HandleScope scope(iso);
 	TryCatch try_catch(iso);
 	g_entrypoint_url = name;
-	Local<String> source =
-	    String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
-	        .ToLocalChecked();
+	Local<String> source;
+	if (!String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
+	         .ToLocal(&source)) {
+		fprintf(stderr,
+		        "Failed to load %s: source is %zu bytes, which exceeds V8's "
+		        "maximum string length\n",
+		        name, len);
+		return false;
+	}
 	ScriptOrigin origin(nx_str(iso, name), 0, 0, false, -1, Local<Value>(),
 	                    false, false, true);
 	ScriptCompiler::Source script_source(source, origin);

--- a/source/main.cc
+++ b/source/main.cc
@@ -569,9 +569,20 @@ static bool run_script(Isolate *iso, Local<Context> context, const char *src,
                        size_t len, const char *name) {
 	HandleScope scope(iso);
 	TryCatch try_catch(iso);
-	Local<String> source =
-	    String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
-	        .ToLocalChecked();
+	// NewFromUtf8 returns an empty MaybeLocal if the source exceeds
+	// String::kMaxLength or a string allocation fails (e.g. tight applet
+	// memory). Don't .ToLocalChecked() — that would abort the process; report
+	// the failure instead.
+	Local<String> source;
+	if (!String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
+	         .ToLocal(&source)) {
+		nx_console_init(nx_ctx(iso));
+		fprintf(stderr,
+		        "Failed to load %s: source is %zu bytes, which exceeds V8's "
+		        "maximum string length\n",
+		        name, len);
+		return false;
+	}
 	ScriptOrigin origin(nx_str(iso, name));
 	Local<Script> script;
 	if (!Script::Compile(context, source, &origin).ToLocal(&script)) {
@@ -621,9 +632,20 @@ static bool run_module(Isolate *iso, Local<Context> context, const char *src,
 	HandleScope scope(iso);
 	TryCatch try_catch(iso);
 	g_entrypoint_url = name;
-	Local<String> source =
-	    String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
-	        .ToLocalChecked();
+	// NewFromUtf8 returns an empty MaybeLocal if the source exceeds
+	// String::kMaxLength or a string allocation fails (e.g. tight applet
+	// memory). Don't .ToLocalChecked() — that would abort the process; report
+	// the failure instead.
+	Local<String> source;
+	if (!String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
+	         .ToLocal(&source)) {
+		nx_console_init(nx_ctx(iso));
+		fprintf(stderr,
+		        "Failed to load %s: source is %zu bytes, which exceeds V8's "
+		        "maximum string length\n",
+		        name, len);
+		return false;
+	}
 	ScriptOrigin origin(nx_str(iso, name), 0, 0, false, -1, Local<Value>(),
 	                    false, false, true /* is_module */);
 	ScriptCompiler::Source script_source(source, origin);


### PR DESCRIPTION
## Summary

A real app (a ~1.97 MiB React bundle) crashed at startup with an Atmosphère **"Undefined Instruction" (`brk #0`)** crash report. Symbolized against a matching CI build, the crash is:

```
PC -> v8::base::OS::Abort()
LR -> v8::Utils::ReportApiFailure("v8::ToLocalChecked", "Empty MaybeLocal")
   -> run_module() (source/main.cc) -> MaybeLocal<String>::ToLocalChecked()
```

`run_module()` / `run_script()` called `String::NewFromUtf8(...).ToLocalChecked()` on the entrypoint source. When the source exceeds `v8::String::kMaxLength`, `NewFromUtf8` returns an **empty** `MaybeLocal`, and `.ToLocalChecked()` aborts the whole process.

## Fix

Check the `MaybeLocal` and fail gracefully with a clear message instead of aborting:

```
Failed to load <name>: source is <N> bytes, which exceeds V8's maximum string length
```

Applied to both the device runtime (`source/main.cc`) and the host test binary (`packages/runtime/test/src/main.cc`).

## Why the limit is so low (root cause, tracked separately)

On device, the threshold is **1 MiB**, not the ~512 MB that `String::kMaxLength` *appears* to be. The `switch-v8` portlib is built with **`v8_lower_limits_mode=true`** — needed because it shrinks V8's `JSDispatchTable` reservation 256 MB → 16 MB (which unblocked `Isolate::New` on Horizon). A side effect of that same flag is lowering `v8::String::kMaxLength` to `1 << 20` (1 MiB), which caps JS bundle size. There is also a define mismatch: the V8 *library* is compiled with the flag (enforces 1 MiB) but nx.js `source/` is compiled without it (header reports ~512 MB).

Raising that limit requires a V8 portlib rebuild and is tracked in the pacman-packages repo (`switch/v8/STRING-MAXLENGTH-INVESTIGATION.md`). **This PR is the runtime-side hardening only** — it converts the hard crash into a clear, recoverable error.

## Verification

- Device (applet mode): the previously-crashing flow no longer aborts (clean exit instead of an Atmosphère crash report); confirmed a 1 MiB module still loads and runs.
- Native `make` builds clean.