### PR TITLE
Size the V8 heap per memory regime (fix application-mode FatalOOM)

### DIFF
--- a/.changeset/v8-heap-sizing.md
+++ b/.changeset/v8-heap-sizing.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: size the V8 heap per memory regime — in application mode from the real committable arena (up to 512 MiB) instead of the misleading free-memory figure, and in applet mode from actual free RAM — so memory-heavy JS no longer fatally OOMs in application mode while applet mode stays correctly bounded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: ghcr.io/tootallnate/pacman-packages@sha256:32a60b2d5bd6f7c0965e903d23e53079aba80bb02d1df7400d4c9e3219ac6ae1
+    container: ghcr.io/tootallnate/pacman-packages@sha256:5fd521a2e2e884e41a42ce5bd412b17ae0498d5a5e61a66b6ca836b6b7bc66b8
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -136,7 +136,7 @@ jobs:
     # into a host ELF), plus the clang-19/lld-19 toolchain. The harness + Skia +
     # V8 are all built against the system libstdc++, so compile the harness with
     # clang-19/lld against /opt/host.
-    container: ghcr.io/tootallnate/pacman-packages@sha256:32a60b2d5bd6f7c0965e903d23e53079aba80bb02d1df7400d4c9e3219ac6ae1
+    container: ghcr.io/tootallnate/pacman-packages@sha256:5fd521a2e2e884e41a42ce5bd412b17ae0498d5a5e61a66b6ca836b6b7bc66b8
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/source/V8-HEAP-SIZING-HANDOFF.md
+++ b/source/V8-HEAP-SIZING-HANDOFF.md
@@ -1,0 +1,124 @@
+# Handoff: V8 heap sizing in application mode (`source/main.cc`)
+
+Context for the nx.js agent. Covers what changed in `switch-v8` and what (if
+anything) to change in nx.js's V8 instantiation. Source of truth for the
+upstream fixes: `pacman-packages/switch/v8/HEAP-COMMIT-INVESTIGATION.md`.
+
+## TL;DR
+
+- **Required:** none. The recent `switch-v8` fixes (full-JIT GC W^X Data Aborts)
+  are entirely inside the monolith. Just rebuild/relink nx.js against
+  **`switch-v8 >= 15.0.243-9`** and the full-JIT crashes are gone.
+- **Recommended bug fix:** nx.js currently sizes V8's max heap from
+  `mem_free = TotalMemorySize - UsedMemorySize`, which is only a few MiB in
+  application mode (the grant is reported as "used"). That underflows the heap to
+  the **32 MiB floor in application mode** — i.e. a ~3 GiB device runs a 32 MiB
+  JS heap and `FatalOOM`s on memory-heavy JS. Fix the heap budget to use the real
+  ceiling. Details below.
+
+## Background: what was fixed upstream (no nx.js change needed)
+
+On Horizon, full-JIT executable memory is a libnx jit_* region with a read-only
+**rx** alias (writes go through the **rw** alias = rx + delta). Two V8 GC paths
+wrote *data* into the start of a CODE page via the rx alias and Data-Aborted —
+**only under full JIT**, which is why it showed up "even in application mode":
+
+- `MutablePage::SetOldGenerationPageFlags` (marking barrier) — fixed by switch-v8
+  patch 0008 (redirect the in-page `MemoryChunk` flag store to the rw alias).
+- `Sweeper::ZeroOrDiscardUnusedMemory` (GC sweeper `memset`) — fixed by switch-v8
+  patch 0009 (skip the cosmetic zeroing for executable pages).
+
+Verified on hardware: full JIT in application mode went from a Data Abort at
+32 MiB → graceful `RangeError` at ~3 GiB. **Action: install/link `switch-v8
+15.0.243-9`** (an older `-7`/`-8` still has these bugs).
+
+## The nx.js bug to fix: application-mode heap underflow
+
+In `source/main.cc`, the JIT gate correctly keys on `mem_total`
+(`tight_memory = mem_total <= 1 GiB`, ~line 898), but the **heap budget** still
+uses `mem_free`:
+
+```c
+// ~line 973
+u64 reserve   = (can_jit ? 180ull : 48ull) * 1024 * 1024;
+u64 max_heap  = mem_free > reserve ? mem_free - reserve : 0;   // <-- mem_free is wrong here
+if (max_heap < 32ull * 1024 * 1024)  max_heap = 32ull * 1024 * 1024;
+if (max_heap > 192ull * 1024 * 1024) max_heap = 192ull * 1024 * 1024;
+create_params.constraints.ConfigureDefaultsFromHeapSize(8 MiB, max_heap);
+```
+
+The code's own comment (~line 886) already notes `UsedMemorySize` reports the
+whole grant as used in application mode, so `mem_free ≈ 3 MiB` there →
+`max_heap` underflows to the 32 MiB floor. That is the original
+`HEAP-COMMIT-INVESTIGATION` "Symptom A" (`FatalOOM` on a big `Array.prototype.join`).
+
+### Recommended fix
+
+Budget the heap from the **real DATA-arena ceiling** exposed by switch-v8,
+clamped by **real free memory**, instead of `mem_free`:
+
+```c
+// Declare alongside the other horizon_mman_* externs (near line 84):
+extern "C" size_t horizon_mman_data_arena_size(void);
+
+// ... in the heap-sizing block (~line 972), replace the mem_free math:
+{
+    // Real committable ceiling for the V8 object heap. Two independent limits:
+    //  - horizon_mman_data_arena_size(): address space the mman reserved from
+    //    the STACK region for the V8 heap (typically 1 GiB).
+    //  - actual free physical RAM. In application/title-redirect mode the host
+    //    game may have eaten most RAM, so this can be small even with a 3 GiB
+    //    grant; in a clean app-mode launch it can be ~3 GiB. NOTE: here
+    //    (total - used) IS meaningful as "physically backable", which is what we
+    //    want — unlike the JIT gate, which needs the grant size (mem_total).
+    u64 arena    = (u64)horizon_mman_data_arena_size();
+    u64 free_ram = mem_free;                       // total - used (backable RAM)
+    u64 ceiling  = arena < free_ram ? arena : free_ram;
+
+    // Headroom for the JIT code arena (~128 MiB real when can_jit), GPU/Mesa or
+    // Cairo, libuv, and native allocs — all share this memory.
+    u64 reserve  = (can_jit ? 180ull : 48ull) * 1024 * 1024;
+    u64 max_heap = ceiling > reserve ? ceiling - reserve : 0;
+
+    if (max_heap < 32ull  * 1024 * 1024) max_heap = 32ull  * 1024 * 1024;
+    if (max_heap > 512ull * 1024 * 1024) max_heap = 512ull * 1024 * 1024; // was 192
+    create_params.constraints.ConfigureDefaultsFromHeapSize(8ull << 20, max_heap);
+}
+```
+
+Leave the `set_code_range_size_in_bytes` block (64 MiB for JIT / 0 for jitless,
+~line 983) exactly as-is — that is correct and load-bearing.
+
+Notes:
+- Raising the clamp from 192 → 512 MiB lets application-mode apps actually use
+  the available heap. Pick a value you're comfortable with; the V8 object heap
+  lives in the (≈1 GiB) mman DATA arena, so 512 MiB is safe headroom-wise.
+- If `horizon_mman_data_arena_size()` returns 0 (reservation failed), the `min`
+  collapses to `free_ram`, which is a sane fallback.
+
+## Important: ArrayBuffer / TypedArray memory is SEPARATE from the V8 heap
+
+`ArrayBuffer::Allocator::NewDefaultAllocator()` (the allocator nx.js passes in
+`create_params`, ~line 957) backs `ArrayBuffer`/`TypedArray` data with
+`malloc`/`calloc` from the **newlib heap**, NOT the V8 object heap and NOT the
+mman DATA arena. Consequences:
+
+- `max_heap` does **not** bound TypedArray memory; large `Uint8Array`/`Blob`/
+  buffer workloads are bounded by physical RAM directly (the on-device test
+  reached ~3 GiB of `Uint8Array` while the V8 object heap used only ~32 MiB).
+- That memory now degrades gracefully (catchable `RangeError`) at the wall rather
+  than crashing, given switch-v8 -9 + the -7 ENOMEM change. No nx.js change
+  needed for it — just don't size it via `max_heap`.
+
+## Verifying on device
+
+There is a standalone regression app at
+`pacman-packages/examples/heap-stress` (V8-only, no Skia/libuv). It sizes the
+heap from `horizon_mman_data_arena_size()`, allocates `Uint8Array`s to the wall,
+and does a large `Array.join`. Expected: prints `SURVIVED (no Data Abort)` and a
+caught `RangeError`, in both applet (jitless) and application (full JIT) mode.
+Use it as the reference for the sizing pattern above.
+
+For nx.js itself: after the change, confirm in application mode that
+`[v8] ... mode=jit` is logged, a multi-hundred-MiB workload runs, and a big
+`Array.prototype.join` (the NSP-builder shape) completes instead of `FatalOOM`.

