### PR TITLE
fix: GPU screen present uses kSrc blend (transparent-pixel additive bug)

### DIFF
--- a/.changeset/gpu-transparent-present.md
+++ b/.changeset/gpu-transparent-present.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: the GPU screen renderer now blits the canvas into the EGL back buffer with `SkBlendMode::kSrc` instead of the default `kSrcOver`, so transparent/partially-transparent pixels fully replace the (double-buffered, stale) back buffer each frame instead of blending it through and looking additive — matching the CPU raster path.

--- a/source/skia_gpu.cc
+++ b/source/skia_gpu.cc
@@ -156,7 +156,7 @@ void nx_skia_gpu_present(void) {
 		// stale destination through, making output look additive across
 		// frames. kSrc copies the surface verbatim — including alpha — so each
 		// present fully replaces the back buffer, matching the CPU raster path
-		// (which memcpy's the pixels straight into the framebuffer).
+		// (which memcpy()s the pixels straight into the framebuffer).
 		SkPaint paint;
 		paint.setBlendMode(SkBlendMode::kSrc);
 		c->drawImage(img, 0, 0, SkSamplingOptions(), &paint);

--- a/source/skia_gpu.cc
+++ b/source/skia_gpu.cc
@@ -5,11 +5,13 @@
 #include <GLES2/gl2.h>
 #include <stdio.h>
 
+#include "include/core/SkBlendMode.h"
 #include "include/core/SkCanvas.h"
 #include "include/core/SkColorSpace.h"
 #include "include/core/SkGraphics.h"
 #include "include/core/SkImage.h"
 #include "include/core/SkImageInfo.h"
+#include "include/core/SkPaint.h"
 #include "include/core/SkSamplingOptions.h"
 #include "include/core/SkSurface.h"
 #include "include/gpu/GpuTypes.h"
@@ -147,7 +149,17 @@ void nx_skia_gpu_present(void) {
 	sk_sp<SkImage> img = s_canvas->makeImageSnapshot();
 	if (img) {
 		SkCanvas *c = s_fbo->getCanvas();
-		c->drawImage(img, 0, 0, SkSamplingOptions(), nullptr);
+		// Use kSrc (source-replace), NOT the default kSrcOver: the EGL back
+		// buffer is double-buffered and retains stale content (the previous
+		// frame, or uninitialized garbage). With kSrcOver, any transparent /
+		// partially-transparent pixel in the canvas surface would blend the
+		// stale destination through, making output look additive across
+		// frames. kSrc copies the surface verbatim — including alpha — so each
+		// present fully replaces the back buffer, matching the CPU raster path
+		// (which memcpy's the pixels straight into the framebuffer).
+		SkPaint paint;
+		paint.setBlendMode(SkBlendMode::kSrc);
+		c->drawImage(img, 0, 0, SkSamplingOptions(), &paint);
 	}
 	s_gr->flush(s_fbo.get());
 	s_gr->submit();


### PR DESCRIPTION
## Summary

- The GPU screen renderer composites the persistent canvas surface into the **double-buffered** EGL back buffer every frame. That blit used the default `kSrcOver` blend mode, so where the canvas had **transparent / partially-transparent** pixels, the stale back-buffer content (the previous frame, or uninitialized garbage) blended through — output looked **additive** and didn't reset each frame.
- Fix: blit with `SkBlendMode::kSrc` (source-replace) so each present copies the canvas surface verbatim, fully replacing the back buffer regardless of double buffering.

## Why this is correct

- This matches the **CPU raster path**, which `memcpy`s the canvas pixels straight into the libnx framebuffer (a verbatim copy, no blend). The reporter confirmed CPU mode is unaffected.
- It completes the earlier persistent-canvas/composite fix (#`795d485`/`b82f076`), which solved the *opaque* stale-buffer case but left the blend mode at `kSrcOver`, so the *transparent* case still leaked the stale destination.

## Testing

- Builds cleanly (devkitPro/Skia; `SkPaint` + `SkBlendMode::kSrc`).
- ⚠️ **On-device verification still pending** (hardware not currently available). Repro plan: in GPU/application mode, `clearRect` the whole screen to transparent each frame and draw a single moving box — with the bug, previous frames ghost/trail; with the fix, only the current frame shows. Will confirm on-device before merge.

## Notes

- `@nx.js/runtime` **patch** changeset included.