### PR TITLE
Native ES module import resolution (static + filesystem dynamic import)

### DIFF
--- a/.changeset/native-import.md
+++ b/.changeset/native-import.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": minor
+---
+
+feat: native ES module `import` resolution — the runtime now resolves static `import` and filesystem `await import()` against `romfs:`/`sdmc:`/`nxjs:` (relative and absolute-URL specifiers; bare specifiers throw), with a module cache for referential stability/cycles and correct per-module `import.meta.url`/`import.meta.main`. Top-level await is supported. Enables unbundled multi-file apps and app-level lazy loading (JSON/asset and remote `http(s):`/`data:` imports are not yet supported).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,31 @@ The `$.entrypoint` gives the base URL for resolving relative paths.
 2. Else (standalone): mount self as `romfs:`, run `romfs:/main.js`; fall back to
    `<argv0>.js` next to the `.nro` on the SD card.
 
+### ES module `import` (static + dynamic)
+
+`source/module.cc` (shared by the device runtime and the host test binary, so
+they never drift) implements native ES module resolution for the entrypoint and
+its imports:
+
+- **Static `import`** and **`await import()`** resolve specifiers as URLs (via
+  `ada`) against the importing module's URL: relative (`./`, `../`),
+  absolute-path (`/x.js`), and absolute-URL (`romfs:`/`sdmc:`/`nxjs:`/`file:`)
+  specifiers work; **bare specifiers throw** (no node_modules / import maps).
+- Resolution is **synchronous** (`fopen`/`read_file`), so only mounted devoptab
+  schemes work. `http(s):`/`data:` imports are not supported (would need an
+  async loader). JSON / asset (synthetic) modules are also not implemented yet.
+- A module **cache** keyed by resolved URL gives referential stability (a shared
+  dependency imported via multiple paths is one instance) and handles cycles.
+  `import.meta.url` is each module's resolved URL; `import.meta.main` is true
+  only for the entrypoint.
+- Apps are normally esbuild-bundled (imports resolved at build time), so this is
+  additive — it enables unbundled multi-file apps, the REPL, and app-level lazy
+  `import()`. Top-level await works (V8 native; a rejected entry graph is routed
+  to the error path).
+- `main.cc` calls `nx_init_modules(iso)` once after `Isolate::New`,
+  `nx_run_entry_module(...)` to run the entrypoint, and `nx_modules_teardown()`
+  before isolate dispose. The host test binary mirrors these calls.
+
 ## Build System
 
 - **C code**: `Makefile` using devkitPro/libnx toolchain (aarch64, cross-compiled)