--- a/source/V8-HEAP-SIZING-HANDOFF.md
+++ b/source/V8-HEAP-SIZING-HANDOFF.md
@@ -52,32 +52,37 @@ whole grant as used in application mode, so `mem_free ≈ 3 MiB` there →
 `max_heap` underflows to the 32 MiB floor. That is the original
 `HEAP-COMMIT-INVESTIGATION` "Symptom A" (`FatalOOM` on a big `Array.prototype.join`).
 
-### Recommended fix
+### Recommended fix (as implemented)
 
-Budget the heap from the **real DATA-arena ceiling** exposed by switch-v8,
-clamped by **real free memory**, instead of `mem_free`:
+Budget the heap **per memory regime** — `mem_free` is only meaningful in
+applet/tight-memory mode, so it must NOT be used in application mode (where it
+reads as only a few MiB even with a multi-GiB grant). This is what landed in
+`source/main.cc`:
 
 ```c
 // Declare alongside the other horizon_mman_* externs (near line 84):
 extern "C" size_t horizon_mman_data_arena_size(void);
 
-// ... in the heap-sizing block (~line 972), replace the mem_free math:
+// ... in the heap-sizing block, replace the mem_free math:
 {
-    // Real committable ceiling for the V8 object heap. Two independent limits:
-    //  - horizon_mman_data_arena_size(): address space the mman reserved from
-    //    the STACK region for the V8 heap (typically 1 GiB).
-    //  - actual free physical RAM. In application/title-redirect mode the host
-    //    game may have eaten most RAM, so this can be small even with a 3 GiB
-    //    grant; in a clean app-mode launch it can be ~3 GiB. NOTE: here
-    //    (total - used) IS meaningful as "physically backable", which is what we
-    //    want — unlike the JIT gate, which needs the grant size (mem_total).
-    u64 arena    = (u64)horizon_mman_data_arena_size();
-    u64 free_ram = mem_free;                       // total - used (backable RAM)
-    u64 ceiling  = arena < free_ram ? arena : free_ram;
-
+    u64 arena   = (u64)horizon_mman_data_arena_size();
     // Headroom for the JIT code arena (~128 MiB real when can_jit), GPU/Mesa or
     // Cairo, libuv, and native allocs — all share this memory.
-    u64 reserve  = (can_jit ? 180ull : 48ull) * 1024 * 1024;
+    u64 reserve = (can_jit ? 180ull : 48ull) * 1024 * 1024;
+    u64 ceiling;
+    if (tight_memory) {
+        // Applet (~380 MiB grant): the ~1 GiB arena is pure address space the
+        // device can't back, so bound by REAL free physical RAM. Here
+        // mem_free (= total - used) IS meaningful (~137 MiB).
+        ceiling = mem_free;
+    } else {
+        // Application (multi-GiB grant): physical RAM is plentiful but mem_free
+        // is unreliable — the whole grant is reported as "used" at startup, so
+        // mem_free reads as only a few MiB. Size from the mman's reserved arena
+        // instead (fallback 192 MiB of address space if the reservation failed,
+        // which after `reserve` lands on the 32 MiB floor — conservative).
+        ceiling = arena ? arena : 192ull * 1024 * 1024;
+    }
     u64 max_heap = ceiling > reserve ? ceiling - reserve : 0;
 
     if (max_heap < 32ull  * 1024 * 1024) max_heap = 32ull  * 1024 * 1024;
@@ -86,15 +91,18 @@ extern "C" size_t horizon_mman_data_arena_size(void);
 }
 ```
 
