### PR TITLE
Support an explicit entrypoint via argv[1] (bootstrap foundation)

### DIFF
--- a/.changeset/argv-entrypoint.md
+++ b/.changeset/argv-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": minor
+---
+
+feat: support an explicit entrypoint via `argv[1]` — launch the nx.js runtime with a `.js` file (run directly) or an app `.nro` (its embedded RomFS is mounted as `romfs:` and `romfs:/main.js` is run). The runtime's own files are now mounted under `nxjs:` so `romfs:` always refers to the app. This is the foundation for a thin "bootstrap" launcher that keeps a single shared nx.js runtime on the SD card.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,27 @@ fetch(url)
 
 The `$.entrypoint` gives the base URL for resolving relative paths.
 
+### RomFS mounts (`romfs:` vs `nxjs:`)
+
+`main.cc` mounts two RomFS devices:
+
+- **`nxjs:`** — the nx.js NRO's OWN embedded RomFS (holds the runtime's source
+  map, `nxjs:/runtime.js.map`). Always mounted. The embedded runtime is run
+  under the name `nxjs:/runtime.js` so its stack frames symbolicate.
+- **`romfs:`** — "the app". For a standalone app this is the same NRO's RomFS
+  (so existing `romfs:/asset` references work). For a **bootstrap launch**
+  (`argv[1]` is an app `.nro`), it is the launched app's RomFS instead.
+
+### Entrypoint resolution (`argv[1]`)
+
+`main.cc` resolves the user entrypoint as:
+
+1. If `argv[1]` is set (bootstrap launch — a thin launcher hands nx.js the app):
+   - `*.nro` → `romfsMountFromFsdev(argv[1], 0, "romfs")`, run `romfs:/main.js`.
+   - otherwise (typically `*.js`) → run `argv[1]` directly.
+2. Else (standalone): mount self as `romfs:`, run `romfs:/main.js`; fall back to
+   `<argv0>.js` next to the `.nro` on the SD card.
+
 ## Build System
 
 - **C code**: `Makefile` using devkitPro/libnx toolchain (aarch64, cross-compiled)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,10 @@ The `$.entrypoint` gives the base URL for resolving relative paths.
 `main.cc` resolves the user entrypoint as:
 
 1. If `argv[1]` is set (bootstrap launch — a thin launcher hands nx.js the app):
-   - `*.nro` → `romfsMountFromFsdev(argv[1], 0, "romfs")`, run `romfs:/main.js`.
+   - `*.nro` → mount its embedded RomFS as `romfs:` and run `romfs:/main.js`.
+     The RomFS is not at file offset 0, so `mount_nro_romfs()` parses the NRO
+     header + asset header to find the RomFS offset, then calls
+     `romfsMountFromFsdev(argv[1], romfs_offset, "romfs")`.
    - otherwise (typically `*.js`) → run `argv[1]` directly.
 2. Else (standalone): mount self as `romfs:`, run `romfs:/main.js`; fall back to
    `<argv0>.js` next to the `.nro` on the SD card.

