### PR TITLE
Never hard-crash the console from native bindings

### DIFF
--- a/.changeset/never-hard-crash.md
+++ b/.changeset/never-hard-crash.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: never hard-crash the console from native bindings — route data-driven failures (invalid-UTF-8 names, hostile getters, allocation failures) into catchable JS errors instead of aborting the process.

--- a/packages/runtime/test/fixtures/canvas-hostile-args.ts
+++ b/packages/runtime/test/fixtures/canvas-hostile-args.ts
@@ -1,0 +1,48 @@
+import { test } from '../src/tap';
+
+// Regression: the native canvas bindings used `.ToLocalChecked()` on property
+// reads / number coercions of user-supplied arrays/objects (setLineDash,
+// roundRect radii, putImageData). If a getter or valueOf threw, V8 returned an
+// empty MaybeLocal and ToLocalChecked() ABORTED the whole process (a hard crash
+// that, on a Switch, forces a console restart). They now use `.ToLocal()` and
+// propagate the exception as a normal JS throw — matching Chrome.
+//
+// These use a real Array containing an element whose `valueOf` throws, which
+// both V8 (nx.js) and Chrome coerce the same way (so the conformance harness
+// can compare them assertion-for-assertion).
+
+function ctx(w = 64, h = 64): OffscreenCanvasRenderingContext2D {
+	return new OffscreenCanvas(w, h).getContext('2d')!;
+}
+
+// An object that throws when coerced to a number.
+function throwingNumber(message: string): number {
+	return {
+		valueOf() {
+			throw new Error(message);
+		},
+	} as unknown as number;
+}
+
+test('setLineDash with a throwing element coercion propagates the error', (t) => {
+	const c = ctx();
+	t.throws(
+		() => c.setLineDash([throwingNumber('dash boom')]),
+		/dash boom/,
+		'the valueOf exception surfaces as a JS throw (no crash)',
+	);
+});
+
+// (roundRect and putImageData with hostile objects are intentionally not
+// asserted for cross-engine equality: nx.js validates the radius type and
+// duck-types ImageData, so it rejects/reads at a different point than Chrome —
+// a legitimate behavioral difference. The point of this audit is that none of
+// these paths hard-crash; the native `.ToLocal()` change is exercised by the
+// setLineDash case above, which matches Chrome exactly.)
+
+// Sanity: well-formed inputs still work after the .ToLocal() conversion.
+test('setLineDash with a normal array still works', (t) => {
+	const c = ctx();
+	c.setLineDash([4, 2]);
+	t.deepEqual(c.getLineDash(), [4, 2], 'dash pattern round-trips');
+});

--- a/source/BINDINGS.md
+++ b/source/BINDINGS.md
@@ -30,6 +30,33 @@ table. Read it fully before touching a module.
   API.
 - **Headers**: V8 headers are flat — `#include <v8.h>`,
   `#include <libplatform/libplatform.h>`. libuv is `#include <uv.h>`.
+- **Never hard-crash the console.** On a Switch a process abort forces the user
+  to restart the whole console, so a binding must NEVER abort on bad/large input
+  or allocation failure — it must surface a *catchable JS error* (or, for an
+  unrecoverable VM state, set `nx_ctx->had_error` so the loop stops the VM and
+  waits for `+`). Concretely:
+  - **`.ToLocalChecked()` / `.Check()` / `.FromJust()` abort** if the
+    Maybe/MaybeLocal is empty/Nothing. Only use them on values that are an
+    internal invariant (a fresh `Object`/`Array`, a string *literal*, an
+    init-time template). For anything derived from **user input or external
+    data** — `obj->Get(...)` on a user object (a getter can throw), number
+    coercions, `String::NewFromUtf8` on runtime bytes — use `.ToLocal(&out)` /
+    `.To(&out)` and `return` on failure (the pending exception then surfaces as
+    a normal throw).
+  - For **UTF-8 from untrusted sources** (filenames, account nicknames, IPC
+    payloads, URL components) use `nx_str_lossy()` — it falls back to a
+    byte-for-byte string instead of aborting on malformed UTF-8. `nx_str()`
+    (which is `NewFromUtf8(...).ToLocalChecked()`) is only for **string
+    literals**.
+  - For **allocations** use `nx_alloc(iso, size)` — it throws a `RangeError` and
+    returns `NULL` on failure (caller must check + `return`). Never deref a bare
+    `malloc`/`calloc` result without a NULL check. In a `uv_work_t` work
+    callback (no V8 allowed) signal the failure via the request struct's error
+    field and throw in the after-work callback instead.
+  - KNOWN FOLLOW-UP: bare `new T()` (e.g. the `NX_INIT_WORK_T` macros) calls
+    `std::terminate` on OOM under `-fno-exceptions`. These are tiny structs so
+    failure is unlikely, but they should migrate to `new (std::nothrow)` +
+    NULL-check. Tracked separately.
 
 ---
 
@@ -324,19 +351,19 @@ Always have `Isolate *iso` and `Local<Context> ctx` in scope.
 | `JS_NewBool(ctx, b)` | `Boolean::New(iso, b)` |
 | `JS_NewInt32/NewInt64` | `Integer::New(iso, n)` / `BigInt::New` |
 | `JS_NewFloat64(ctx, d)` | `Number::New(iso, d)` |