-Leave the `set_code_range_size_in_bytes` block (64 MiB for JIT / 0 for jitless,
-~line 983) exactly as-is — that is correct and load-bearing.
+Leave the `set_code_range_size_in_bytes` block (64 MiB for JIT / 0 for jitless)
+exactly as-is — that is correct and load-bearing.
 
 Notes:
+- Do NOT use `min(arena, mem_free)` unconditionally: in application mode
+  `mem_free ≈ a few MiB`, so the `min` would collapse to it and reintroduce the
+  32 MiB under-sizing bug. `mem_free` is only a valid ceiling in applet mode.
 - Raising the clamp from 192 → 512 MiB lets application-mode apps actually use
-  the available heap. Pick a value you're comfortable with; the V8 object heap
-  lives in the (≈1 GiB) mman DATA arena, so 512 MiB is safe headroom-wise.
-- If `horizon_mman_data_arena_size()` returns 0 (reservation failed), the `min`
-  collapses to `free_ram`, which is a sane fallback.
+  the available heap. The V8 object heap lives in the (≈1 GiB) mman DATA arena,
+  so 512 MiB is safe headroom-wise.
+- Verified on device: application mode `max_heap=512 MiB`; applet mode
+  `max_heap=89 MiB` (sized from ~137 MiB free RAM). Both stable.
 
 ## Important: ArrayBuffer / TypedArray memory is SEPARATE from the V8 heap
 