--- a/packages/runtime/src/source-map.ts
+++ b/packages/runtime/src/source-map.ts
@@ -119,7 +119,7 @@ function filenameToTracer(filename: string) {
 					return `    at ${filename}:${callsite.getLineNumber()}:${callsite.getColumnNumber()}`;
 				}
 				if (filename) {
-					const proto = filename === 'romfs:/runtime.js' ? 'nxjs' : 'app';
+					const proto = filename === 'nxjs:/runtime.js' ? 'nxjs' : 'app';
 					let line = callsite.getLineNumber() ?? 1;
 					let column = callsite.getColumnNumber() ?? 1;
 

--- a/packages/runtime/src/switch/index.ts
+++ b/packages/runtime/src/switch/index.ts
@@ -248,9 +248,25 @@ export const env = new Env(INTERNAL_SYMBOL);
 export const argv = $.argv;
 
 /**
- * String value of the entrypoint JavaScript file that was evaluated. If a `main.js` file is present on the application's RomFS, then that will be executed first, in which case the value will be `romfs:/main.js`. Otherwise, the value will be the path of the `.nro` file on the SD card, with the `.nro` extension replaced with `.js`.
+ * String value of the entrypoint JavaScript file that was evaluated. It is the
+ * base URL used to resolve relative `fetch()` / `Image` / `Audio` paths.
+ *
+ * It is resolved in the following order:
+ *
+ *  - If a second launch argument ({@link argv | `Switch.argv[1]`}) was provided
+ *    (a "bootstrap" launch, where a thin launcher hands the nx.js runtime an app
+ *    to run):
+ *    - a `.nro` path: its embedded RomFS is mounted and the value is
+ *      `"romfs:/main.js"`.
+ *    - any other path (typically a `.js` file): the value is that path as given.
+ *  - Otherwise (a standalone app): if a `main.js` is present in the
+ *    application's own RomFS, the value is `"romfs:/main.js"`. Failing that, it
+ *    is the path of the `.nro` on the SD card with `.nro` replaced by `.js`.
+ *
+ * Note: the nx.js runtime's own files (e.g. its source map) are mounted
+ * separately under `nxjs:` so that `romfs:` always refers to the running app.
  * @example "romfs:/main.js"
- * @example "sdmc:/switch/nxjs.js"
+ * @example "sdmc:/switch/my-app.js"
  */
 export const entrypoint = $.entrypoint;
 

--- a/source/main.cc
+++ b/source/main.cc
@@ -495,8 +495,9 @@ static bool path_has_suffix(const char *path, const char *suffix) {
 // RomFS is not at file offset 0: it lives after the code segments + asset
 // header. romfsMountFromFsdev() takes the romfs start offset but does NOT parse
 // the NRO, so compute the offset here (mirroring libnx's romfsMountSelf): read
-// the NroHeader at 0 to get `size`, then the NroAssetHeader at `size` to get
-// the romfs section offset. Returns a libnx Result.
+// the NroHeader (which follows the 16-byte NroStart, so at offset
+// sizeof(NroStart)) to get `size`, then the NroAssetHeader at `size` to get the
+// romfs section offset. Returns a libnx Result.
 static Result mount_nro_romfs(const char *path, const char *name) {
 	FILE *f = fopen(path, "rb");
 	if (!f)

--- a/source/main.cc
+++ b/source/main.cc
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 
 #include <ada.h>
@@ -482,6 +483,46 @@ static void js_hid_send_vibration_values(
 // ---------------------------------------------------------------------------
 // File reading helper.
 // ---------------------------------------------------------------------------
+
+// Case-insensitive check that `path` ends with `suffix` (e.g. ".nro").
+static bool path_has_suffix(const char *path, const char *suffix) {
+	size_t plen = strlen(path);
+	size_t slen = strlen(suffix);
+	return plen >= slen && strcasecmp(path + plen - slen, suffix) == 0;
+}
+
+// Mount the embedded RomFS of the NRO at `path` under device `name`. An NRO's
+// RomFS is not at file offset 0: it lives after the code segments + asset
+// header. romfsMountFromFsdev() takes the romfs start offset but does NOT parse
+// the NRO, so compute the offset here (mirroring libnx's romfsMountSelf): read
+// the NroHeader at 0 to get `size`, then the NroAssetHeader at `size` to get
+// the romfs section offset. Returns a libnx Result.
+static Result mount_nro_romfs(const char *path, const char *name) {
+	FILE *f = fopen(path, "rb");
+	if (!f)
+		return MAKERESULT(Module_Libnx, LibnxError_NotFound);
+	NroHeader hdr;
+	NroAssetHeader asset;
+	Result rc = MAKERESULT(Module_Libnx, LibnxError_IoError);
+	// NroHeader follows NroStart (16 bytes) at the start of the file.
+	if (fseek(f, sizeof(NroStart), SEEK_SET) != 0 ||
+	    fread(&hdr, 1, sizeof(hdr), f) != sizeof(hdr) ||
+	    hdr.magic != NROHEADER_MAGIC)
+		goto done;
+	// The asset header is appended right after the NRO code image (hdr.size).
+	if (fseek(f, hdr.size, SEEK_SET) != 0 ||
+	    fread(&asset, 1, sizeof(asset), f) != sizeof(asset) ||
+	    asset.magic != NROASSETHEADER_MAGIC || asset.romfs.offset == 0 ||
+	    asset.romfs.size == 0)
+		goto done;
+	fclose(f);
+	// romfsMountFromFsdev opens its own handle; pass the absolute romfs offset.
+	return romfsMountFromFsdev(path, hdr.size + asset.romfs.offset, name);
+done:
+	fclose(f);
+	return rc;
+}
+
 uint8_t *read_file(const char *filename, size_t *out_size) {
 	FILE *file = fopen(filename, "rb");
 	if (file == NULL)
@@ -879,7 +920,17 @@ int main(int argc, char *argv[]) {
 	nx_context_t *nx_ctx = (nx_context_t *)calloc(1, sizeof(nx_context_t));
 	nx_ctx->rendering_mode = NX_RENDERING_MODE_INIT;
 
-	rc = romfsInit();
+	// Mount the nx.js NRO's OWN embedded romfs as `nxjs:` (it holds the
+	// runtime's source map). The app's romfs is mounted separately as `romfs:`
+	// during entrypoint resolution below: for a standalone app that is also
+	// this NRO's romfs; for a bootstrap launch (argv[1] = an app `.nro`) it is
+	// the launched app's romfs. Keeping the runtime files under `nxjs:` lets
+	// `romfs:` always mean "the app".
+	//
+	// Use romfsMountSelf (NRO-aware: reads our own NRO file via argv[0]), NOT
+	// romfsMountFromCurrentProcess (which uses fsOpenDataStorageByCurrentProcess
+	// — that is for installed titles/NSO and fails for a homebrew NRO).
+	rc = romfsMountSelf("nxjs");
 	if (R_FAILED(rc))
 		diagAbortWithResult(rc);
 
@@ -1050,17 +1101,61 @@ int main(int argc, char *argv[]) {
 		              (HidNpadIdType)(HidNpadIdType_No1 + i));
 	}
 
-	// Resolve the user entrypoint (romfs:/main.js, then sdmc <nro>.js).
+	// Resolve the user entrypoint. Two launch models:
+	//
+	//   1. Bootstrap launch: `argv[1]` is an explicit entrypoint passed by a
+	//      thin launcher (which keeps the big nx.js NRO at a well-known path and
+	//      hands it the app to run). `argv[1]` is either:
+	//        - a `.nro`: mount its embedded romfs as `romfs:` and run
+	//          `romfs:/main.js` (the app's assets resolve under `romfs:`), or
+	//        - any other path (typically a `.js`): run it directly; its URL is
+	//          the base for relative fetch/import resolution.
+	//
+	//   2. Standalone app (the original model, no argv[1]): the app's own NRO
+	//      romfs holds `main.js` + assets, so mount self as `romfs:` and run
+	//      `romfs:/main.js`; fall back to `<nro>.js` next to the NRO on the SD
+	//      card.
 	size_t user_code_size = 0;
 	bool user_path_needs_free = false;
-	char *user_code_path = (char *)"romfs:/main.js";
-	char *user_code = (char *)read_file(user_code_path, &user_code_size);
-	if (user_code == NULL && errno == ENOENT && argc > 0) {
-		user_path_needs_free = true;
-		user_code_path = strdup(argv[0]);
-		if (user_code_path) {
-			replace_file_extension(user_code_path, ".js");
+	char *user_code_path = NULL;
+	char *user_code = NULL;
+
+	if (argc > 1 && argv[1] && argv[1][0]) {
+		// Bootstrap launch with an explicit entrypoint.
+		if (path_has_suffix(argv[1], ".nro")) {
+			rc = mount_nro_romfs(argv[1], "romfs");
+			if (R_FAILED(rc)) {
+				nx_console_init(nx_ctx);
+				printf("Failed to mount romfs from %s (0x%x)\n", argv[1], rc);
+				nx_ctx->had_error = 1;
+			} else {
+				user_code_path = (char *)"romfs:/main.js";
+				user_code = (char *)read_file(user_code_path, &user_code_size);
+			}
+		} else {
+			user_path_needs_free = true;
+			user_code_path = strdup(argv[1]);
+			if (user_code_path) {
+				user_code = (char *)read_file(user_code_path, &user_code_size);
+			}
+		}
+	} else {
+		// Standalone app: this NRO's own romfs is the app. Also expose it as
+		// `romfs:` (it is already mounted as `nxjs:` for the runtime's files).
+		// romfsMountSelf opens our NRO file again with an independent handle, so
+		// the second mount coexists with the `nxjs:` one.
+		rc = romfsMountSelf("romfs");
+		if (R_SUCCEEDED(rc)) {
+			user_code_path = (char *)"romfs:/main.js";
 			user_code = (char *)read_file(user_code_path, &user_code_size);
+		}
+		if (user_code == NULL && errno == ENOENT && argc > 0) {
+			user_path_needs_free = true;
+			user_code_path = strdup(argv[0]);
+			if (user_code_path) {
+				replace_file_extension(user_code_path, ".js");
+				user_code = (char *)read_file(user_code_path, &user_code_size);
+			}
 		}
 	}
 
@@ -1072,9 +1167,16 @@ int main(int argc, char *argv[]) {
 		Local<Object> global = context->Global();
 
 		if (user_code == NULL) {
-			nx_console_init(nx_ctx);
-			printf("%s: %s\n", strerror(errno), user_code_path);
-			nx_ctx->had_error = 1;
+			// A more specific error may already have been reported (e.g. an
+			// argv[1] `.nro` whose romfs failed to mount, leaving had_error set
+			// and user_code_path NULL). Only print the generic errno message
+			// when we actually have a path that couldn't be read.
+			if (!nx_ctx->had_error) {
+				nx_console_init(nx_ctx);
+				printf("%s: %s\n", strerror(errno),
+				       user_code_path ? user_code_path : "(no entrypoint)");
+				nx_ctx->had_error = 1;
+			}
 		} else {
 			Local<Object> init_obj = Object::New(iso);
 			nx_ctx->init_obj.Reset(iso, init_obj);
@@ -1082,10 +1184,13 @@ int main(int argc, char *argv[]) {
 			                  argv);
 			global->Set(context, nx_str(iso, "$"), init_obj).Check();
 
-			// Initialize the runtime (embedded runtime.js source).
+			// Initialize the runtime (embedded runtime.js source). Name it
+			// `nxjs:/runtime.js` so its stack frames symbolicate against the
+			// source map at `nxjs:/runtime.js.map` (the runtime's own romfs,
+			// mounted as `nxjs:`).
 			if (!run_script(iso, context,
 			                (const char *)nxjs_runtime_js,
-			                nxjs_runtime_js_len, "runtime.js")) {
+			                nxjs_runtime_js_len, "nxjs:/runtime.js")) {
 				nx_console_init(nx_ctx);
 				printf("Runtime initialization failed\n");
 				nx_ctx->had_error = 1;
@@ -1287,7 +1392,11 @@ int main(int argc, char *argv[]) {
 
 	// Close libnx services in reverse init order, while memory is still valid.
 	plExit();
-	romfsExit();
+	romfsUnmount("nxjs");
+	// The `romfs:` mount (self for a standalone app, or the launched app's NRO
+	// for a bootstrap launch) is unmounted best-effort; it is a no-op if no
+	// such mount was registered.
+	romfsUnmount("romfs");
 	socketExit();
 
 	if (debug_fd) {


### PR DESCRIPTION
## Summary

The nx.js binary is large (~40 MB) because every app embeds the full runtime. This is step 1 toward a **bootstrap** model: a thin launcher keeps a single shared `nx.js-vX.nro` on the SD card and hands it the app to run, so apps no longer need to bundle the whole runtime.

This PR makes the runtime accept an explicit entrypoint via **`argv[1]`**:

- **`.nro`**: parse the NRO/asset header for the embedded RomFS offset, mount it as `romfs:`, and run `romfs:/main.js`. The app's bundled assets resolve under `romfs:` exactly as today.
- **any other path** (typically a `.js`): run it directly; its path is the base URL for relative `fetch`/`Image`/`Audio` resolution.

**Standalone apps (no `argv[1]`) are unchanged**: the app's own NRO RomFS is mounted as `romfs:` and `romfs:/main.js` runs (falling back to `<nro>.js` on the SD card).

## RomFS mounts: `romfs:` vs `nxjs:`

The runtime's OWN embedded RomFS (which holds the runtime source map) is now mounted separately as **`nxjs:`**, and `runtime.js` runs under the name `nxjs:/runtime.js`. This keeps the invariant that **`romfs:` always means "the app"** — whether that's a standalone app's own NRO or a bootstrap-launched app NRO. `source-map.ts` updated to symbolicate runtime frames against `nxjs:/runtime.js` and read `nxjs:/runtime.js.map`.

## Implementation notes

- Mounts use `romfsMountSelf` (NRO-aware — reads our own NRO via `argv[0]`), **not** `romfsMountFromCurrentProcess` (which uses `fsOpenDataStorageByCurrentProcess`, for installed titles/NSO, and fails for a homebrew NRO).
- `mount_nro_romfs()` parses the `NroHeader`/`NroAssetHeader` to compute the real RomFS offset (an NRO's RomFS is not at file offset 0); `romfsMountFromFsdev` does not parse the NRO itself.

## Verification (on device)

All three launch paths verified end-to-end (via `Application.launch()` to re-enter the runtime with `argv[1]`):

1. **Standalone**: `entrypoint=romfs:/main.js`, `romfs:/asset.txt` reads the app's asset, `nxjs:/runtime.js.map` reads (277 KB), stack frames symbolicate.
2. **`argv[1]` = `.js`**: `entrypoint=sdmc:/switch/myapp.js`, runs directly.
3. **`argv[1]` = `.nro`**: mounts the app NRO's RomFS, runs its `main.js`, and `romfs:/asset.txt` resolves to the **app NRO's** asset (not the launcher runtime's).

## Out of scope (future bootstrap steps)

- The thin C bootstrap NRO (downloads `nx.js-vX.nro` from GitHub Releases, then `envSetNextLoad` with the app as `argv[1]`).
- `@nx.js/nro` producing "thin" app NROs (RomFS-only, no embedded runtime).
- Static ES-module `import` resolution (still single-file bundle).