--- a/packages/runtime/test/CMakeLists.txt
+++ b/packages/runtime/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set(NX_SOURCES
   ${NX_SOURCE_DIR}/font.cc
   ${NX_SOURCE_DIR}/fs.cc
   ${NX_SOURCE_DIR}/image.cc
+  ${NX_SOURCE_DIR}/module.cc
   ${NX_SOURCE_DIR}/path2d.cc
   ${NX_SOURCE_DIR}/tcp.cc
   ${NX_SOURCE_DIR}/tls.cc

--- a/packages/runtime/test/fixtures/import-meta.ts
+++ b/packages/runtime/test/fixtures/import-meta.ts
@@ -1,0 +1,35 @@
+import { test } from '../src/tap';
+
+// `import.meta` and dynamic-import error semantics that are comparable between
+// nx.js (native ES module loader, see source/module.cc) and Chrome. Multi-file
+// static/dynamic import of sibling files is verified separately on-device
+// (the conformance harness injects fixture content inline, so there are no
+// sibling files to resolve here).
+
+test('import.meta.url is a non-empty string', (t) => {
+	t.equal(typeof import.meta.url, 'string', 'import.meta.url is a string');
+	t.ok(import.meta.url.length > 0, 'import.meta.url is non-empty');
+});
+
+test('dynamic import of a bare specifier rejects', async (t) => {
+	let threw = false;
+	try {
+		// A bare specifier (no ./, ../, /, or scheme) is not resolvable: nx.js
+		// has no node_modules/import-map semantics, and Chrome rejects an
+		// unmapped bare specifier too.
+		await import('this-is-a-bare-specifier-that-does-not-exist');
+	} catch {
+		threw = true;
+	}
+	t.ok(threw, 'import() of a bare specifier rejects');
+});
+
+test('dynamic import of a missing relative module rejects', async (t) => {
+	let threw = false;
+	try {
+		await import('./this-sibling-does-not-exist.mjs');
+	} catch {
+		threw = true;
+	}
+	t.ok(threw, 'import() of a missing module rejects');
+});

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -695,6 +695,12 @@ int main(int argc, char *argv[]) {
 		nx_ctx->exit_handler.Reset();
 		nx_ctx->init_obj.Reset();
 		nx_ctx->unhandled_rejected_promise.Reset();
+		// Release the module cache's Global<Module> handles while the isolate
+		// is still alive. Without this the static map in module.cc is destroyed
+		// at process exit, AFTER iso->Dispose() / V8::Dispose(), and the
+		// Global<> destructors touch a disposed isolate -> segfault. (The device
+		// runtime calls this before its iso->Dispose() too.)
+		nx_modules_teardown();
 	}
 
 	uv_walk(

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -38,6 +38,7 @@
 #include <psa/crypto.h>
 
 #include "error.h"
+#include "module.h"
 #include "types.h"
 #include "util.h"
 
@@ -287,59 +288,9 @@ static bool run_script(Isolate *iso, Local<Context> context, const char *src,
 	return true;
 }
 
-static const char *g_entrypoint_url = "";
-static MaybeLocal<Module> resolve_module_callback(Local<Context>,
-                                                  Local<String>,
-                                                  Local<FixedArray>,
-                                                  Local<Module>) {
-	Isolate *iso = Isolate::GetCurrent();
-	iso->ThrowException(
-	    Exception::Error(nx_str(iso, "module resolution not implemented")));
-	return MaybeLocal<Module>();
-}
-static void init_import_meta(Local<Context> context, Local<Module>,
-                             Local<Object> meta) {
-	Isolate *iso = Isolate::GetCurrent();
-	meta->CreateDataProperty(context, nx_str(iso, "url"),
-	                         nx_str(iso, g_entrypoint_url))
-	    .Check();
-	meta->CreateDataProperty(context, nx_str(iso, "main"), True(iso)).Check();
-}
-
-static bool run_module(Isolate *iso, Local<Context> context, const char *src,
-                       size_t len, const char *name) {
-	HandleScope scope(iso);
-	TryCatch try_catch(iso);
-	g_entrypoint_url = name;
-	Local<String> source;
-	if (!String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
-	         .ToLocal(&source)) {
-		fprintf(stderr,
-		        "Failed to load %s: source is %zu bytes, which exceeds V8's "
-		        "maximum string length\n",
-		        name, len);
-		return false;
-	}
-	ScriptOrigin origin(nx_str(iso, name), 0, 0, false, -1, Local<Value>(),
-	                    false, false, true);
-	ScriptCompiler::Source script_source(source, origin);
-	Local<Module> module;
-	if (!ScriptCompiler::CompileModule(iso, &script_source).ToLocal(&module)) {
-		print_js_error(iso, &try_catch);
-		return false;
-	}
-	if (module->InstantiateModule(context, resolve_module_callback)
-	        .IsNothing()) {
-		print_js_error(iso, &try_catch);
-		return false;
-	}
-	Local<Value> result;
-	if (!module->Evaluate(context).ToLocal(&result)) {
-		print_js_error(iso, &try_catch);
-		return false;
-	}
-	return true;
-}
+// ES module loading (static `import` + filesystem `await import()`) is shared
+// with the device runtime via source/module.cc (nx_init_modules /
+// nx_run_entry_module).
 
 // ---------------------------------------------------------------------------
 // $ bridge
@@ -634,7 +585,7 @@ int main(int argc, char *argv[]) {
 	nx_ctx->iso = iso;
 	iso->SetData(0, nx_ctx);
 	iso->SetPromiseRejectCallback(nx_promise_rejection_handler);
-	iso->SetHostInitializeImportMetaObjectCallback(init_import_meta);
+	nx_init_modules(iso); // import.meta + static/dynamic import (module.cc)
 	iso->SetMicrotasksPolicy(MicrotasksPolicy::kExplicit);
 
 	int exit_code = 0;
@@ -686,7 +637,7 @@ int main(int argc, char *argv[]) {
 		} else {
 			char url[4096];
 			snprintf(url, sizeof(url), "file://%s", script_path);
-			run_module(iso, context, sc_src, sc_len, url);
+			nx_run_entry_module(iso, context, sc_src, sc_len, url);
 		}
 		free(rt_src);
 		free(sc_src);

--- a/source/main.cc
+++ b/source/main.cc
@@ -21,6 +21,7 @@
 #include FT_FREETYPE_H
 
 #include "error.h"
+#include "module.h"
 #include "skia_gpu.h"
 #include "types.h"
 #include "util.h"
@@ -647,75 +648,6 @@ static bool run_script(Isolate *iso, Local<Context> context, const char *src,
 	return true;
 }
 
-// Minimal ES-module loader for the user entrypoint. (Full import resolution is
-// a follow-up; for now we run the entrypoint as a module with no static
-// imports resolvable, matching the common single-file app case.)
-static MaybeLocal<Module> resolve_module_callback(
-    Local<Context> context, Local<String> specifier,
-    Local<FixedArray> import_assertions, Local<Module> referrer) {
-	// TODO(phase1): real module resolution against romfs:/ + sdmc:/.
-	(void)context;
-	Isolate *iso = Isolate::GetCurrent();
-	iso->ThrowException(
-	    Exception::Error(nx_str(iso, "module resolution not implemented yet")));
-	return MaybeLocal<Module>();
-}
-
-// The entrypoint module's URL, used to populate import.meta.url. Single-file
-// app for now, so one global suffices.
-static const char *g_entrypoint_url = "";
-
-// Populates import.meta for the (single) entrypoint module: `url` (the module's
-// resource name) and `main` (true — the entrypoint is always the main module).
-static void init_import_meta(Local<Context> context, Local<Module> module,
-                             Local<Object> meta) {
-	Isolate *iso = Isolate::GetCurrent();
-	(void)module;
-	meta->CreateDataProperty(context, nx_str(iso, "url"),
-	                         nx_str(iso, g_entrypoint_url))
-	    .Check();
-	meta->CreateDataProperty(context, nx_str(iso, "main"), True(iso)).Check();
-}
-
-static bool run_module(Isolate *iso, Local<Context> context, const char *src,
-                       size_t len, const char *name) {
-	HandleScope scope(iso);
-	TryCatch try_catch(iso);
-	g_entrypoint_url = name;
-	// NewFromUtf8 returns an empty MaybeLocal if the source exceeds
-	// String::kMaxLength or a string allocation fails (e.g. tight applet
-	// memory). Don't .ToLocalChecked() — that would abort the process; report
-	// the failure instead.
-	Local<String> source;
-	if (!String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
-	         .ToLocal(&source)) {
-		nx_console_init(nx_ctx(iso));
-		fprintf(stderr,
-		        "Failed to load %s: source is %zu bytes, which exceeds V8's "
-		        "maximum string length\n",
-		        name, len);
-		return false;
-	}
-	ScriptOrigin origin(nx_str(iso, name), 0, 0, false, -1, Local<Value>(),
-	                    false, false, true /* is_module */);
-	ScriptCompiler::Source script_source(source, origin);
-	Local<Module> module;
-	if (!ScriptCompiler::CompileModule(iso, &script_source).ToLocal(&module)) {
-		nx_emit_error_event(iso, &try_catch);
-		return false;
-	}
-	if (module->InstantiateModule(context, resolve_module_callback)
-	        .IsNothing()) {
-		nx_emit_error_event(iso, &try_catch);
-		return false;
-	}
-	Local<Value> result;
-	if (!module->Evaluate(context).ToLocal(&result)) {
-		nx_emit_error_event(iso, &try_catch);
-		return false;
-	}
-	return true;
-}
 
 // ---------------------------------------------------------------------------
 // `$` bridge construction.
@@ -1091,7 +1023,8 @@ int main(int argc, char *argv[]) {
 	nx_ctx->iso = iso;
 	iso->SetData(0, nx_ctx);
 	iso->SetPromiseRejectCallback(nx_promise_rejection_handler);
-	iso->SetHostInitializeImportMetaObjectCallback(init_import_meta);
+	// ES module loading (import.meta + static/dynamic import); see module.cc.
+	nx_init_modules(iso);
 	// Microtasks are pumped explicitly from the loop.
 	iso->SetMicrotasksPolicy(MicrotasksPolicy::kExplicit);
 
@@ -1197,8 +1130,8 @@ int main(int argc, char *argv[]) {
 				nx_ctx->had_error = 1;
 			} else {
 				// Run the user entrypoint as an ES module.
-				run_module(iso, context, user_code, user_code_size,
-				           user_code_path);
+				nx_run_entry_module(iso, context, user_code, user_code_size,
+				                    user_code_path);
 			}
 		}
 
@@ -1324,6 +1257,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Release retained handles before disposing the isolate.
+	nx_modules_teardown();
 	nx_ctx->frame_handler.Reset();
 	nx_ctx->exit_handler.Reset();
 	nx_ctx->error_handler.Reset();

--- a/source/module.cc
+++ b/source/module.cc
@@ -1,0 +1,357 @@
+#include "module.h"
+#include "error.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <unordered_map>
+
+// ada's C API header has no extern "C" guard; the symbols are defined with C
+// linkage (see source/url.cc), so wrap the include to match.
+extern "C" {
+#include <ada_c.h>
+}
+
+using namespace v8;
+
+namespace {
+
+// resolved-URL -> Module, so the same URL always returns the same instance
+// (V8 requires referential stability; also handles import cycles).
+std::unordered_map<std::string, Global<Module>> g_module_cache;
+// Module identity hash -> resolved URL, to recover a referrer's base URL and to
+// populate import.meta.url per module.
+std::unordered_map<int, std::string> g_module_urls;
+// The entrypoint module's URL (drives import.meta.main).
+std::string g_entrypoint_url;
+
+void register_module(Isolate *iso, Local<Module> module,
+                     const std::string &url) {
+	g_module_cache[url].Reset(iso, module);
+	g_module_urls[module->GetIdentityHash()] = url;
+}
+
+// Read an entire file at `path` (a mounted devoptab URL, e.g. romfs:/x.js, or a
+// host path). Returns a malloc'd NUL-terminated buffer (caller frees) or NULL.
+char *read_module_file(const char *path, size_t *out_size) {
+	FILE *f = fopen(path, "rb");
+	if (!f)
+		return NULL;
+	fseek(f, 0, SEEK_END);
+	long n = ftell(f);
+	fseek(f, 0, SEEK_SET);
+	if (n < 0) {
+		fclose(f);
+		return NULL;
+	}
+	char *buf = (char *)malloc((size_t)n + 1);
+	if (!buf) {
+		fclose(f);
+		return NULL;
+	}
+	size_t rd = fread(buf, 1, (size_t)n, f);
+	fclose(f);
+	buf[rd] = '\0';
+	if (out_size)
+		*out_size = rd;
+	return buf;
+}
+
+// Resolve `specifier` against `base` (an absolute URL) into an absolute URL.
+// Returns false for bare specifiers or on parse failure.
+bool resolve_specifier(const std::string &base, const std::string &specifier,
+                       std::string &out) {
+	// Only relative ("./", "../"), absolute-path ("/x"), and absolute-URL
+	// ("scheme:...") specifiers are supported; bare specifiers are rejected.
+	bool is_relative =
+	    specifier.rfind("./", 0) == 0 || specifier.rfind("../", 0) == 0;
+	bool is_abs_path = !specifier.empty() && specifier[0] == '/';
+	bool has_scheme = !is_relative && !is_abs_path &&
+	                  specifier.find(':') != std::string::npos;
+	if (!is_relative && !is_abs_path && !has_scheme)
+		return false;
+
+	ada_url url = ada_parse_with_base(specifier.c_str(), specifier.size(),
+	                                  base.c_str(), base.size());
+	if (!ada_is_valid(url)) {
+		ada_free(url);
+		return false;
+	}
+	ada_string href = ada_get_href(url);
+	out.assign(href.data, href.length);
+	ada_free(url);
+	return true;
+}
+
+// Map a resolved module URL to a path that fopen() can open. Mounted devoptab
+// schemes (romfs:/sdmc:/nxjs:) are opened as-is. `file://` (host test binary)
+// is stripped to an absolute path.
+std::string url_to_fs_path(const std::string &url) {
+	if (url.rfind("file://", 0) == 0)
+		return url.substr(7);
+	if (url.rfind("file:", 0) == 0)
+		return url.substr(5);
+	return url;
+}
+
+// Compile (and cache) the module at the already-resolved absolute URL `url`.
+// On failure, schedules a V8 exception and returns an empty MaybeLocal.
+MaybeLocal<Module> load_module(Isolate *iso, const std::string &url) {
+	auto cached = g_module_cache.find(url);
+	if (cached != g_module_cache.end())
+		return cached->second.Get(iso);
+
+	std::string path = url_to_fs_path(url);
+	size_t len = 0;
+	char *src = read_module_file(path.c_str(), &len);
+	if (!src) {
+		char msg[1024];
+		snprintf(msg, sizeof(msg), "Cannot find module '%s'", url.c_str());
+		iso->ThrowException(Exception::Error(nx_str(iso, msg)));
+		return MaybeLocal<Module>();
+	}
+
+	Local<String> source;
+	bool ok = String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
+	              .ToLocal(&source);
+	free(src);
+	if (!ok) {
+		iso->ThrowException(Exception::Error(
+		    nx_str(iso, "module source too large or invalid UTF-8")));
+		return MaybeLocal<Module>();
+	}
+
+	ScriptOrigin origin(nx_str(iso, url.c_str()), 0, 0, false, -1,
+	                    Local<Value>(), false, false, true /* is_module */);
+	ScriptCompiler::Source script_source(source, origin);
+	Local<Module> module;
+	if (!ScriptCompiler::CompileModule(iso, &script_source).ToLocal(&module))
+		return MaybeLocal<Module>(); // CompileModule left an exception pending
+
+	// Register BEFORE returning so import cycles resolve to this instance.
+	register_module(iso, module, url);
+	return module;
+}
+
+// V8 static-import resolver: resolve `specifier` against the `referrer`'s URL.
+MaybeLocal<Module> resolve_module_callback(Local<Context> context,
+                                           Local<String> specifier,
+                                           Local<FixedArray> import_assertions,
+                                           Local<Module> referrer) {
+	Isolate *iso = Isolate::GetCurrent();
+	(void)context;
+	(void)import_assertions; // JSON / asset modules are a future addition.
+
+	auto it = g_module_urls.find(referrer->GetIdentityHash());
+	std::string base = it != g_module_urls.end() ? it->second : g_entrypoint_url;
+
+	String::Utf8Value spec(iso, specifier);
+	std::string resolved;
+	if (!resolve_specifier(base, std::string(*spec, spec.length()), resolved)) {
+		char msg[1024];
+		snprintf(msg, sizeof(msg),
+		         "Cannot find module '%s' imported from '%s' (only relative "
+		         "and absolute-URL specifiers are supported)",
+		         *spec ? *spec : "", base.c_str());
+		iso->ThrowException(Exception::Error(nx_str(iso, msg)));
+		return MaybeLocal<Module>();
+	}
+	return load_module(iso, resolved);
+}
+
+// Instantiate + evaluate a loaded module. Returns the evaluation result
+// (a Promise; pending if the graph uses top-level await), or empty on failure.
+MaybeLocal<Value> instantiate_and_evaluate(Isolate *iso,
+                                           Local<Context> context,
+                                           Local<Module> module) {
+	if (module->InstantiateModule(context, resolve_module_callback).IsNothing())
+		return MaybeLocal<Value>();
+	return module->Evaluate(context);
+}
+
+void init_import_meta(Local<Context> context, Local<Module> module,
+                      Local<Object> meta) {
+	Isolate *iso = Isolate::GetCurrent();
+	auto it = g_module_urls.find(module->GetIdentityHash());
+	const std::string &url =
+	    it != g_module_urls.end() ? it->second : g_entrypoint_url;
+	meta->CreateDataProperty(context, nx_str(iso, "url"),
+	                         nx_str(iso, url.c_str()))
+	    .Check();
+	meta->CreateDataProperty(context, nx_str(iso, "main"),
+	                         Boolean::New(iso, url == g_entrypoint_url))
+	    .Check();
+}
+
+// HostImportModuleDynamicallyCallback: backs `import()` for filesystem schemes.
+// The whole graph loads synchronously (fopen), so resolve the returned promise
+// with the module namespace once evaluation completes (chaining on the
+// evaluation promise so top-level await in the imported graph is awaited).
+MaybeLocal<Promise> dynamic_import_callback(
+    Local<Context> context, Local<Data> host_defined_options,
+    Local<Value> resource_name, Local<String> specifier,
+    Local<FixedArray> import_attributes) {
+	Isolate *iso = Isolate::GetCurrent();
+	(void)host_defined_options;
+	(void)import_attributes;
+
+	Local<Promise::Resolver> resolver;
+	if (!Promise::Resolver::New(context).ToLocal(&resolver))
+		return MaybeLocal<Promise>(); // OOM: propagate as empty
+
+	// Base URL: the importing module/script's resource name.
+	std::string base;
+	if (resource_name->IsString()) {
+		String::Utf8Value rn(iso, resource_name);
+		base.assign(*rn ? *rn : "", rn.length());
+	}
+	if (base.empty())
+		base = g_entrypoint_url;
+
+	String::Utf8Value spec(iso, specifier);
+	std::string resolved;
+
+	TryCatch try_catch(iso);
+	bool failed = false;
+	Local<Value> error;
+
+	if (!resolve_specifier(base, std::string(*spec, spec.length()), resolved)) {
+		char msg[1024];
+		snprintf(msg, sizeof(msg), "Cannot find module '%s' imported from '%s'",
+		         *spec ? *spec : "", base.c_str());
+		error = Exception::Error(nx_str(iso, msg));
+		failed = true;
+	}
+
+	Local<Module> module;
+	if (!failed && !load_module(iso, resolved).ToLocal(&module)) {
+		error = try_catch.Exception();
+		failed = true;
+	}
+
+	Local<Value> eval_result;
+	if (!failed &&
+	    !instantiate_and_evaluate(iso, context, module).ToLocal(&eval_result)) {
+		error = try_catch.Exception();
+		failed = true;
+	}
+
+	if (failed) {
+		if (error.IsEmpty())
+			error = Exception::Error(nx_str(iso, "dynamic import failed"));
+		resolver->Reject(context, error).Check();
+		return resolver->GetPromise();
+	}
+
+	// `eval_result` is the module's evaluation promise (settled unless the
+	// graph uses top-level await). `import()` must resolve to the namespace
+	// once evaluation completes.
+	Local<Promise> eval_promise = eval_result.As<Promise>();
+	Local<Value> ns = module->GetModuleNamespace();
+	if (eval_promise->State() == Promise::kFulfilled) {
+		resolver->Resolve(context, ns).Check();
+	} else if (eval_promise->State() == Promise::kRejected) {
+		resolver->Reject(context, eval_promise->Result()).Check();
+	} else {
+		// Pending (top-level await): chain eval-completion -> namespace by
+		// resolving with `eval_promise.then(() => ns)`. The namespace is
+		// stashed in the then-callback's Data.
+		Local<Object> data = Object::New(iso);
+		data->Set(context, nx_str(iso, "ns"), ns).Check();
+		Local<Function> on_ok =
+		    Function::New(
+		        context,
+		        [](const FunctionCallbackInfo<Value> &info) {
+			        Local<Context> ctx =
+			            info.GetIsolate()->GetCurrentContext();
+			        Local<Object> d = info.Data().As<Object>();
+			        info.GetReturnValue().Set(
+			            d->Get(ctx, nx_str(info.GetIsolate(), "ns"))
+			                .ToLocalChecked());
+		        },
+		        data)
+		        .ToLocalChecked();
+		Local<Promise> mapped;
+		if (eval_promise->Then(context, on_ok).ToLocal(&mapped))
+			resolver->Resolve(context, mapped).Check();
+		else
+			resolver->Resolve(context, ns).Check();
+	}
+	return resolver->GetPromise();
+}
+
+} // namespace
+
+void nx_init_modules(Isolate *iso) {
+	iso->SetHostInitializeImportMetaObjectCallback(init_import_meta);
+	iso->SetHostImportModuleDynamicallyCallback(dynamic_import_callback);
+}
+
+bool nx_run_entry_module(Isolate *iso, Local<Context> context, const char *src,
+                         size_t len, const char *name) {
+	HandleScope scope(iso);
+	TryCatch try_catch(iso);
+	g_entrypoint_url = name;
+
+	Local<String> source;
+	if (!String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
+	         .ToLocal(&source)) {
+		nx_console_init(nx_ctx(iso));
+		fprintf(stderr,
+		        "Failed to load %s: source is %zu bytes, which exceeds V8's "
+		        "maximum string length\n",
+		        name, len);
+		return false;
+	}
+
+	ScriptOrigin origin(nx_str(iso, name), 0, 0, false, -1, Local<Value>(),
+	                    false, false, true /* is_module */);
+	ScriptCompiler::Source script_source(source, origin);
+	Local<Module> module;
+	if (!ScriptCompiler::CompileModule(iso, &script_source).ToLocal(&module)) {
+		nx_emit_error_event(iso, &try_catch);
+		return false;
+	}
+	register_module(iso, module, name);
+
+	Local<Value> result;
+	if (!instantiate_and_evaluate(iso, context, module).ToLocal(&result)) {
+		nx_emit_error_event(iso, &try_catch);
+		return false;
+	}
+
+	// `result` is the evaluation promise. If the entrypoint graph uses
+	// top-level await and rejects, surface it via the error path rather than
+	// letting it become a silent unhandled rejection.
+	if (result->IsPromise()) {
+		Local<Promise> p = result.As<Promise>();
+		if (p->State() == Promise::kRejected) {
+			iso->ThrowException(p->Result());
+			nx_emit_error_event(iso, &try_catch);
+			return false;
+		}
+		if (p->State() == Promise::kPending) {
+			Local<Function> on_reject;
+			if (Function::New(context,
+			                  [](const FunctionCallbackInfo<Value> &info) {
+				                  Isolate *i = info.GetIsolate();
+				                  TryCatch tc(i);
+				                  i->ThrowException(info[0]);
+				                  nx_emit_error_event(i, &tc);
+			                  })
+			        .ToLocal(&on_reject)) {
+				Local<Promise> caught;
+				if (!p->Catch(context, on_reject).ToLocal(&caught)) {
+					// best-effort; ignore failure to attach the handler
+				}
+			}
+		}
+	}
+	return true;
+}
+
+void nx_modules_teardown() {
+	g_module_cache.clear(); // Global<Module> destructors release the handles
+	g_module_urls.clear();
+	g_entrypoint_url.clear();
+}

--- a/source/module.h
+++ b/source/module.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "types.h"
+
+// Defined by each runtime entrypoint (device main.cc / host test main.cc);
+// switches the screen to the libnx text console (no-op on the host).
+void nx_console_init(nx_context_t *nx_ctx);
+
+// ---------------------------------------------------------------------------
+// ES module loading (static `import` + filesystem `await import()`).
+//
+// Shared by both the device runtime (source/main.cc) and the host test binary
+// (packages/runtime/test/src/main.cc) so the two never drift. Specifiers are
+// resolved as URLs (via `ada`) against the importing module's URL and read
+// synchronously with read_file()/fopen, so only mounted devoptab schemes
+// (romfs:, sdmc:, nxjs:, file:) work; bare specifiers are rejected.
+// ---------------------------------------------------------------------------
+
+// Register the host module callbacks on the isolate:
+//   - SetHostInitializeImportMetaObjectCallback (import.meta.url / .main)
+//   - SetHostImportModuleDynamicallyCallback   (filesystem `import()`)
+// Call once, after Isolate::New.
+void nx_init_modules(v8::Isolate *iso);
+
+// Compile + instantiate + evaluate `src` (length `len`) as the entrypoint ES
+// module, recorded under URL `name` (its ScriptOrigin resource name and
+// import.meta.url base). Resolves static + dynamic imports against the
+// filesystem. Returns false on failure (the error is reported via
+// nx_emit_error_event). Handles top-level await: a rejected async graph is
+// surfaced via the error path rather than becoming a silent unhandled
+// rejection.
+bool nx_run_entry_module(v8::Isolate *iso, v8::Local<v8::Context> context,
+                         const char *src, size_t len, const char *name);
+
+// Release retained module handles (call before disposing the isolate).
+void nx_modules_teardown();


### PR DESCRIPTION
## Summary

The runtime now resolves ES `import` at runtime against the filesystem, so apps can ship **unbundled multi-file modules** (and lazily `await import()` feature modules) instead of always esbuild-bundling. This is additive — bundled apps are unaffected.

Shared logic lives in **`source/module.cc` + `module.h`**, compiled by **both** the device runtime (`source/main.cc`) and the host test binary (`packages/runtime/test/src/main.cc`), so the two never drift (no mirrored implementations).

## Behavior

- **Specifiers resolve as URLs** (via `ada`) against the importing module's URL: relative (`./`, `../`), absolute-path (`/x.js`), and absolute-URL (`romfs:`/`sdmc:`/`nxjs:`/`file:`) work. **Bare specifiers throw** (no node_modules / import maps).
- **Synchronous** resolution (`fopen`/`read_file`), so only mounted devoptab schemes work. `http(s):`/`data:` and JSON/asset (synthetic) modules are future additions.
- **Module cache** keyed by resolved URL → referential stability (a shared dependency imported via multiple paths is one instance) and cycle handling.
- **`import.meta.url`** is each module's resolved URL; **`import.meta.main`** is true only for the entrypoint.
- **Static `import`** via `ResolveModuleCallback`; **filesystem `await import()`** via `SetHostImportModuleDynamicallyCallback` (resolves with the module namespace, chaining on the evaluation promise so a top-level-await graph is awaited first).
- **Top-level await** in the entrypoint is surfaced to the error path on rejection instead of becoming a silent unhandled rejection.

`main.cc` calls `nx_init_modules(iso)` once after `Isolate::New`, `nx_run_entry_module(...)` for the entrypoint, and `nx_modules_teardown()` before isolate dispose.

## Verification

- **Device** (unbundled multi-file app, 15/15 checks): static `import` from `romfs:`, shared **module cache** (one `dep.js` instance across two import paths), **per-module** `import.meta.url` (`romfs:/dep.js`, `romfs:/dep2.js`, `romfs:/lazy.js`) with `import.meta.main === false` and the entry `=== true`, `await import('./lazy.js')`, and missing-module / bare-specifier rejection.
- **Host** `nxjs-test` builds + links with the shared `module.cc`; a direct functional run passes the same checks.
- Adds an `import-meta` conformance fixture for the cross-engine-comparable subset (`import.meta.url` is a string; bare / missing dynamic imports reject). Full multi-file static-import comparison is done on-device because the conformance harness injects fixture content inline (no sibling files served to Chrome).

## Out of scope (future)

- JSON modules / asset imports (`import x from './a.json' with { type: 'json' }`) via V8 synthetic modules.
- Remote/`data:` dynamic `import()` (needs an async loader).