--- a/source/main.cc
+++ b/source/main.cc
@@ -83,6 +83,11 @@ extern "C" const unsigned int nxjs_runtime_js_len;
 // switch-v8: release manual svcMapMemory arenas before returning to hbloader.
 extern "C" void horizon_mman_teardown(void);
 
+// switch-v8: address space the mman reserved (from the STACK region) for V8's
+// object heap, in bytes (typically ~1 GiB; 0 if the reservation failed). Used to
+// size the V8 max heap against the real committable ceiling.
+extern "C" size_t horizon_mman_data_arena_size(void);
+
 // ---------------------------------------------------------------------------
 // Rendering state (Phase 1: Cairo raster -> libnx framebuffer memcpy).
 // ---------------------------------------------------------------------------
@@ -967,17 +972,49 @@ int main(int argc, char *argv[]) {
 	// V8 reserve/commit oversized arenas that the horizon mman can't satisfy
 	// (crash in Arena::CommitRange -> _malloc_r). This matches the hello-v8
 	// reference. ConfigureDefaultsFromHeapSize also RESETS the code range size,
-	// so (re)apply it AFTER. Budget the max heap from memory free at startup,
-	// reserving headroom for the JIT code arena, GPU/Cairo, and native allocs.
+	// so (re)apply it AFTER.
+	//
+	// Budget the V8 object heap per memory regime. Two facts drive this:
+	//   - horizon_mman_data_arena_size(): the ADDRESS SPACE switch-v8 reserved
+	//     (from the STACK region) for the V8 heap (~1 GiB), committed lazily in
+	//     16 MiB slabs as V8 touches pages. This is an address-space ceiling,
+	//     NOT a guarantee of physical RAM.
+	//   - the actual physical memory the process can commit.
+	// In APPLICATION mode the grant is several GiB but mem_free (= total - used)
+	// is misleading: Horizon reports the whole grant as "used" at startup, so
+	// mem_free reads as only a few MiB. There, size from the arena ceiling
+	// (capped) — physical RAM is plentiful. In APPLET mode the grant is small
+	// (~380 MiB) and mem_free IS meaningful (~137 MiB free); the 1 GiB arena is
+	// pure address space the device cannot back, so configuring a big heap makes
+	// V8 grow until physical commits fail and it fatally OOMs
+	// ("CALL_AND_RETRY_LAST"). So in applet mode clamp to real free RAM.
+	// Reserve headroom for the JIT code arena (~128 MiB real when can_jit),
+	// GPU/Mesa, libuv, and native allocs — they share the process memory.
 	{
+		u64 arena = (u64)horizon_mman_data_arena_size();
 		u64 reserve = (can_jit ? 180ull : 48ull) * 1024 * 1024;
-		u64 max_heap = mem_free > reserve ? mem_free - reserve : 0;
+		u64 ceiling;
+		if (tight_memory) {
+			// Applet: bounded by real free physical RAM, not the address-space
+			// arena. mem_free is reliable in this regime.
+			ceiling = mem_free;
+		} else {
+			// Application: physical RAM is plentiful; mem_free is unreliable.
+			// Use the mman's reserved arena (fallback to a proven 192 MiB).
+			ceiling = arena ? arena : 192ull * 1024 * 1024;
+		}
+		u64 max_heap = ceiling > reserve ? ceiling - reserve : 0;
 		if (max_heap < 32ull * 1024 * 1024)
 			max_heap = 32ull * 1024 * 1024;
-		if (max_heap > 192ull * 1024 * 1024)
-			max_heap = 192ull * 1024 * 1024;
+		if (max_heap > 512ull * 1024 * 1024)
+			max_heap = 512ull * 1024 * 1024;
 		create_params.constraints.ConfigureDefaultsFromHeapSize(
 		    8ull * 1024 * 1024 /* initial */, max_heap /* max */);
+		fprintf(stderr,
+		        "[v8] max_heap=%llu MiB (arena=%llu MiB free=%llu MiB)\n",
+		        (unsigned long long)(max_heap / (1024 * 1024)),
+		        (unsigned long long)(arena / (1024 * 1024)),
+		        (unsigned long long)(mem_free / (1024 * 1024)));
 	}
 
 	if (can_jit) {

--- a/source/main.cc
+++ b/source/main.cc
@@ -1000,7 +1000,12 @@ int main(int argc, char *argv[]) {
 			ceiling = mem_free;
 		} else {
 			// Application: physical RAM is plentiful; mem_free is unreliable.
-			// Use the mman's reserved arena (fallback to a proven 192 MiB).
+			// Size from the mman's reserved arena (normally ~1 GiB -> capped at
+			// 512 MiB below). If the arena reservation reported 0 (it failed),
+			// fall back to 192 MiB of address space; after the `reserve`
+			// subtraction this lands on the 32 MiB floor — a deliberately
+			// conservative last resort, since with no arena we can't trust a
+			// larger heap to be backable.
 			ceiling = arena ? arena : 192ull * 1024 * 1024;
 		}
 		u64 max_heap = ceiling > reserve ? ceiling - reserve : 0;
@@ -1015,6 +1020,10 @@ int main(int argc, char *argv[]) {
 		        (unsigned long long)(max_heap / (1024 * 1024)),
 		        (unsigned long long)(arena / (1024 * 1024)),
 		        (unsigned long long)(mem_free / (1024 * 1024)));
+		// stderr is fully buffered when redirected to a file; flush so this
+		// milestone survives an early abnormal exit (matches the other init
+		// logs above).
+		fflush(stderr);
 	}
 
 	if (can_jit) {


### PR DESCRIPTION
## Summary

Memory-heavy JS in **application mode** (e.g. building an NSP via a big `Array.prototype.push`/`join`) fatally OOM'd (`[FatalOOM] JavaScript OOM: CALL_AND_RETRY_LAST` → abort). Root cause: the V8 max-heap budget was derived from `mem_free` (`TotalMemorySize - UsedMemorySize`), which on Horizon reads as only **a few MiB in application mode** (the whole multi-GiB grant is reported as "used" at startup). That underflowed the heap to the 32 MiB floor.

## Fix

Size the V8 heap **per memory regime**:

- **Application mode** (multi-GiB grant): budget from the switch-v8 DATA arena (`horizon_mman_data_arena_size()`, ~1 GiB, committed lazily in 16 MiB slabs), reserve headroom for the JIT code arena / GPU / native allocs, capped at **512 MiB** (was 192). `mem_free` is unreliable here; physical RAM is plentiful.
- **Applet mode** (~380 MiB grant): the 1 GiB arena is pure address space the device can't back, so budget from **real free RAM** (`mem_free`, ~137 MiB). Avoids configuring an impossible heap that OOMs when physical commits fail.

Requires **switch-v8 >= 15.0.243-9** — its full-JIT GC W^X fixes make an over-commit degrade to a catchable `RangeError` rather than a Data Abort. This PR bumps both CI jobs to the image that ships `-9` (`sha256:5fd521a2…`).

`ArrayBuffer`/`TypedArray` data is malloc-backed (separate from the V8 object heap) and is unaffected by `max_heap`; it degrades gracefully (catchable `RangeError`) at the RAM wall.

## Verification (on device)

- **Application mode:** `[v8] max_heap=512 MiB (arena=1024 MiB)`; allocated ~600 MiB of TypedArrays and completed a ~46 MiB `Array.join` that previously crashed. `SURVIVED`, no abort.
- **Applet mode:** `[v8] max_heap=89 MiB (free=137 MiB)` (sized to physical RAM, not an impossible 512 MiB); allocated ~56 MiB then `SURVIVED`. Stable for normal apps.

## Notes / out of scope

- Building an NSP **still requires application mode** — it does not physically fit in applet memory (~380 MiB total). `FatalOOM` there is an unconditional V8 abort and can't be made catchable; lowering the NSP builder's peak memory (hacbrewpack streaming) is a separate, app/library-side effort.
- A separate `console.log`-while-GPU-canvas-active crash (EGL ↔ libnx-console NWindow handoff) was found during testing and is **deferred** — not addressed here.
- Includes upstream handoff notes at `source/V8-HEAP-SIZING-HANDOFF.md`.