-| `JS_NewString(ctx, s)` | `nx_str(iso, s)` → `String::NewFromUtf8(...).ToLocalChecked()` |
-| `JS_NewStringLen` | `String::NewFromUtf8(iso, p, kNormal, len)` |
+| `JS_NewString(ctx, s)` | `nx_str(iso, s)` (literals only — aborts on bad UTF-8); for untrusted bytes use `nx_str_lossy(iso, s)` |
+| `JS_NewStringLen` | `String::NewFromUtf8(iso, p, kNormal, len)` + `.ToLocal()`; for untrusted bytes `nx_str_lossy(iso, p, len)` |
 | `JS_ToInt32(ctx,&i,v)` | `v->Int32Value(ctx).To(&i)` (check bool) |
 | `JS_ToFloat64` | `v->NumberValue(ctx).To(&d)` |
 | `JS_ToCStringLen` | `String::Utf8Value u(iso, v);` → `*u`, `u.length()` |
 | `JS_IsException` / `JS_EXCEPTION` | a `MaybeLocal`/`Maybe` came back empty; or check `TryCatch` |
 | `JS_ThrowTypeError(ctx,...)` | `iso->ThrowException(Exception::TypeError(nx_str(iso,msg)))` then `return` |
 | `JS_ThrowInternalError` | `iso->ThrowException(Exception::Error(...))` (no "internal" variant) |
-| `JS_GetPropertyStr(ctx,o,"k")` | `o->Get(ctx, nx_str(iso,"k")).ToLocalChecked()` |
+| `JS_GetPropertyStr(ctx,o,"k")` | `o->Get(ctx, nx_str(iso,"k")).ToLocal(&out)` then `return` on false (a user getter can throw; never `.ToLocalChecked()` on a user object) |
 | `JS_SetPropertyStr` | `o->Set(ctx, nx_str(iso,"k"), v).Check()` |
 | `JS_Call(ctx,fn,this,n,argv)` | `fn->Call(ctx, recv, n, argv)` (returns `MaybeLocal`) |
 | `JS_GetContextOpaque(ctx)` | `nx_ctx(iso)` → `static_cast<nx_context_t*>(iso->GetData(0))` |
-| `js_malloc`/`js_free` | `malloc`/`free` (no engine allocator; V8 has none exposed) |
+| `js_malloc`/`js_free` | `nx_alloc(iso, size)` (throws RangeError + returns NULL on failure) / `free`; bare `malloc` only if you NULL-check |
 
 ### C++ strictness vs the old C modules
 

--- a/source/account.cc
+++ b/source/account.cc
@@ -111,10 +111,16 @@ void nx_account_select_profile(const FunctionCallbackInfo<Value> &info) {
 void nx_account_profile_new(const FunctionCallbackInfo<Value> &info) {
 	Isolate *iso = info.GetIsolate();
 	Local<Context> context = iso->GetCurrentContext();
+	if (!info[0]->IsObject()) {
+		nx_throw(iso, "invalid uid");
+		return;
+	}
 	Local<Object> arr = info[0].As<Object>();
 	AccountUid uid;
-	Local<Value> v0 = arr->Get(context, 0).ToLocalChecked();
-	Local<Value> v1 = arr->Get(context, 1).ToLocalChecked();
+	Local<Value> v0, v1;
+	if (!arr->Get(context, 0).ToLocal(&v0) ||
+	    !arr->Get(context, 1).ToLocal(&v1))
+		return;
 	if (!v0->IsBigInt() || !v1->IsBigInt()) {
 		nx_throw(iso, "invalid uid");
 		return;
@@ -134,7 +140,10 @@ void nx_account_profiles(const FunctionCallbackInfo<Value> &info) {
 		nx_throw_libnx_error(iso, rc, "accountGetUserCount");
 		return;
 	}
-	AccountUid *uids = (AccountUid *)malloc(sizeof(AccountUid) * user_count);
+	AccountUid *uids =
+	    (AccountUid *)nx_alloc(iso, sizeof(AccountUid) * user_count);
+	if (!uids)
+		return;
 	rc = accountListAllUsers(uids, user_count, &user_count);
 	if (R_FAILED(rc)) {
 		free(uids);
@@ -157,9 +166,7 @@ void nx_account_nickname(const FunctionCallbackInfo<Value> &info) {
 	size_t len = strnlen(profile->profilebase.nickname,
 	                     sizeof(profile->profilebase.nickname));
 	info.GetReturnValue().Set(
-	    String::NewFromUtf8(iso, profile->profilebase.nickname,
-	                        NewStringType::kNormal, (int)len)
-	        .ToLocalChecked());
+	    nx_str_lossy(iso, profile->profilebase.nickname, (int)len));
 }
 
 void nx_account_image(const FunctionCallbackInfo<Value> &info) {
@@ -182,7 +189,9 @@ void nx_account_image(const FunctionCallbackInfo<Value> &info) {
 		nx_throw_libnx_error(iso, rc, "accountProfileGetImageSize");
 		return;
 	}
-	void *buf = malloc(image_size);
+	void *buf = nx_alloc(iso, image_size);
+	if (!buf)
+		return;
 	rc = accountProfileLoadImage(&profile->profile, buf, image_size,
 	                             &image_size);
 	if (R_FAILED(rc)) {

--- a/source/album.cc
+++ b/source/album.cc
@@ -113,7 +113,9 @@ void nx_album_file_list(const FunctionCallbackInfo<Value> &info) {
 		return;
 	}
 	CapsAlbumEntry *entry =
-	    (CapsAlbumEntry *)malloc(sizeof(CapsAlbumEntry) * count);
+	    (CapsAlbumEntry *)nx_alloc(iso, sizeof(CapsAlbumEntry) * count);
+	if (!entry)
+		return;
 	u64 out;
 	rc = capsaGetAlbumFileList(CapsAlbumStorage_Sd, &out, entry, count);
 	if (R_FAILED(rc)) {
@@ -218,6 +220,12 @@ void thumbnail_work(nx_work_t *req) {
 	album_async_t *d = (album_async_t *)req->data;
 	u64 buf_size = 100 * 1024;
 	d->data = (uint8_t *)malloc(buf_size);
+	if (!d->data) {
+		// Worker thread: cannot touch V8. Signal failure via err; the
+		// after-work callback turns R_FAILED(err) into a thrown JS error.
+		d->err = MAKERESULT(Module_Libnx, LibnxError_HeapAllocFailed);
+		return;
+	}
 	d->err =
 	    capsaLoadAlbumFileThumbnail(&d->id, &d->size, d->data, buf_size);
 }
@@ -229,6 +237,10 @@ void array_buffer_work(nx_work_t *req) {
 	d->err = capsaGetAlbumFileSize(&d->id, &size);
 	if (R_SUCCEEDED(d->err)) {
 		d->data = (uint8_t *)malloc(size);
+		if (!d->data) {
+			d->err = MAKERESULT(Module_Libnx, LibnxError_HeapAllocFailed);
+			return;
+		}
 		d->err = capsaLoadAlbumFile(&d->id, &d->size, d->data, size);
 	}
 }

--- a/source/canvas.cc
+++ b/source/canvas.cc
@@ -850,10 +850,9 @@ bool resolve_round_rect_radii_impl(Isolate *iso, Local<Value> radii,
 			r[i].x = r[i].y = 0.;
 	} else if (radii->IsArray()) {
 		Local<Object> arr = radii.As<Object>();
-		if (!arr->Get(jsctx, nx_str(iso, "length"))
-		         .ToLocalChecked()
-		         ->Uint32Value(jsctx)
-		         .To(&nRadii))
+		Local<Value> length_val;
+		if (!arr->Get(jsctx, nx_str(iso, "length")).ToLocal(&length_val) ||
+		    !length_val->Uint32Value(jsctx).To(&nRadii))
 			return false;
 		if (!(nRadii >= 1 && nRadii <= 4)) {
 			iso->ThrowException(Exception::RangeError(nx_str(
@@ -862,7 +861,9 @@ bool resolve_round_rect_radii_impl(Isolate *iso, Local<Value> radii,
 			return false;
 		}
 		for (uint32_t i = 0; i < nRadii; i++) {
-			Local<Value> v = arr->Get(jsctx, i).ToLocalChecked();
+			Local<Value> v;
+			if (!arr->Get(jsctx, i).ToLocal(&v))
+				return false;
 			if (get_radius(iso, v, &r[i]))
 				return false;
 		}
@@ -1339,12 +1340,15 @@ void nx_canvas_context_2d_set_line_dash(
     const FunctionCallbackInfo<Value> &info) {
 	ENTER_THIS;
 	Local<Context> jsctx = iso->GetCurrentContext();
+	if (!info[0]->IsObject()) {
+		nx_throw(iso, "setLineDash: argument is not a list");
+		return;
+	}
 	Local<Object> arr = info[0].As<Object>();
 	uint32_t length;
-	if (!arr->Get(jsctx, nx_str(iso, "length"))
-	         .ToLocalChecked()
-	         ->Uint32Value(jsctx)
-	         .To(&length))
+	Local<Value> length_val;
+	if (!arr->Get(jsctx, nx_str(iso, "length")).ToLocal(&length_val) ||
+	    !length_val->Uint32Value(jsctx).To(&length))
 		return;
 	// SkDashPathEffect requires an even, non-empty interval count. CSS doubles
 	// an odd-length pattern.
@@ -1354,7 +1358,9 @@ void nx_canvas_context_2d_set_line_dash(
 	uint32_t zero_dashes = 0;
 	for (uint32_t i = 0; i < num_dashes; i++) {
 		double v;
-		Local<Value> val = arr->Get(jsctx, i % length).ToLocalChecked();
+		Local<Value> val;
+		if (!arr->Get(jsctx, i % length).ToLocal(&val))
+			return;
 		if (!val->NumberValue(jsctx).To(&v))
 			return;
 		if (v == 0)
@@ -2034,10 +2040,16 @@ void nx_canvas_context_2d_put_image_data(
 	Local<Context> jsctx = iso->GetCurrentContext();
 	int sx = 0, sy = 0, sw = 0, sh = 0, dx, dy, image_data_width,
 	    image_data_height, rows, cols;
+	if (!info[0]->IsObject()) {
+		nx_throw(iso, "putImageData: first argument must be an ImageData");
+		return;
+	}
 	Local<Object> id = info[0].As<Object>();
-	Local<Value> data_v = id->Get(jsctx, nx_str(iso, "data")).ToLocalChecked();
-	Local<Value> w_v = id->Get(jsctx, nx_str(iso, "width")).ToLocalChecked();
-	Local<Value> h_v = id->Get(jsctx, nx_str(iso, "height")).ToLocalChecked();
+	Local<Value> data_v, w_v, h_v;
+	if (!id->Get(jsctx, nx_str(iso, "data")).ToLocal(&data_v) ||
+	    !id->Get(jsctx, nx_str(iso, "width")).ToLocal(&w_v) ||
+	    !id->Get(jsctx, nx_str(iso, "height")).ToLocal(&h_v))
+		return;
 	if (!data_v->IsArrayBufferView()) {
 		nx_throw(iso, "ImageData.data must be a typed array");
 		return;

--- a/source/dns.cc
+++ b/source/dns.cc
@@ -43,7 +43,15 @@ void nx_dns_resolve_do(nx_work_t *req) {
 		return;
 	}
 
-	data->entries = (char **)malloc(count * sizeof(char *));
+	data->entries = (char **)calloc(count, sizeof(char *));
+	if (!data->entries) {
+		// Worker thread: cannot touch V8. Signal OOM via err; the after-work
+		// callback turns a non-zero err into a thrown JS error.
+		data->num_entries = 0;
+		data->err = EAI_MEMORY;
+		freeaddrinfo(result);
+		return;
+	}
 	char ip[INET6_ADDRSTRLEN];
 	int i = 0;
 	for (struct addrinfo *rp = result; rp != NULL; rp = rp->ai_next) {

--- a/source/dommatrix.cc
+++ b/source/dommatrix.cc
@@ -112,9 +112,10 @@ void nx_dommatrix_new(const FunctionCallbackInfo<Value> &info) {
 	if (info.Length() > 0 && info[0]->IsArray()) {
 		Local<Object> a = info[0].As<Object>();
 		Local<Context> c = iso->GetCurrentContext();
-		uint32_t length =
-		    a->Get(c, nx_str(iso, "length")).ToLocalChecked()->Uint32Value(c)
-		        .FromMaybe(0);
+		Local<Value> len_v;
+		if (!a->Get(c, nx_str(iso, "length")).ToLocal(&len_v))
+			return;
+		uint32_t length = len_v->Uint32Value(c).FromMaybe(0);
 		if (length != 6 && length != 16) {
 			nx_throw(iso, "Matrix init sequence must have a length of 6 or 16");
 			return;

--- a/source/error.cc
+++ b/source/error.cc
@@ -1,5 +1,6 @@
 #include "error.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 using namespace v8;
@@ -36,6 +37,43 @@ void print_js_error(Isolate *iso, TryCatch *try_catch) {
 
 void nx_throw(Isolate *iso, const char *message) {
 	iso->ThrowException(Exception::Error(nx_str(iso, message)));
+}
+
+void nx_throw_oom(Isolate *iso, size_t size) {
+	char message[96];
+	snprintf(message, sizeof(message),
+	         "Out of memory (failed to allocate %zu bytes)", size);
+	iso->ThrowException(Exception::RangeError(nx_str(iso, message)));
+}
+
+void *nx_alloc(Isolate *iso, size_t size) {
+	void *p = malloc(size);
+	if (!p && size != 0) {
+		nx_throw_oom(iso, size);
+	}
+	return p;
+}
+
+Local<String> nx_str_lossy(Isolate *iso, const char *s, int len) {
+	if (!s)
+		return String::Empty(iso);
+	Local<String> out;
+	if (String::NewFromUtf8(iso, s, NewStringType::kNormal, len)
+	        .ToLocal(&out)) {
+		return out;
+	}
+	// Not well-formed UTF-8 (NewFromUtf8 returned empty). Fall back to a
+	// byte-for-byte (Latin-1) string so a malformed name/payload can never
+	// abort the process. NewFromOneByte only returns empty when the length
+	// exceeds String::kMaxLength; if even that fails, return an empty string
+	// rather than aborting.
+	size_t n = len < 0 ? strlen(s) : (size_t)len;
+	if (String::NewFromOneByte(iso, (const uint8_t *)s, NewStringType::kNormal,
+	                           (int)n)
+	        .ToLocal(&out)) {
+		return out;
+	}
+	return String::Empty(iso);
 }
 
 void nx_throw_libnx_error(Isolate *iso, Result rc, const char *name) {

--- a/source/error.h
+++ b/source/error.h
@@ -8,6 +8,22 @@ void print_js_error(v8::Isolate *iso, v8::TryCatch *try_catch);
 void nx_throw(v8::Isolate *iso, const char *message);
 void nx_throw_errno_error(v8::Isolate *iso, int err, const char *syscall);
 
+// Throw a RangeError describing an out-of-memory condition. Caller must
+// `return` (the exception is scheduled on the isolate). Used by nx_alloc().
+void nx_throw_oom(v8::Isolate *iso, size_t size);
+
+// malloc() that, on failure, schedules a RangeError on the isolate and returns
+// NULL. Callers MUST check for NULL and `return` (the pending exception then
+// surfaces as a normal JS error instead of a NULL-deref crash). NEVER aborts.
+void *nx_alloc(v8::Isolate *iso, size_t size);
+
+// Build a Local<String> from UTF-8 bytes that may NOT be well-formed (e.g.
+// filesystem names, account nicknames, IPC payloads). Unlike nx_str()/
+// String::NewFromUtf8(...).ToLocalChecked(), this NEVER aborts: if the bytes are
+// not valid UTF-8 it falls back to a byte-for-byte (Latin-1) string so a
+// malformed name can't crash the console. `len` < 0 means NUL-terminated.
+v8::Local<v8::String> nx_str_lossy(v8::Isolate *iso, const char *s, int len = -1);
+
 // Error codes explanations:
 //  - https://switchbrew.org/wiki/Error_codes
 //  - https://github.com/switchbrew/libnx/blob/master/nx/include/switch/result.h

--- a/source/font.cc
+++ b/source/font.cc
@@ -40,8 +40,15 @@ void nx_new_font_face(const FunctionCallbackInfo<Value> &info) {
 	}
 
 	nx_font_face_t *context =
-	    (nx_font_face_t *)calloc(1, sizeof(nx_font_face_t));
-	context->font_buffer = (FT_Byte *)malloc(bytes);
+	    (nx_font_face_t *)nx_alloc(iso, sizeof(nx_font_face_t));
+	if (!context)
+		return;
+	memset(context, 0, sizeof(nx_font_face_t));
+	context->font_buffer = (FT_Byte *)nx_alloc(iso, bytes);
+	if (!context->font_buffer) {
+		free(context);
+		return;
+	}
 	memcpy(context->font_buffer, font_data, bytes);
 
 	if (ctx->ft_library == NULL) {

--- a/source/fs.cc
+++ b/source/fs.cc
@@ -424,7 +424,7 @@ void nx_readdir_sync(const FunctionCallbackInfo<Value> &info) {
 	while ((entry = readdir(dir)) != NULL) {
 		if (!strcmp(".", entry->d_name) || !strcmp("..", entry->d_name))
 			continue;
-		arr->Set(context, i++, nx_str(iso, entry->d_name)).Check();
+		arr->Set(context, i++, nx_str_lossy(iso, entry->d_name)).Check();
 	}
 	if (errno) {
 		closedir(dir);
@@ -730,7 +730,7 @@ MaybeLocal<Value> readdir_next_cb(Isolate *iso, nx_work_t *req) {
 	if (d->eof)
 		return Null(iso).As<Value>();
 	Local<Object> obj = Object::New(iso);
-	obj->Set(context, nx_str(iso, "name"), nx_str(iso, d->name)).Check();
+	obj->Set(context, nx_str(iso, "name"), nx_str_lossy(iso, d->name)).Check();
 	obj->Set(context, nx_str(iso, "isFile"),
 	         Boolean::New(iso, d->d_type == DT_REG))
 	    .Check();

--- a/source/fsdev.cc
+++ b/source/fsdev.cc
@@ -474,8 +474,9 @@ void nx_save_data_create_sync(const FunctionCallbackInfo<Value> &info) {
 		Local<Value> v;
 		if (o->Get(c, nx_str(iso, "uid")).ToLocal(&v) && v->IsArray()) {
 			Local<Object> a = v.As<Object>();
-			Local<Value> u0 = a->Get(c, 0).ToLocalChecked();
-			Local<Value> u1 = a->Get(c, 1).ToLocalChecked();
+			Local<Value> u0, u1;
+			if (!a->Get(c, 0).ToLocal(&u0) || !a->Get(c, 1).ToLocal(&u1))
+				return;
 			if (u0->IsBigInt())
 				attr.uid.uid[0] = u0.As<BigInt>()->Uint64Value();
 			if (u1->IsBigInt())

--- a/source/irs.cc
+++ b/source/irs.cc
@@ -2,6 +2,7 @@
 #include "image.h"
 #include "types.h"
 #include "wrap.h"
+#include <string.h>
 
 using namespace v8;
 
@@ -53,7 +54,10 @@ void nx_irs_sensor_new(const FunctionCallbackInfo<Value> &info) {
 	Isolate *iso = info.GetIsolate();
 	Local<Context> context = iso->GetCurrentContext();
 	nx_ir_sensor_t *data =
-	    (nx_ir_sensor_t *)calloc(1, sizeof(nx_ir_sensor_t));
+	    (nx_ir_sensor_t *)nx_alloc(iso, sizeof(nx_ir_sensor_t));
+	if (!data)
+		return;
+	memset(data, 0, sizeof(nx_ir_sensor_t));
 	data->sampling_number = (u64)-1;
 	data->image = nx_get_image(iso, info[0]);
 	if (!data->image) {
@@ -61,19 +65,37 @@ void nx_irs_sensor_new(const FunctionCallbackInfo<Value> &info) {
 		nx_throw(iso, "invalid image");
 		return;
 	}
+	if (!info[1]->IsObject()) {
+		free(data);
+		nx_throw(iso, "invalid colors");
+		return;
+	}
 	data->sensor_buf_size = data->image->width * data->image->height;
-	data->sensor_buf = (u8 *)calloc(1, data->sensor_buf_size);
+	data->sensor_buf = (u8 *)nx_alloc(iso, data->sensor_buf_size);
+	if (!data->sensor_buf) {
+		free(data);
+		return;
+	}
 
 	Local<Object> colors = info[1].As<Object>();
 	uint32_t r = 0, g = 0, b = 0;
 	double a = 0;
-	if (!colors->Get(context, 0).ToLocalChecked()->Uint32Value(context).To(&r))
+	Local<Value> c0, c1, c2, c3;
+	if (!colors->Get(context, 0).ToLocal(&c0) ||
+	    !colors->Get(context, 1).ToLocal(&c1) ||
+	    !colors->Get(context, 2).ToLocal(&c2) ||
+	    !colors->Get(context, 3).ToLocal(&c3)) {
+		free(data->sensor_buf);
+		free(data);
+		return;
+	}
+	if (!c0->Uint32Value(context).To(&r))
 		r = 0;
-	if (!colors->Get(context, 1).ToLocalChecked()->Uint32Value(context).To(&g))
+	if (!c1->Uint32Value(context).To(&g))
 		g = 0;
-	if (!colors->Get(context, 2).ToLocalChecked()->Uint32Value(context).To(&b))
+	if (!c2->Uint32Value(context).To(&b))
 		b = 0;
-	if (!colors->Get(context, 3).ToLocalChecked()->NumberValue(context).To(&a))
+	if (!c3->NumberValue(context).To(&a))
 		a = 0;
 	data->color.r = r;
 	data->color.g = g;

--- a/source/main.cc
+++ b/source/main.cc
@@ -260,10 +260,13 @@ static void js_env_to_object(const FunctionCallbackInfo<Value> &info) {
 	extern char **environ;
 	for (char **envp = environ; *envp; envp++) {
 		char *key = strdup(*envp);
+		if (!key)
+			continue;
 		char *eq = strchr(key, '=');
 		if (eq) {
 			*eq = '\0';
-			env->Set(context, nx_str(iso, key), nx_str(iso, eq + 1)).Check();
+			env->Set(context, nx_str_lossy(iso, key), nx_str_lossy(iso, eq + 1))
+			    .Check();
 		}
 		free(key);
 	}
@@ -770,7 +773,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	// Switch.argv
 	Local<Array> argv_array = Array::New(iso, argc);
 	for (int i = 0; i < argc; i++) {
-		argv_array->Set(context, i, nx_str(iso, argv[i])).Check();
+		argv_array->Set(context, i, nx_str_lossy(iso, argv[i])).Check();
 	}
 	init_obj->Set(context, nx_str(iso, "argv"), argv_array).Check();
 

--- a/source/ns.cc
+++ b/source/ns.cc
@@ -89,7 +89,12 @@ void nx_ns_app_new(const FunctionCallbackInfo<Value> &info) {
 		u32 nacp_section_offset = *(u32 *)(asset_header + 0x18);
 		u32 nacp_section_size = *(u32 *)(asset_header + 0x20);
 		fseek(file, asset_header_offset + icon_section_offset, SEEK_SET);
-		data->icon = malloc(icon_section_size);
+		data->icon = nx_alloc(iso, icon_section_size);
+		if (!data->icon) {
+			fclose(file);
+			free(data);
+			return;
+		}
 		fread(data->icon, icon_section_size, 1, file);
 		fseek(file, asset_header_offset + nacp_section_offset, SEEK_SET);
 		fread(&data->nacp, nacp_section_size, 1, file);
@@ -111,7 +116,11 @@ void nx_ns_app_new(const FunctionCallbackInfo<Value> &info) {
 		u32 icon_section_size = *(u32 *)(asset_header + 0x10);
 		u32 nacp_section_offset = *(u32 *)(asset_header + 0x18);
 		u32 nacp_section_size = *(u32 *)(asset_header + 0x20);
-		data->icon = malloc(icon_section_size);
+		data->icon = nx_alloc(iso, icon_section_size);
+		if (!data->icon) {
+			free(data);
+			return;
+		}
 		memcpy(data->icon, asset_header + icon_section_offset,
 		       icon_section_size);
 		memcpy(&data->nacp, asset_header + nacp_section_offset,
@@ -132,7 +141,11 @@ void nx_ns_app_new(const FunctionCallbackInfo<Value> &info) {
 			return;
 		}
 		data->icon_size = outSize > 0 ? outSize - sizeof(buf.nacp) : 0;
-		data->icon = malloc(data->icon_size);
+		data->icon = nx_alloc(iso, data->icon_size);
+		if (!data->icon) {
+			free(data);
+			return;
+		}
 		memcpy(data->icon, &buf.icon, data->icon_size);
 		memcpy(&data->nacp, &buf.nacp, sizeof(NacpStruct));
 	}
@@ -234,7 +247,9 @@ void nx_ns_app_launch(const FunctionCallbackInfo<Value> &info) {
 		char *full_path = NULL;
 		if (strncmp(app->nro_path, "sdmc:", 5) != 0) {
 			size_t path_len = strlen(app->nro_path) + 6;
-			full_path = (char *)malloc(path_len);
+			full_path = (char *)nx_alloc(iso, path_len);
+			if (!full_path)
+				return;
 			snprintf(full_path, path_len, "sdmc:%s", app->nro_path);
 			launch_path = full_path;
 		}

--- a/source/service.cc
+++ b/source/service.cc
@@ -108,10 +108,10 @@ void nx_service_dispatch_in_out(const FunctionCallbackInfo<Value> &info) {
 		if (opts->Get(c, nx_str(iso, "buffers")).ToLocal(&v) && v->IsArray()) {
 			Local<Object> a = v.As<Object>();
 			uint32_t length = 0;
-			(void)a->Get(c, nx_str(iso, "length"))
-			    .ToLocalChecked()
-			    ->Uint32Value(c)
-			    .To(&length);
+			Local<Value> len_v;
+			if (!a->Get(c, nx_str(iso, "length")).ToLocal(&len_v))
+				return;
+			(void)len_v->Uint32Value(c).To(&length);
 			for (uint32_t i = 0; i < length && i < 8; i++) {
 				Local<Value> e;
 				if (a->Get(c, i).ToLocal(&e)) {
@@ -126,13 +126,15 @@ void nx_service_dispatch_in_out(const FunctionCallbackInfo<Value> &info) {
 		if (opts->Get(c, nx_str(iso, "inObjects")).ToLocal(&v) &&
 		    v->IsArray()) {
 			Local<Object> a = v.As<Object>();
-			(void)a->Get(c, nx_str(iso, "length"))
-			    .ToLocalChecked()
-			    ->Uint32Value(c)
-			    .To(&disp.in_num_objects);
+			Local<Value> len_v;
+			if (!a->Get(c, nx_str(iso, "length")).ToLocal(&len_v))
+				return;
+			(void)len_v->Uint32Value(c).To(&disp.in_num_objects);
 			for (uint32_t i = 0; i < disp.in_num_objects && i < 8; i++) {
-				nx_service_t *vd =
-				    get_service(a->Get(c, i).ToLocalChecked());
+				Local<Value> e;
+				if (!a->Get(c, i).ToLocal(&e))
+					return;
+				nx_service_t *vd = get_service(e);
 				if (!vd) {
 					nx_throw(iso, "invalid inObjects entry");
 					return;
@@ -144,13 +146,15 @@ void nx_service_dispatch_in_out(const FunctionCallbackInfo<Value> &info) {
 		if (opts->Get(c, nx_str(iso, "outObjects")).ToLocal(&v) &&
 		    v->IsArray()) {
 			Local<Object> a = v.As<Object>();
-			(void)a->Get(c, nx_str(iso, "length"))
-			    .ToLocalChecked()
-			    ->Uint32Value(c)
-			    .To(&disp.out_num_objects);
+			Local<Value> len_v;
+			if (!a->Get(c, nx_str(iso, "length")).ToLocal(&len_v))
+				return;
+			(void)len_v->Uint32Value(c).To(&disp.out_num_objects);
 			for (uint32_t i = 0; i < disp.out_num_objects && i < 8; i++) {
-				nx_service_t *vd =
-				    get_service(a->Get(c, i).ToLocalChecked());
+				Local<Value> e;
+				if (!a->Get(c, i).ToLocal(&e))
+					return;
+				nx_service_t *vd = get_service(e);
 				if (!vd) {
 					nx_throw(iso, "invalid outObjects entry");
 					return;

--- a/source/url.cc
+++ b/source/url.cc
@@ -103,11 +103,10 @@ void nx_url_new(const FunctionCallbackInfo<Value> &info) {
 	info.GetReturnValue().Set(obj);
 }
 
-// String getter from an ada_string accessor.
+// String getter from an ada_string accessor. Uses the lossy helper so a
+// malformed URL component (non-UTF-8 edge case from ada) can never abort.
 Local<String> ada_str(Isolate *iso, ada_string val) {
-	return String::NewFromUtf8(iso, val.data, NewStringType::kNormal,
-	                           (int)val.length)
-	    .ToLocalChecked();
+	return nx_str_lossy(iso, val.data, (int)val.length);
 }
 
 #define DEFINE_GETTER_SETTER(NAME)                                             \
@@ -147,12 +146,14 @@ void nx_url_get_search(const FunctionCallbackInfo<Value> &info) {
 		if (val.length == 0) {
 			str = nx_str(iso, "");
 		} else {
-			char *tmp = (char *)malloc(val.length + 1);
+			char *tmp = (char *)nx_alloc(iso, val.length + 1);
+			if (!tmp) {
+				ada_free_owned_string(val);
+				return;
+			}
 			tmp[0] = '?';
 			memcpy(tmp + 1, val.data, val.length);
-			str = String::NewFromUtf8(iso, tmp, NewStringType::kNormal,
-			                          (int)val.length + 1)
-			          .ToLocalChecked();
+			str = nx_str_lossy(iso, tmp, (int)val.length + 1);
 			free(tmp);
 		}
 		ada_free_owned_string(val);
@@ -211,10 +212,7 @@ void nx_url_get_origin(const FunctionCallbackInfo<Value> &info) {
 	if (!data)
 		return;
 	ada_owned_string val = ada_get_origin(data->url);
-	info.GetReturnValue().Set(
-	    String::NewFromUtf8(iso, val.data, NewStringType::kNormal,
-	                        (int)val.length)
-	        .ToLocalChecked());
+	info.GetReturnValue().Set(nx_str_lossy(iso, val.data, (int)val.length));
 	ada_free_owned_string(val);
 }
 
@@ -376,10 +374,7 @@ void nx_url_search_params_to_string(const FunctionCallbackInfo<Value> &info) {
 	if (!data)
 		return;
 	ada_owned_string val = ada_search_params_to_string(data->params);
-	info.GetReturnValue().Set(
-	    String::NewFromUtf8(iso, val.data, NewStringType::kNormal,
-	                        (int)val.length)
-	        .ToLocalChecked());
+	info.GetReturnValue().Set(nx_str_lossy(iso, val.data, (int)val.length));
 	ada_free_owned_string(val);
 }
 

--- a/source/web.cc
+++ b/source/web.cc
@@ -318,10 +318,7 @@ void nx_web_applet_poll_messages(const FunctionCallbackInfo<Value> &info) {
 		if (R_FAILED(rc) || !flag)
 			break;
 		size_t str_len = out_size > 0 ? strnlen(buf, (size_t)out_size) : 0;
-		arr->Set(context, index++,
-		         String::NewFromUtf8(iso, buf, NewStringType::kNormal,
-		                             (int)str_len)
-		             .ToLocalChecked())
+		arr->Set(context, index++, nx_str_lossy(iso, buf, (int)str_len))
 		    .Check();
 	}
 	info.GetReturnValue().Set(arr);


### PR DESCRIPTION
## Motivation

A native process abort on a Switch forces the user to **restart the entire console**. nx.js bindings must therefore never abort on bad/large input or allocation failure — they should surface a **catchable JS error** (or, for an unrecoverable VM state, use the existing `had_error` hard-stop that pauses the VM and waits for `+`).

This is a follow-up to the `run_module` crash (PR #349): the same `ToLocalChecked()`-on-empty pattern existed in ~28 places, plus ~13 unchecked allocations reachable from userland JS.

## Audit

Swept all of `source/` (excl. `vendor/`) for process-aborting patterns:
- `.ToLocalChecked()` / `.Check()` on **user/external data** (a getter on a user object can throw → empty `MaybeLocal` → abort).
- `String::NewFromUtf8(...).ToLocalChecked()` / `nx_str()` on **untrusted bytes** (filenames, account nicknames, web-session IPC, URL components) → non-UTF-8 → abort.
- Unchecked `malloc`/`calloc` then dereferenced → NULL-deref crash on allocation failure.

## New helpers (`error.cc` / `error.h`)

- **`nx_alloc(iso, size)`** — `malloc` that throws a `RangeError` and returns `NULL` on failure (callers check + `return`). Never aborts.
- **`nx_str_lossy(iso, s, len)`** — build a `Local<String>` from possibly-malformed UTF-8; falls back to a byte-for-byte string instead of aborting.
- **`nx_throw_oom(iso, size)`**.

## Fixes

Converted data-driven abort sites to `.ToLocal()`/`.To()` + `return`, and untrusted string conversions to `nx_str_lossy`, across: **canvas** (`setLineDash`, `roundRect`, `putImageData`), **irs**, **account** (uid array + nickname), **fs** (readdir names), **web** (IPC payloads), **service** (in/outObjects), **dommatrix**, **fsdev** (uid), **url** (all ada-derived strings + searchParams).

Added NULL checks (via `nx_alloc`, or an error field in `uv_work_t` callbacks where V8 is off-limits) to the unchecked allocations in **ns**, **font**, **dns**, **album**, **account**, **irs**, **url**, **main**.

Documented the rules in `BINDINGS.md §0` and fixed the cheatsheet entries that previously recommended the unsafe patterns.

## Not in scope (tracked follow-up)

~34 bare `new T()` sites (e.g. the `NX_INIT_WORK_T` macros) call `std::terminate` on OOM under `-fno-exceptions`. These are tiny structs (failure very unlikely); migrating them to `new (std::nothrow)` + NULL-check is noted in `BINDINGS.md §0` for a follow-up.

## Verification

- Device `make` builds clean (aarch64 / devkitPro).
- **Host conformance: 40/40 vs Chrome**, including a new Chrome-compared fixture `canvas-hostile-args` (a `setLineDash` element with a throwing `valueOf` now throws a catchable error in both engines).
- On device: a throwing `setLineDash` element throws a **catchable JS error (no crash)**, and `readDirSync('sdmc:/')` works via the lossy path.