### PR TITLE
feat: nxjs.ini application configuration file

### DIFF
--- a/.changeset/nxjs-ini-config.md
+++ b/.changeset/nxjs-ini-config.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": minor
+---
+
+feat: optional `nxjs.ini` config file (read next to the entrypoint, before V8 init) lets an app override V8 JIT mode + flags (`[v8] jit/flags`), the V8 heap limit (`[memory] heap_limit`, clamped to what fits), the renderer (`[renderer] mode = auto|cpu|gpu`), and the libnx socket config (`[socket]` fields incl. `service_type`); effective values are exposed on `$.config`, and any value that can't be honored is logged to `nxjs-debug.log` with the reason.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,54 @@ The `$.entrypoint` gives the base URL for resolving relative paths.
 2. Else (standalone): mount self as `romfs:`, run `romfs:/main.js`; fall back to
    `<argv0>.js` next to the `.nro` on the SD card.
 
+The entrypoint resolution (`resolve_entrypoint()`) runs **early in `main()`, before
+V8 init** — not because the app code runs early, but because `nxjs.ini` (below)
+lives next to the entrypoint and its V8/heap settings must apply before
+`V8::Initialize()`/`Isolate::New`.
+
+### Configuration (`nxjs.ini`)
+
+An optional INI file located **next to the entrypoint** (`romfs:/nxjs.ini` for a
+standalone/bootstrap app, `<dir>/nxjs.ini` for a loose `.js`). Parsed very early
+in `main()` with the bundled `source/vendor/ini.h` (inih), using plain `fopen` —
+the JS `fetch`/`readFileSync` layer doesn't exist yet, and the `[v8]`/`[memory]`
+settings must be applied before the isolate is created. Lives in
+`source/config.cc`/`config.h` (`nx_config_t` on `nx_context_t`).
+
+```ini
+[v8]
+jit   = auto                       ; auto (regime-based) | on | off
+flags = --max-old-space-size=256   ; appended AFTER the runtime's default V8 flags
+
+[memory]
+heap_limit = 256MiB                ; KiB/MiB/GiB or raw bytes; clamped to fit
+
+[renderer]
+mode = auto                        ; auto | cpu | gpu (gpu falls back to raster on init fail)
+
+[socket]                           ; field-level overrides on the regime base (lean/full)
+tcp_tx_buf_size = 256KiB
+tcp_rx_buf_size = 256KiB
+tcp_tx_buf_max_size = 1MiB
+tcp_rx_buf_max_size = 1MiB
+udp_tx_buf_size = 9KiB
+udp_rx_buf_size = 42KiB
+sb_efficiency = 6
+num_bsd_sessions = 3
+service_type = auto                ; auto | user | system
+```
+
+- **Effective** (post-clamp) values are exposed to JS as `$.config`
+  (`{ jit, heapLimit, renderer, v8Flags, socket:{…}, loaded }`).
+- **Every value that can't be honored is logged** to `nxjs-debug.log` as a
+  `[config] … not honored: <reason>` line (clamped heap, invalid value, GPU
+  init fallback, socket reservation too big, etc.). A missing file is silent.
+- `jit` is honored verbatim (no clamp): JIT works in applet mode for CPU
+  rendering; only **applet + GPU + JIT** is known to crash (jitCreate starves
+  Mesa) — that combo is warned about but still attempted.
+- The host `nxjs-test` reads **no** INI; its `build_init_object` exposes a
+  default `$.config`. Keep that mirror in sync if you change `$.config`'s shape.
+
 ### ES module `import` (static + dynamic)
 
 `source/module.cc` (shared by the device runtime and the host test binary, so
@@ -259,6 +307,7 @@ The `screen` global is the main display (1280×720). Use `screen.getContext('2d'
 - **Globals like `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval` are NOT available inside `packages/runtime/src/`** — they're only registered as globals in `index.ts` for user code. Within the runtime package itself, import them: `import { setInterval, clearInterval } from './timers';`
 - **Gamepad button mapping** is NOT standard Web Gamepad API order. Use `@nx.js/constants` `Button` enum (e.g. `Button.A`, `Button.B`). The order is: B=0, A=1, Y=2, X=3, L=4, R=5, ZL=6, ZR=7, Minus=8, Plus=9, StickL=10, StickR=11, Up=12, Down=13, Left=14, Right=15
 - **`stub()` does NOT mean unimplemented.** Methods marked with `stub()` in TypeScript (from `./utils`) are placeholders for type generation only. At runtime, the C side overwrites them on the prototype via `NX_DEF_FUNC()` or `NX_DEF_GET()`/`NX_DEF_GETSET()`. If you see `stub()`, check the corresponding C file's `nx_init_*` or `*_init_class` function — the real implementation is there. Only `throw new Error('Method not implemented.')` means actually not implemented.
+- **`nxjs.ini` must be read before `V8::Initialize()`** (for `[v8]`/`[memory]`), so entrypoint resolution is hoisted to the top of `main()` and the INI is parsed with plain `fopen` (via `source/vendor/ini.h`), NOT the JS `readFileSync`. The `[v8] jit` setting drives `can_jit`, which **couples** the V8 flags (`--jitless`), the heap `reserve` (180 vs 48 MiB), AND the code-range size (64 MiB vs 0) — override `can_jit` once, don't touch those three independently. Socket overrides are clamped so a bad value can't make `socketInitialize` (which `diagAbortWithResult`s on failure) brick startup. Any non-honored value logs `[config] … not honored: <reason>` to `nxjs-debug.log`.
 
 ## Host-Platform Test Binary (`nxjs-test`)
 

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -55,6 +55,36 @@ type DecompressHandle = Opaque<'DecompressHandle'>;
 type SaveDataIterator = Opaque<'SaveDataIterator'>;
 type URLSearchParamsIterator = Opaque<'URLSearchParamsIterator'>;
 
+/** Effective socket (libnx SocketInitConfig) values, after nxjs.ini overrides. */
+export interface NxSocketConfig {
+	tcpTxBufSize: number;
+	tcpRxBufSize: number;
+	tcpTxBufMaxSize: number;
+	tcpRxBufMaxSize: number;
+	udpTxBufSize: number;
+	udpRxBufSize: number;
+	sbEfficiency: number;
+	numBsdSessions: number;
+	/** libnx BsdServiceType: 1=user, 2=system, 3=auto. */
+	serviceType: number;
+}
+
+/** Effective application config (from `nxjs.ini`); values reflect post-clamp reality. */
+export interface NxConfig {
+	/** Whether V8 JIT is enabled (vs jitless interpreter). */
+	jit: boolean;
+	/** Effective V8 max heap size in bytes (0 if the computed default was used unmodified). */
+	heapLimit: number;
+	/** Requested renderer mode. */
+	renderer: 'auto' | 'cpu' | 'gpu';
+	/** App-provided V8 flag string applied after the runtime defaults (empty if none). */
+	v8Flags: string;
+	/** Effective libnx socket configuration. */
+	socket: NxSocketConfig;
+	/** Whether an `nxjs.ini` file was found and parsed. */
+	loaded: boolean;
+}
+
 export interface Init {
 	// account.c
 	accountInitialize(): () => void;
@@ -344,6 +374,8 @@ export interface Init {
 	version: Versions;
 	/** Configured bsdsocket TCP receive buffer size (bytes) for this memory regime. */
 	tcpRxBufSize: number;
+	/** Effective application config parsed from `nxjs.ini` (next to the entrypoint). */
+	config: NxConfig;
 	exit(): never;
 	queueMicrotask(callback: () => void): void;
 	cwd(): string;

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -73,7 +73,7 @@ export interface NxSocketConfig {
 export interface NxConfig {
 	/** Whether V8 JIT is enabled (vs jitless interpreter). */
 	jit: boolean;
-	/** Effective V8 max heap size in bytes (0 if the computed default was used unmodified). */
+	/** Effective V8 max heap size in bytes (post-clamp; the value actually passed to V8). */
 	heapLimit: number;
 	/** Requested renderer mode. */
 	renderer: 'auto' | 'cpu' | 'gpu';

--- a/packages/runtime/test/src/compat/switch.h
+++ b/packages/runtime/test/src/compat/switch.h
@@ -686,7 +686,9 @@ static inline Result splGetConfig(SplConfigItem item, u64 *out) {
 // ============================================================================
 
 typedef enum {
-	BsdServiceType_Auto = 0,
+	BsdServiceType_User = 1,   // BIT(0)
+	BsdServiceType_System = 2, // BIT(1)
+	BsdServiceType_Auto = 3,   // User | System
 } BsdServiceType;
 
 typedef struct {

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -404,7 +404,10 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 			conf->Set(context, nx_str(iso, k), v).Check();
 		};
 		cset("jit", Boolean::New(iso, true));
-		cset("heapLimit", Number::New(iso, 0.0));
+		// Device exposes the effective (post-clamp) max heap in bytes, never 0;
+		// report the device application-regime cap (512 MiB) so host fixtures
+		// see the same semantics.
+		cset("heapLimit", Number::New(iso, 512.0 * 1024 * 1024));
 		cset("renderer", nx_str(iso, "auto"));
 		cset("v8Flags", nx_str(iso, ""));
 

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -395,6 +395,41 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	          Integer::NewFromUnsigned(iso, 1024u * 1024u))
 	    .Check();
 
+	// `$.config`: the host reads no nxjs.ini, so expose defaults matching the
+	// device application regime. Mirrors the device build_init_object so
+	// fixtures that read `$.config` see the same shape.
+	{
+		Local<Object> conf = Object::New(iso);
+		auto cset = [&](const char *k, Local<Value> v) {
+			conf->Set(context, nx_str(iso, k), v).Check();
+		};
+		cset("jit", Boolean::New(iso, true));
+		cset("heapLimit", Number::New(iso, 0.0));
+		cset("renderer", nx_str(iso, "auto"));
+		cset("v8Flags", nx_str(iso, ""));
+
+		Local<Object> sock = Object::New(iso);
+		auto sset = [&](const char *k, uint32_t v) {
+			sock->Set(context, nx_str(iso, k),
+			          Integer::NewFromUnsigned(iso, v))
+			    .Check();
+		};
+		sset("tcpTxBufSize", 256u * 1024u);
+		sset("tcpRxBufSize", 256u * 1024u);
+		sset("tcpTxBufMaxSize", 1024u * 1024u);
+		sset("tcpRxBufMaxSize", 1024u * 1024u);
+		sset("udpTxBufSize", 0x2400u);
+		sset("udpRxBufSize", 0xA500u);
+		sset("sbEfficiency", 6u);
+		sset("numBsdSessions", 3u);
+		sset("serviceType", 3u); // BsdServiceType_Auto
+		conf->Set(context, nx_str(iso, "socket"), sock).Check();
+
+		conf->Set(context, nx_str(iso, "loaded"), Boolean::New(iso, false))
+		    .Check();
+		init_obj->Set(context, nx_str(iso, "config"), conf).Check();
+	}
+
 	Local<Object> argv = Object::New(iso);  // not used by fixtures
 	(void)argv;
 }

--- a/source/config.cc
+++ b/source/config.cc
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,14 +33,19 @@ static bool str_ieq(const char *a, const char *b) {
 }
 
 // Parse a size string: decimal digits with optional KiB/MiB/GiB/KB/MB/GB/K/M/G
-// suffix (case-insensitive), or raw bytes. Returns true on success.
+// suffix (case-insensitive), or raw bytes. Returns true on success. Detects
+// both strtoull range overflow and overflow of the value*multiplier product so
+// a huge value can't silently wrap to a small (apparently valid) size.
 static bool parse_size(const char *s, uint64_t *out) {
 	if (!s || !*s)
 		return false;
+	errno = 0;
 	char *end = NULL;
 	unsigned long long v = strtoull(s, &end, 10);
 	if (end == s)
 		return false; // no digits
+	if (errno == ERANGE)
+		return false; // value itself overflowed uint64
 	while (*end == ' ' || *end == '\t')
 		end++;
 	uint64_t mult = 1;
@@ -53,6 +59,9 @@ static bool parse_size(const char *s, uint64_t *out) {
 		else
 			return false; // unknown suffix
 	}
+	// Guard the multiply against uint64 overflow.
+	if (mult != 0 && (uint64_t)v > UINT64_MAX / mult)
+		return false;
 	*out = (uint64_t)v * mult;
 	return true;
 }
@@ -296,33 +305,65 @@ void nx_config_apply_socket(SocketInitConfig *base, const nx_config_t *cfg,
 	// Total transfer-memory reservation must fit the regime. The libnx BSD
 	// service reserves ~(tcp_tx_max + tcp_rx_max + udp_tx + udp_rx) *
 	// sb_efficiency. Cap the reservation: 16 MiB in applet (tight) mode,
-	// 64 MiB in application mode. If over, scale the TCP max buffers down.
+	// 64 MiB in application mode. Because socketInitialize() failure is fatal
+	// (diagAbortWithResult), this clamp MUST be exhaustive: a misconfigured INI
+	// with huge UDP buffers and/or a high sb_efficiency must not be able to keep
+	// the reservation above the cap. Shrink contributors in order — TCP max
+	// buffers, then UDP buffers, then sb_efficiency — and as a final guarantee
+	// solve for an sb_efficiency that fits.
 	uint64_t cap = (tight_memory ? 16ull : 64ull) * 1024 * 1024;
-	for (int guard = 0; guard < 8; guard++) {
+	auto reservation = [&]() -> uint64_t {
 		uint64_t per = (uint64_t)base->tcp_tx_buf_max_size +
 		               base->tcp_rx_buf_max_size + base->udp_tx_buf_size +
 		               base->udp_rx_buf_size;
-		uint64_t total = per * base->sb_efficiency;
-		if (total <= cap)
-			break;
+		return per * base->sb_efficiency;
+	};
+	if (reservation() > cap) {
 		cfg_log("socket buffers not honored: reservation ~%llu MiB exceeds the "
-		        "%llu MiB %s-mode cap; halving tcp_*_buf_max_size",
-		        (unsigned long long)(total / (1024 * 1024)),
+		        "%llu MiB %s-mode cap; shrinking buffers to fit",
+		        (unsigned long long)(reservation() / (1024 * 1024)),
 		        (unsigned long long)(cap / (1024 * 1024)),
 		        tight_memory ? "applet" : "application");
-		base->tcp_tx_buf_max_size =
-		    base->tcp_tx_buf_max_size > 16384 ? base->tcp_tx_buf_max_size / 2
-		                                      : base->tcp_tx_buf_max_size;
-		base->tcp_rx_buf_max_size =
-		    base->tcp_rx_buf_max_size > 16384 ? base->tcp_rx_buf_max_size / 2
-		                                      : base->tcp_rx_buf_max_size;
+
+		// 1) Halve TCP max buffers down to a 16 KiB floor.
+		while (reservation() > cap &&
+		       (base->tcp_tx_buf_max_size > 16384 ||
+		        base->tcp_rx_buf_max_size > 16384)) {
+			if (base->tcp_tx_buf_max_size > 16384)
+				base->tcp_tx_buf_max_size /= 2;
+			if (base->tcp_rx_buf_max_size > 16384)
+				base->tcp_rx_buf_max_size /= 2;
+		}
+		// 2) Halve UDP buffers down to a 2 KiB floor.
+		while (reservation() > cap && (base->udp_tx_buf_size > 2048 ||
+		                               base->udp_rx_buf_size > 2048)) {
+			if (base->udp_tx_buf_size > 2048)
+				base->udp_tx_buf_size /= 2;
+			if (base->udp_rx_buf_size > 2048)
+				base->udp_rx_buf_size /= 2;
+		}
+		// 3) Solve for the largest sb_efficiency (>=1) that still fits, as a
+		//    hard guarantee the reservation is <= cap.
+		uint64_t per = (uint64_t)base->tcp_tx_buf_max_size +
+		               base->tcp_rx_buf_max_size + base->udp_tx_buf_size +
+		               base->udp_rx_buf_size;
+		if (per == 0)
+			per = 1; // avoid div-by-zero; reservation is then 0 anyway
+		uint64_t max_eff = cap / per;
+		if (max_eff < 1)
+			max_eff = 1; // floor: a single set of buffers must still be allowed
+		if (base->sb_efficiency > max_eff)
+			base->sb_efficiency = (uint32_t)max_eff;
+
+		// Keep the initial buffer sizes <= their (possibly reduced) max.
 		if (base->tcp_tx_buf_size > base->tcp_tx_buf_max_size)
 			base->tcp_tx_buf_size = base->tcp_tx_buf_max_size;
 		if (base->tcp_rx_buf_size > base->tcp_rx_buf_max_size)
 			base->tcp_rx_buf_size = base->tcp_rx_buf_max_size;
-		if (base->tcp_tx_buf_max_size <= 16384 &&
-		    base->tcp_rx_buf_max_size <= 16384)
-			break; // can't shrink further
+
+		cfg_log("socket reservation now ~%llu MiB (cap %llu MiB)",
+		        (unsigned long long)(reservation() / (1024 * 1024)),
+		        (unsigned long long)(cap / (1024 * 1024)));
 	}
 }
 

--- a/source/config.cc
+++ b/source/config.cc
@@ -1,0 +1,334 @@
+#include "config.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#define INI_IMPLEMENTATION
+#include "vendor/ini.h"
+
+// ---------------------------------------------------------------------------
+// Logging helper: every value that can't be honored prints a `[config]` line
+// to stderr (redirected to sdmc:/switch/nxjs-debug.log on device).
+// ---------------------------------------------------------------------------
+static void cfg_log(const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	fputs("[config] ", stderr);
+	vfprintf(stderr, fmt, ap);
+	fputc('\n', stderr);
+	va_end(ap);
+	fflush(stderr);
+}
+
+// ---------------------------------------------------------------------------
+// Value parsers.
+// ---------------------------------------------------------------------------
+
+static bool str_ieq(const char *a, const char *b) {
+	return strcasecmp(a, b) == 0;
+}
+
+// Parse a size string: decimal digits with optional KiB/MiB/GiB/KB/MB/GB/K/M/G
+// suffix (case-insensitive), or raw bytes. Returns true on success.
+static bool parse_size(const char *s, uint64_t *out) {
+	if (!s || !*s)
+		return false;
+	char *end = NULL;
+	unsigned long long v = strtoull(s, &end, 10);
+	if (end == s)
+		return false; // no digits
+	while (*end == ' ' || *end == '\t')
+		end++;
+	uint64_t mult = 1;
+	if (*end) {
+		if (str_ieq(end, "k") || str_ieq(end, "kb") || str_ieq(end, "kib"))
+			mult = 1024ull;
+		else if (str_ieq(end, "m") || str_ieq(end, "mb") || str_ieq(end, "mib"))
+			mult = 1024ull * 1024;
+		else if (str_ieq(end, "g") || str_ieq(end, "gb") || str_ieq(end, "gib"))
+			mult = 1024ull * 1024 * 1024;
+		else
+			return false; // unknown suffix
+	}
+	*out = (uint64_t)v * mult;
+	return true;
+}
+
+static bool parse_u32(const char *s, uint32_t *out) {
+	uint64_t v;
+	if (!parse_size(s, &v))
+		return false;
+	if (v > 0xFFFFFFFFull)
+		return false;
+	*out = (uint32_t)v;
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// inih handler.
+// ---------------------------------------------------------------------------
+
+static int ini_cb(void *user, const char *section, const char *name,
+                  const char *value) {
+	nx_config_t *cfg = (nx_config_t *)user;
+	if (!section || !name || !value)
+		return 1;
+
+	if (str_ieq(section, "v8")) {
+		if (str_ieq(name, "jit")) {
+			if (str_ieq(value, "auto"))
+				cfg->jit = NX_JIT_AUTO;
+			else if (str_ieq(value, "on") || str_ieq(value, "true") ||
+			         str_ieq(value, "1"))
+				cfg->jit = NX_JIT_ON;
+			else if (str_ieq(value, "off") || str_ieq(value, "false") ||
+			         str_ieq(value, "0"))
+				cfg->jit = NX_JIT_OFF;
+			else
+				cfg_log("v8.jit=\"%s\" not honored: invalid (use auto|on|off), "
+				        "using auto",
+				        value);
+		} else if (str_ieq(name, "flags")) {
+			free(cfg->v8_flags);
+			cfg->v8_flags = strdup(value);
+		} else {
+			cfg_log("v8.%s ignored: unknown key", name);
+		}
+		return 1;
+	}
+
+	if (str_ieq(section, "memory")) {
+		if (str_ieq(name, "heap_limit")) {
+			uint64_t v;
+			if (parse_size(value, &v))
+				cfg->heap_limit = v;
+			else
+				cfg_log("memory.heap_limit=\"%s\" not honored: invalid size, "
+				        "using computed default",
+				        value);
+		} else {
+			cfg_log("memory.%s ignored: unknown key", name);
+		}
+		return 1;
+	}
+
+	if (str_ieq(section, "renderer")) {
+		if (str_ieq(name, "mode")) {
+			if (str_ieq(value, "auto"))
+				cfg->renderer = NX_RENDER_AUTO;
+			else if (str_ieq(value, "cpu") || str_ieq(value, "raster"))
+				cfg->renderer = NX_RENDER_CPU;
+			else if (str_ieq(value, "gpu"))
+				cfg->renderer = NX_RENDER_GPU;
+			else
+				cfg_log("renderer.mode=\"%s\" not honored: invalid "
+				        "(use auto|cpu|gpu), using auto",
+				        value);
+		} else {
+			cfg_log("renderer.%s ignored: unknown key", name);
+		}
+		return 1;
+	}
+
+	if (str_ieq(section, "socket")) {
+		nx_socket_config_t *s = &cfg->socket;
+		uint32_t u;
+		if (str_ieq(name, "tcp_tx_buf_size")) {
+			if (parse_u32(value, &u)) { s->tcp_tx_buf_size = u; s->has_tcp_tx_buf_size = true; }
+			else cfg_log("socket.tcp_tx_buf_size=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "tcp_rx_buf_size")) {
+			if (parse_u32(value, &u)) { s->tcp_rx_buf_size = u; s->has_tcp_rx_buf_size = true; }
+			else cfg_log("socket.tcp_rx_buf_size=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "tcp_tx_buf_max_size")) {
+			if (parse_u32(value, &u)) { s->tcp_tx_buf_max_size = u; s->has_tcp_tx_buf_max_size = true; }
+			else cfg_log("socket.tcp_tx_buf_max_size=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "tcp_rx_buf_max_size")) {
+			if (parse_u32(value, &u)) { s->tcp_rx_buf_max_size = u; s->has_tcp_rx_buf_max_size = true; }
+			else cfg_log("socket.tcp_rx_buf_max_size=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "udp_tx_buf_size")) {
+			if (parse_u32(value, &u)) { s->udp_tx_buf_size = u; s->has_udp_tx_buf_size = true; }
+			else cfg_log("socket.udp_tx_buf_size=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "udp_rx_buf_size")) {
+			if (parse_u32(value, &u)) { s->udp_rx_buf_size = u; s->has_udp_rx_buf_size = true; }
+			else cfg_log("socket.udp_rx_buf_size=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "sb_efficiency")) {
+			if (parse_u32(value, &u)) { s->sb_efficiency = u; s->has_sb_efficiency = true; }
+			else cfg_log("socket.sb_efficiency=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "num_bsd_sessions")) {
+			if (parse_u32(value, &u)) { s->num_bsd_sessions = u; s->has_num_bsd_sessions = true; }
+			else cfg_log("socket.num_bsd_sessions=\"%s\" not honored: invalid", value);
+		} else if (str_ieq(name, "service_type")) {
+			if (str_ieq(value, "auto")) { s->service_type = BsdServiceType_Auto; s->has_service_type = true; }
+			else if (str_ieq(value, "user")) { s->service_type = BsdServiceType_User; s->has_service_type = true; }
+			else if (str_ieq(value, "system")) { s->service_type = BsdServiceType_System; s->has_service_type = true; }
+			else cfg_log("socket.service_type=\"%s\" not honored: invalid (use auto|user|system)", value);
+		} else {
+			cfg_log("socket.%s ignored: unknown key", name);
+		}
+		return 1;
+	}
+
+	cfg_log("[%s] section ignored: unknown", section);
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Public API.
+// ---------------------------------------------------------------------------
+
+void nx_config_defaults(nx_config_t *cfg) {
+	memset(cfg, 0, sizeof(*cfg));
+	cfg->jit = NX_JIT_AUTO;
+	cfg->renderer = NX_RENDER_AUTO;
+	cfg->v8_flags = NULL;
+	cfg->heap_limit = 0;
+	cfg->loaded = false;
+}
+
+bool nx_config_load(nx_config_t *cfg, const char *ini_path) {
+	if (!ini_path)
+		return false;
+	// fopen-based: missing file -> ini_parse returns -1. A positive return is
+	// the line number of the first parse error (handler still ran for valid
+	// lines). We treat any "file existed" outcome as loaded.
+	int rc = ini_parse(ini_path, ini_cb, cfg);
+	if (rc == -1) {
+		// File not present (or unreadable). Silent for the common no-config
+		// case; nothing to honor/explain.
+		return false;
+	}
+	if (rc == -2) {
+		cfg_log("nxjs.ini at %s: out of memory while parsing; using defaults",
+		        ini_path);
+		return false;
+	}
+	if (rc > 0) {
+		cfg_log("nxjs.ini at %s: parse error near line %d (other settings "
+		        "still applied)",
+		        ini_path, rc);
+	}
+	cfg->loaded = true;
+	return true;
+}
+
+char *nx_config_ini_path_for(const char *entrypoint) {
+	if (!entrypoint)
+		return NULL;
+	// Replace the basename (everything after the last '/') with "nxjs.ini".
+	const char *slash = strrchr(entrypoint, '/');
+	size_t dir_len = slash ? (size_t)(slash - entrypoint) + 1 : 0;
+	const char *fname = "nxjs.ini";
+	size_t out_len = dir_len + strlen(fname) + 1;
+	char *out = (char *)malloc(out_len);
+	if (!out)
+		return NULL;
+	if (dir_len)
+		memcpy(out, entrypoint, dir_len);
+	memcpy(out + dir_len, fname, strlen(fname) + 1);
+	return out;
+}
+
+void nx_config_apply_socket(SocketInitConfig *base, const nx_config_t *cfg,
+                            bool tight_memory) {
+	const nx_socket_config_t *s = &cfg->socket;
+
+	if (s->has_tcp_tx_buf_size)
+		base->tcp_tx_buf_size = s->tcp_tx_buf_size;
+	if (s->has_tcp_rx_buf_size)
+		base->tcp_rx_buf_size = s->tcp_rx_buf_size;
+	if (s->has_tcp_tx_buf_max_size)
+		base->tcp_tx_buf_max_size = s->tcp_tx_buf_max_size;
+	if (s->has_tcp_rx_buf_max_size)
+		base->tcp_rx_buf_max_size = s->tcp_rx_buf_max_size;
+	if (s->has_udp_tx_buf_size)
+		base->udp_tx_buf_size = s->udp_tx_buf_size;
+	if (s->has_udp_rx_buf_size)
+		base->udp_rx_buf_size = s->udp_rx_buf_size;
+	if (s->has_sb_efficiency)
+		base->sb_efficiency = s->sb_efficiency;
+	if (s->has_num_bsd_sessions)
+		base->num_bsd_sessions = s->num_bsd_sessions;
+	if (s->has_service_type)
+		base->bsd_service_type = s->service_type;
+
+	// --- Validation / clamping (each clamp is logged) -----------------------
+
+	// A buffer's initial size can't exceed its max.
+	if (base->tcp_tx_buf_size > base->tcp_tx_buf_max_size) {
+		cfg_log("socket.tcp_tx_buf_size (%u) not honored: exceeds "
+		        "tcp_tx_buf_max_size (%u), clamped",
+		        base->tcp_tx_buf_size, base->tcp_tx_buf_max_size);
+		base->tcp_tx_buf_size = base->tcp_tx_buf_max_size;
+	}
+	if (base->tcp_rx_buf_size > base->tcp_rx_buf_max_size) {
+		cfg_log("socket.tcp_rx_buf_size (%u) not honored: exceeds "
+		        "tcp_rx_buf_max_size (%u), clamped",
+		        base->tcp_rx_buf_size, base->tcp_rx_buf_max_size);
+		base->tcp_rx_buf_size = base->tcp_rx_buf_max_size;
+	}
+
+	// sb_efficiency: libnx expects a small multiplier; clamp to [1, 8].
+	if (base->sb_efficiency < 1) {
+		cfg_log("socket.sb_efficiency (%u) not honored: below 1, clamped to 1",
+		        base->sb_efficiency);
+		base->sb_efficiency = 1;
+	} else if (base->sb_efficiency > 8) {
+		cfg_log("socket.sb_efficiency (%u) not honored: above 8, clamped to 8",
+		        base->sb_efficiency);
+		base->sb_efficiency = 8;
+	}
+
+	// num_bsd_sessions: valid range is 1..4 (libnx allows up to 4 sockets
+	// service sessions). Clamp.
+	if (base->num_bsd_sessions < 1) {
+		cfg_log("socket.num_bsd_sessions (%u) not honored: below 1, clamped to 1",
+		        base->num_bsd_sessions);
+		base->num_bsd_sessions = 1;
+	} else if (base->num_bsd_sessions > 4) {
+		cfg_log("socket.num_bsd_sessions (%u) not honored: above 4, clamped to 4",
+		        base->num_bsd_sessions);
+		base->num_bsd_sessions = 4;
+	}
+
+	// Total transfer-memory reservation must fit the regime. The libnx BSD
+	// service reserves ~(tcp_tx_max + tcp_rx_max + udp_tx + udp_rx) *
+	// sb_efficiency. Cap the reservation: 16 MiB in applet (tight) mode,
+	// 64 MiB in application mode. If over, scale the TCP max buffers down.
+	uint64_t cap = (tight_memory ? 16ull : 64ull) * 1024 * 1024;
+	for (int guard = 0; guard < 8; guard++) {
+		uint64_t per = (uint64_t)base->tcp_tx_buf_max_size +
+		               base->tcp_rx_buf_max_size + base->udp_tx_buf_size +
+		               base->udp_rx_buf_size;
+		uint64_t total = per * base->sb_efficiency;
+		if (total <= cap)
+			break;
+		cfg_log("socket buffers not honored: reservation ~%llu MiB exceeds the "
+		        "%llu MiB %s-mode cap; halving tcp_*_buf_max_size",
+		        (unsigned long long)(total / (1024 * 1024)),
+		        (unsigned long long)(cap / (1024 * 1024)),
+		        tight_memory ? "applet" : "application");
+		base->tcp_tx_buf_max_size =
+		    base->tcp_tx_buf_max_size > 16384 ? base->tcp_tx_buf_max_size / 2
+		                                      : base->tcp_tx_buf_max_size;
+		base->tcp_rx_buf_max_size =
+		    base->tcp_rx_buf_max_size > 16384 ? base->tcp_rx_buf_max_size / 2
+		                                      : base->tcp_rx_buf_max_size;
+		if (base->tcp_tx_buf_size > base->tcp_tx_buf_max_size)
+			base->tcp_tx_buf_size = base->tcp_tx_buf_max_size;
+		if (base->tcp_rx_buf_size > base->tcp_rx_buf_max_size)
+			base->tcp_rx_buf_size = base->tcp_rx_buf_max_size;
+		if (base->tcp_tx_buf_max_size <= 16384 &&
+		    base->tcp_rx_buf_max_size <= 16384)
+			break; // can't shrink further
+	}
+}
+
+void nx_config_free(nx_config_t *cfg) {
+	if (!cfg)
+		return;
+	free(cfg->v8_flags);
+	cfg->v8_flags = NULL;
+}

--- a/source/config.h
+++ b/source/config.h
@@ -1,0 +1,126 @@
+#pragma once
+
+// nx.js application configuration (`nxjs.ini`).
+//
+// An optional INI file located next to the entrypoint (e.g. `romfs:/nxjs.ini`
+// for a standalone/bootstrap app, or `sdmc:/switch/app.ini`-style next to a
+// loose `.js`). It lets an app override runtime knobs that otherwise default
+// from the memory regime:
+//
+//   [v8]
+//   jit   = auto            ; auto (regime-based) | on | off
+//   flags = --expose-gc     ; appended after the runtime's default V8 flags
+//
+//   [memory]
+//   heap_limit = 256MiB     ; KiB/MiB/GiB suffix or raw bytes; clamped to fit
+//
+//   [renderer]
+//   mode = auto             ; auto | cpu | gpu
+//
+//   [socket]                ; overrides on the regime-selected SocketInitConfig
+//   tcp_tx_buf_size     = 256KiB
+//   tcp_rx_buf_size     = 256KiB
+//   tcp_tx_buf_max_size = 1MiB
+//   tcp_rx_buf_max_size = 1MiB
+//   udp_tx_buf_size     = 9KiB
+//   udp_rx_buf_size     = 42KiB
+//   sb_efficiency       = 6
+//   num_bsd_sessions    = 3
+//   service_type        = auto   ; auto | user | system
+//
+// Parsing happens VERY early in main() (before V8::Initialize), using plain
+// fopen via the bundled inih parser, because the V8 flag/heap settings must be
+// applied before the isolate is created. The JS `fetch`/`readFileSync` layer
+// does not exist that early.
+//
+// Whenever a requested value cannot be honored (clamped, invalid, or an init
+// fell back), the runtime logs a `[config] ... not honored: <reason>` line to
+// stderr (which is redirected to `sdmc:/switch/nxjs-debug.log`).
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <switch.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+	NX_JIT_AUTO = 0, // regime-based (today's behavior): JIT off in applet mode
+	NX_JIT_ON,
+	NX_JIT_OFF,
+} nx_jit_mode_t;
+
+typedef enum {
+	NX_RENDER_AUTO = 0, // regime-based: raster in applet, GPU (w/ fallback) in app
+	NX_RENDER_CPU,      // force raster
+	NX_RENDER_GPU,      // attempt GPU regardless of regime (falls back to raster)
+} nx_render_mode_t;
+
+// Socket overrides. Each field has a `has_*` flag; when false, the
+// regime-selected default (lean/full) value is kept for that field.
+typedef struct {
+	bool has_tcp_tx_buf_size;
+	uint32_t tcp_tx_buf_size;
+	bool has_tcp_rx_buf_size;
+	uint32_t tcp_rx_buf_size;
+	bool has_tcp_tx_buf_max_size;
+	uint32_t tcp_tx_buf_max_size;
+	bool has_tcp_rx_buf_max_size;
+	uint32_t tcp_rx_buf_max_size;
+	bool has_udp_tx_buf_size;
+	uint32_t udp_tx_buf_size;
+	bool has_udp_rx_buf_size;
+	uint32_t udp_rx_buf_size;
+	bool has_sb_efficiency;
+	uint32_t sb_efficiency;
+	bool has_num_bsd_sessions;
+	uint32_t num_bsd_sessions;
+	bool has_service_type;
+	BsdServiceType service_type;
+} nx_socket_config_t;
+
+typedef struct {
+	nx_jit_mode_t jit;
+	char *v8_flags;       // strdup'd app-provided flag string, or NULL
+	uint64_t heap_limit;  // requested heap max in bytes; 0 = use computed default
+	nx_render_mode_t renderer;
+	nx_socket_config_t socket;
+	bool loaded;          // true if an nxjs.ini was found + parsed
+
+	// Effective values, filled in by main() after clamping, for diagnostics
+	// (exposed to JS via `$.config`). `effective_renderer` is the requested
+	// mode; the actual GPU-vs-raster outcome isn't known until the lazy
+	// framebuffer init and is logged there.
+	bool effective_jit;
+	uint64_t effective_heap_limit; // bytes actually passed to V8
+} nx_config_t;
+
+// Initialize `cfg` to defaults (everything auto/unset).
+void nx_config_defaults(nx_config_t *cfg);
+
+// Parse the INI at `ini_path` into `cfg` (which should already hold defaults).
+// A missing file is not an error (cfg keeps defaults, loaded=false). Invalid
+// values are logged and left at their default. Returns true if a file was
+// found and parsed (even with per-value errors), false if absent/unreadable.
+bool nx_config_load(nx_config_t *cfg, const char *ini_path);
+
+// Derive the `nxjs.ini` path that sits next to `entrypoint`. Returns a malloc'd
+// string the caller must free, or NULL on allocation failure / null input.
+// e.g. "romfs:/main.js" -> "romfs:/nxjs.ini"; "sdmc:/switch/app.js" ->
+// "sdmc:/switch/nxjs.ini"; "romfs:/main.js" with no '/' after scheme handled.
+char *nx_config_ini_path_for(const char *entrypoint);
+
+// Apply the socket overrides in `cfg` on top of `base` (the regime-selected
+// SocketInitConfig), clamping each field to a safe/valid range and logging any
+// value that could not be honored. `tight_memory` selects the per-regime
+// ceiling used for clamping the total buffer reservation.
+void nx_config_apply_socket(SocketInitConfig *base, const nx_config_t *cfg,
+                            bool tight_memory);
+
+// Free any heap memory owned by `cfg` (the v8_flags string).
+void nx_config_free(nx_config_t *cfg);
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/config.h
+++ b/source/config.h
@@ -89,9 +89,9 @@ typedef struct {
 	bool loaded;          // true if an nxjs.ini was found + parsed
 
 	// Effective values, filled in by main() after clamping, for diagnostics
-	// (exposed to JS via `$.config`). `effective_renderer` is the requested
-	// mode; the actual GPU-vs-raster outcome isn't known until the lazy
-	// framebuffer init and is logged there.
+	// (exposed to JS via `$.config`). There is no effective_renderer field: the
+	// requested mode lives in `renderer` above, and the actual GPU-vs-raster
+	// outcome isn't known until the lazy framebuffer init (it's logged there).
 	bool effective_jit;
 	uint64_t effective_heap_limit; // bytes actually passed to V8
 } nx_config_t;

--- a/source/main.cc
+++ b/source/main.cc
@@ -338,9 +338,27 @@ static void nx_framebuffer_init(const FunctionCallbackInfo<Value> &info) {
 	//     incorrect. Raster is fully correct and fits. (This also avoids the
 	//     EGL-mid-loop HID issue that only affected applet+GPU.)
 	// A failed GPU init in application mode still falls back to raster below.
+	//
+	// nxjs.ini [renderer] mode overrides this: `auto` keeps the regime default;
+	// `cpu` forces raster; `gpu` attempts GPU even in applet mode. GPU init that
+	// returns null ALWAYS falls back to raster (never a hard failure), so `gpu`
+	// can't crash startup.
+	bool want_gpu;
+	switch (ctx->config.renderer) {
+	case NX_RENDER_CPU:
+		want_gpu = false;
+		break;
+	case NX_RENDER_GPU:
+		want_gpu = true;
+		break;
+	case NX_RENDER_AUTO:
+	default:
+		want_gpu = !g_tight_memory;
+		break;
+	}
 	sk_sp<SkSurface> gpu =
-	    g_tight_memory ? nullptr
-	                   : nx_skia_gpu_screen_init(width, height, /*samples=*/4);
+	    want_gpu ? nx_skia_gpu_screen_init(width, height, /*samples=*/4)
+	             : nullptr;
 	if (gpu) {
 		nx_canvas_set_gpu_surface(canvas, gpu);
 		screen_is_gpu = true;
@@ -358,9 +376,19 @@ static void nx_framebuffer_init(const FunctionCallbackInfo<Value> &info) {
 			padInitialize(&ctx->pads[i], (HidNpadIdType)(HidNpadIdType_No1 + i));
 		}
 	} else {
-		fprintf(stderr, "[skia] using raster path (%s)\n",
-		        g_tight_memory ? "applet regime"
-		                       : "GPU init failed, falling back");
+		// Explain why raster was chosen. If the app explicitly asked for GPU
+		// but init failed, log it as a config value that wasn't honored.
+		if (ctx->config.renderer == NX_RENDER_GPU) {
+			fprintf(stderr,
+			        "[config] renderer.mode=gpu not honored: GPU/EGL init "
+			        "failed, falling back to CPU raster\n");
+		} else {
+			fprintf(stderr, "[skia] using raster path (%s)\n",
+			        ctx->config.renderer == NX_RENDER_CPU
+			            ? "renderer.mode=cpu"
+			            : (g_tight_memory ? "applet regime"
+			                              : "GPU init failed, falling back"));
+		}
 		fflush(stderr);
 		screen_is_gpu = false;
 		js_framebuffer = nx_canvas_pixels(canvas);
@@ -658,10 +686,15 @@ static bool run_script(Isolate *iso, Local<Context> context, const char *src,
 // (1 MiB in application mode, 128 KiB in the lean applet config) instead of
 // hard-coding 1 MiB and over-allocating the limited ArrayBuffer pool.
 static u32 nx_selected_tcp_rx_buf_size(void);
+// The effective SocketInitConfig passed to socketInitialize() (regime base +
+// nxjs.ini overrides). Forward-declared so build_init_object() can expose it on
+// `$.config.socket`; defined alongside the socket configs below.
+static const SocketInitConfig *nx_effective_socket_cfg(void);
 
 static void build_init_object(Isolate *iso, Local<Context> context,
                               Local<Object> init_obj, const char *entrypoint,
-                              int argc, char *argv[]) {
+                              int argc, char *argv[],
+                              const nx_config_t *cfg) {
 	nx_init_account(iso, init_obj);
 	nx_init_album(iso, init_obj);
 	nx_init_applet(iso, init_obj);
@@ -785,6 +818,48 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	    ->Set(context, nx_str(iso, "tcpRxBufSize"),
 	          Integer::NewFromUnsigned(iso, nx_selected_tcp_rx_buf_size()))
 	    .Check();
+
+	// Switch-side config (`$.config`): the EFFECTIVE values applied from
+	// nxjs.ini (after clamping/regime defaults), for diagnostics. Mirrors the
+	// `version` object pattern above.
+	{
+		Local<Object> conf = Object::New(iso);
+		auto cset = [&](const char *k, Local<Value> v) {
+			conf->Set(context, nx_str(iso, k), v).Check();
+		};
+		cset("jit", Boolean::New(iso, cfg->effective_jit));
+		cset("heapLimit",
+		     Number::New(iso, (double)cfg->effective_heap_limit));
+		const char *rmode = cfg->renderer == NX_RENDER_CPU   ? "cpu"
+		                    : cfg->renderer == NX_RENDER_GPU ? "gpu"
+		                                                     : "auto";
+		cset("renderer", nx_str(iso, rmode));
+		cset("v8Flags",
+		     nx_str_lossy(iso, cfg->v8_flags ? cfg->v8_flags : ""));
+
+		const SocketInitConfig *esc = nx_effective_socket_cfg();
+		Local<Object> sock = Object::New(iso);
+		auto sset = [&](const char *k, u32 v) {
+			sock->Set(context, nx_str(iso, k),
+			          Integer::NewFromUnsigned(iso, v))
+			    .Check();
+		};
+		sset("tcpTxBufSize", esc->tcp_tx_buf_size);
+		sset("tcpRxBufSize", esc->tcp_rx_buf_size);
+		sset("tcpTxBufMaxSize", esc->tcp_tx_buf_max_size);
+		sset("tcpRxBufMaxSize", esc->tcp_rx_buf_max_size);
+		sset("udpTxBufSize", esc->udp_tx_buf_size);
+		sset("udpRxBufSize", esc->udp_rx_buf_size);
+		sset("sbEfficiency", esc->sb_efficiency);
+		sset("numBsdSessions", esc->num_bsd_sessions);
+		sset("serviceType", (u32)esc->bsd_service_type);
+		conf->Set(context, nx_str(iso, "socket"), sock).Check();
+
+		conf->Set(context, nx_str(iso, "loaded"),
+		          Boolean::New(iso, cfg->loaded))
+		    .Check();
+		init_obj->Set(context, nx_str(iso, "config"), conf).Check();
+	}
 }
 
 // BsdServiceType_Auto (tries bsd:s first) is intentional: bsd:s is required to
@@ -837,11 +912,80 @@ static SocketInitConfig const s_socketInitConfigLean = {
     .bsd_service_type = BsdServiceType_Auto,
 };
 
-// tcp_rx_buf_size of whichever config socketInitialize() selected for this
-// memory regime (gated on g_tight_memory, set before socketInitialize).
+// The SocketInitConfig actually passed to socketInitialize() — the
+// regime-selected base after any [socket] nxjs.ini overrides + clamping. Set
+// once in main() before socketInitialize. Initialized to the full config so a
+// read before assignment (shouldn't happen) is still sane.
+static SocketInitConfig g_effective_socket_cfg = s_socketInitConfigFull;
+
+// tcp_rx_buf_size of the config socketInitialize() actually used (so the JS
+// socket layer sizes its read buffer to match the native config).
 static u32 nx_selected_tcp_rx_buf_size(void) {
-	return (g_tight_memory ? s_socketInitConfigLean : s_socketInitConfigFull)
-	    .tcp_rx_buf_size;
+	return g_effective_socket_cfg.tcp_rx_buf_size;
+}
+
+static const SocketInitConfig *nx_effective_socket_cfg(void) {
+	return &g_effective_socket_cfg;
+}
+
+// Resolve the user entrypoint and (for standalone / bootstrap-.nro launches)
+// mount `romfs:`. Hoisted out of main()'s body so it can run BEFORE V8 init:
+// the entrypoint directory is needed to locate `nxjs.ini`, whose [v8]/[memory]
+// settings must be applied before the isolate is created. Two launch models:
+//
+//   1. Bootstrap launch: `argv[1]` is an explicit entrypoint passed by a thin
+//      launcher. Either a `.nro` (mount its embedded romfs as `romfs:`, run
+//      `romfs:/main.js`) or any other path (typically `.js`: run it directly).
+//   2. Standalone app (no argv[1]): the app's own NRO romfs holds `main.js` +
+//      assets, so mount self as `romfs:` and run `romfs:/main.js`; fall back to
+//      `<nro>.js` next to the NRO on the SD card.
+static void resolve_entrypoint(nx_context_t *nx_ctx, int argc, char *argv[],
+                               char **out_path, char **out_code,
+                               size_t *out_size, bool *out_needs_free) {
+	*out_path = NULL;
+	*out_code = NULL;
+	*out_size = 0;
+	*out_needs_free = false;
+	Result rc;
+
+	if (argc > 1 && argv[1] && argv[1][0]) {
+		// Bootstrap launch with an explicit entrypoint.
+		if (path_has_suffix(argv[1], ".nro")) {
+			rc = mount_nro_romfs(argv[1], "romfs");
+			if (R_FAILED(rc)) {
+				nx_console_init(nx_ctx);
+				printf("Failed to mount romfs from %s (0x%x)\n", argv[1], rc);
+				nx_ctx->had_error = 1;
+			} else {
+				*out_path = (char *)"romfs:/main.js";
+				*out_code = (char *)read_file(*out_path, out_size);
+			}
+		} else {
+			*out_needs_free = true;
+			*out_path = strdup(argv[1]);
+			if (*out_path) {
+				*out_code = (char *)read_file(*out_path, out_size);
+			}
+		}
+	} else {
+		// Standalone app: this NRO's own romfs is the app. Also expose it as
+		// `romfs:` (it is already mounted as `nxjs:` for the runtime's files).
+		// romfsMountSelf opens our NRO file again with an independent handle, so
+		// the second mount coexists with the `nxjs:` one.
+		rc = romfsMountSelf("romfs");
+		if (R_SUCCEEDED(rc)) {
+			*out_path = (char *)"romfs:/main.js";
+			*out_code = (char *)read_file(*out_path, out_size);
+		}
+		if (*out_code == NULL && errno == ENOENT && argc > 0) {
+			*out_needs_free = true;
+			*out_path = strdup(argv[0]);
+			if (*out_path) {
+				replace_file_extension(*out_path, ".js");
+				*out_code = (char *)read_file(*out_path, out_size);
+			}
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -887,16 +1031,50 @@ int main(int argc, char *argv[]) {
 	bool tight_memory = mem_total <= (1024ull * 1024 * 1024);
 	g_tight_memory = tight_memory;
 
-	rc = socketInitialize(tight_memory ? &s_socketInitConfigLean
-	                                    : &s_socketInitConfigFull);
+	// Redirect stderr to the on-SD debug log NOW (before socket init and the
+	// config parse) so that `[config]`/`[v8]`/`[skia]` diagnostics — including
+	// any "value not honored" lines from the nxjs.ini parse below — are
+	// captured to sdmc:/switch/nxjs-debug.log.
+	FILE *debug_fd = freopen(LOG_FILENAME, "w", stderr);
+
+	// Resolve the app entrypoint up front (this is the hoisted version of the
+	// block that used to run after V8 init). We need the entrypoint path early
+	// because (a) `nxjs.ini` lives next to it, and (b) the V8 flag/heap/JIT
+	// settings it can override MUST be applied before V8::Initialize() below.
+	// This mounts `romfs:` (for standalone / bootstrap-.nro launches) and reads
+	// the user code. The actual evaluation still happens much later.
+	size_t user_code_size = 0;
+	bool user_path_needs_free = false;
+	char *user_code_path = NULL;
+	char *user_code = NULL;
+	resolve_entrypoint(nx_ctx, argc, argv, &user_code_path, &user_code,
+	                   &user_code_size, &user_path_needs_free);
+
+	// Parse `nxjs.ini` (next to the entrypoint) into the per-isolate config.
+	// Missing/unreadable file -> defaults, silently. Done before socket init +
+	// V8 init so every setting can take effect.
+	nx_config_defaults(&nx_ctx->config);
+	if (user_code_path) {
+		char *ini_path = nx_config_ini_path_for(user_code_path);
+		if (ini_path) {
+			nx_config_load(&nx_ctx->config, ini_path);
+			free(ini_path);
+		}
+	}
+
+	// Socket buffers: start from the regime-selected base, then apply any
+	// [socket] overrides from nxjs.ini (clamped + logged).
+	SocketInitConfig socket_cfg =
+	    tight_memory ? s_socketInitConfigLean : s_socketInitConfigFull;
+	nx_config_apply_socket(&socket_cfg, &nx_ctx->config, tight_memory);
+	g_effective_socket_cfg = socket_cfg;
+	rc = socketInitialize(&socket_cfg);
 	if (R_FAILED(rc))
 		diagAbortWithResult(rc);
 
 	rc = plInitialize(PlServiceType_User);
 	if (R_FAILED(rc))
 		diagAbortWithResult(rc);
-
-	FILE *debug_fd = freopen(LOG_FILENAME, "w", stderr);
 
 	// libuv loop.
 	uv_loop_t loop;
@@ -912,11 +1090,38 @@ int main(int argc, char *argv[]) {
 
 	// Memory-gated JIT policy: full-JIT's libnx jitCreate dual-maps a >=64 MiB
 	// code range (~128 MiB real). In applet mode (~137 MiB free) that starves
-	// the GPU/Mesa stack, so when free memory is tight we fall back to jitless
-	// (interpreter) + raster canvas; application mode (~3 GiB) runs full JIT +
-	// GPU. mem_free / tight_memory were probed before socketInitialize above.
-	// ~300 MiB headroom: code arena (128 MiB real) + GPU/Mesa + JS heap.
-	bool can_jit = !tight_memory;
+	// the GPU/Mesa stack, so by default we fall back to jitless (interpreter) +
+	// raster canvas when free memory is tight; application mode (~3 GiB) runs
+	// full JIT + GPU. mem_free / tight_memory were probed before
+	// socketInitialize above. ~300 MiB headroom: code arena (128 MiB real) +
+	// GPU/Mesa + JS heap.
+	//
+	// nxjs.ini [v8] jit overrides this: `auto` keeps the regime default; `on`
+	// forces full JIT; `off` forces jitless. JIT is honored verbatim (no clamp)
+	// — JIT in applet mode is fine for CPU rendering; only the applet + GPU +
+	// JIT combination is known to crash (jitCreate starves Mesa), for which we
+	// emit a warning below but still proceed.
+	bool can_jit;
+	switch (nx_ctx->config.jit) {
+	case NX_JIT_ON:
+		can_jit = true;
+		break;
+	case NX_JIT_OFF:
+		can_jit = false;
+		break;
+	case NX_JIT_AUTO:
+	default:
+		can_jit = !tight_memory;
+		break;
+	}
+	nx_ctx->config.effective_jit = can_jit;
+	if (nx_ctx->config.jit == NX_JIT_ON && tight_memory &&
+	    nx_ctx->config.renderer == NX_RENDER_GPU) {
+		fprintf(stderr,
+		        "[config] jit=on + renderer=gpu in applet regime: known-"
+		        "unstable (V8 jitCreate starves Mesa); may crash\n");
+		fflush(stderr);
+	}
 
 	if (can_jit) {
 		V8::SetFlagsFromString("--single-threaded --single-threaded-gc "
@@ -926,16 +1131,25 @@ int main(int argc, char *argv[]) {
 		                       "--single-threaded-gc "
 		                       "--no-concurrent-recompilation --predictable");
 	}
+	// App-provided V8 flags, applied AFTER the runtime defaults so they take
+	// precedence (V8's later SetFlagsFromString wins). Advanced/at-own-risk:
+	// V8 silently ignores unknown flags, so we just record what was applied.
+	if (nx_ctx->config.v8_flags && nx_ctx->config.v8_flags[0]) {
+		fprintf(stderr, "[config] applying app V8 flags: \"%s\"\n",
+		        nx_ctx->config.v8_flags);
+		V8::SetFlagsFromString(nx_ctx->config.v8_flags);
+	}
 	// Report the memory gate + JIT mode. When JIT is on, the linked monolith
 	// tiers up Ignition -> Sparkplug -> Maglev -> TurboFan; jitless is Ignition
 	// only.
 	fprintf(stderr,
-	        "[v8] mem_total=%llu MiB free=%llu MiB regime=%s -> mode=%s (%s)\n",
+	        "[v8] mem_total=%llu MiB free=%llu MiB regime=%s -> mode=%s (%s)%s\n",
 	        (unsigned long long)(mem_total / (1024 * 1024)),
 	        (unsigned long long)(mem_free / (1024 * 1024)),
 	        tight_memory ? "applet" : "application",
 	        can_jit ? "jit" : "jitless",
-	        can_jit ? "Ignition+Sparkplug+Maglev+TurboFan" : "Ignition only");
+	        can_jit ? "Ignition+Sparkplug+Maglev+TurboFan" : "Ignition only",
+	        nx_ctx->config.jit != NX_JIT_AUTO ? " [config override]" : "");
 	// stderr is fully buffered when redirected to a file (not a TTY), so an
 	// early abnormal exit would lose this line. Flush each init milestone so the
 	// log reflects how far startup actually got.
@@ -992,18 +1206,52 @@ int main(int argc, char *argv[]) {
 			// larger heap to be backable.
 			ceiling = arena ? arena : 192ull * 1024 * 1024;
 		}
-		u64 max_heap = ceiling > reserve ? ceiling - reserve : 0;
-		if (max_heap < 32ull * 1024 * 1024)
+		u64 computed = ceiling > reserve ? ceiling - reserve : 0;
+		u64 max_heap = computed;
+		// nxjs.ini [memory] heap_limit override. Allowed to raise or lower the
+		// limit, but still clamped to what is physically backable (the same
+		// ceiling - reserve the runtime computed) so a too-high value can't
+		// guarantee a FatalOOM. The 32 MiB floor / 512 MiB cap below also apply.
+		bool heap_overridden = false;
+		if (nx_ctx->config.heap_limit != 0) {
+			u64 req = nx_ctx->config.heap_limit;
+			max_heap = req;
+			if (max_heap > computed) {
+				fprintf(stderr,
+				        "[config] memory.heap_limit=%llu MiB not honored: "
+				        "exceeds backable %llu MiB (ceiling %llu - reserve %llu "
+				        "MiB), clamped\n",
+				        (unsigned long long)(req / (1024 * 1024)),
+				        (unsigned long long)(computed / (1024 * 1024)),
+				        (unsigned long long)(ceiling / (1024 * 1024)),
+				        (unsigned long long)(reserve / (1024 * 1024)));
+				max_heap = computed;
+			}
+			heap_overridden = true;
+		}
+		if (max_heap < 32ull * 1024 * 1024) {
+			if (heap_overridden)
+				fprintf(stderr,
+				        "[config] memory.heap_limit not honored: below 32 MiB "
+				        "floor, clamped to 32 MiB\n");
 			max_heap = 32ull * 1024 * 1024;
-		if (max_heap > 512ull * 1024 * 1024)
+		}
+		if (max_heap > 512ull * 1024 * 1024) {
+			if (heap_overridden)
+				fprintf(stderr,
+				        "[config] memory.heap_limit not honored: above 512 MiB "
+				        "cap, clamped to 512 MiB\n");
 			max_heap = 512ull * 1024 * 1024;
+		}
+		nx_ctx->config.effective_heap_limit = max_heap;
 		create_params.constraints.ConfigureDefaultsFromHeapSize(
 		    8ull * 1024 * 1024 /* initial */, max_heap /* max */);
 		fprintf(stderr,
-		        "[v8] max_heap=%llu MiB (arena=%llu MiB free=%llu MiB)\n",
+		        "[v8] max_heap=%llu MiB (arena=%llu MiB free=%llu MiB)%s\n",
 		        (unsigned long long)(max_heap / (1024 * 1024)),
 		        (unsigned long long)(arena / (1024 * 1024)),
-		        (unsigned long long)(mem_free / (1024 * 1024)));
+		        (unsigned long long)(mem_free / (1024 * 1024)),
+		        heap_overridden ? " [config override]" : "");
 		// stderr is fully buffered when redirected to a file; flush so this
 		// milestone survives an early abnormal exit (matches the other init
 		// logs above).
@@ -1035,63 +1283,10 @@ int main(int argc, char *argv[]) {
 		              (HidNpadIdType)(HidNpadIdType_No1 + i));
 	}
 
-	// Resolve the user entrypoint. Two launch models:
-	//
-	//   1. Bootstrap launch: `argv[1]` is an explicit entrypoint passed by a
-	//      thin launcher (which keeps the big nx.js NRO at a well-known path and
-	//      hands it the app to run). `argv[1]` is either:
-	//        - a `.nro`: mount its embedded romfs as `romfs:` and run
-	//          `romfs:/main.js` (the app's assets resolve under `romfs:`), or
-	//        - any other path (typically a `.js`): run it directly; its URL is
-	//          the base for relative fetch/import resolution.
-	//
-	//   2. Standalone app (the original model, no argv[1]): the app's own NRO
-	//      romfs holds `main.js` + assets, so mount self as `romfs:` and run
-	//      `romfs:/main.js`; fall back to `<nro>.js` next to the NRO on the SD
-	//      card.
-	size_t user_code_size = 0;
-	bool user_path_needs_free = false;
-	char *user_code_path = NULL;
-	char *user_code = NULL;
-
-	if (argc > 1 && argv[1] && argv[1][0]) {
-		// Bootstrap launch with an explicit entrypoint.
-		if (path_has_suffix(argv[1], ".nro")) {
-			rc = mount_nro_romfs(argv[1], "romfs");
-			if (R_FAILED(rc)) {
-				nx_console_init(nx_ctx);
-				printf("Failed to mount romfs from %s (0x%x)\n", argv[1], rc);
-				nx_ctx->had_error = 1;
-			} else {
-				user_code_path = (char *)"romfs:/main.js";
-				user_code = (char *)read_file(user_code_path, &user_code_size);
-			}
-		} else {
-			user_path_needs_free = true;
-			user_code_path = strdup(argv[1]);
-			if (user_code_path) {
-				user_code = (char *)read_file(user_code_path, &user_code_size);
-			}
-		}
-	} else {
-		// Standalone app: this NRO's own romfs is the app. Also expose it as
-		// `romfs:` (it is already mounted as `nxjs:` for the runtime's files).
-		// romfsMountSelf opens our NRO file again with an independent handle, so
-		// the second mount coexists with the `nxjs:` one.
-		rc = romfsMountSelf("romfs");
-		if (R_SUCCEEDED(rc)) {
-			user_code_path = (char *)"romfs:/main.js";
-			user_code = (char *)read_file(user_code_path, &user_code_size);
-		}
-		if (user_code == NULL && errno == ENOENT && argc > 0) {
-			user_path_needs_free = true;
-			user_code_path = strdup(argv[0]);
-			if (user_code_path) {
-				replace_file_extension(user_code_path, ".js");
-				user_code = (char *)read_file(user_code_path, &user_code_size);
-			}
-		}
-	}
+	// The user entrypoint (user_code_path / user_code) was already resolved
+	// near the top of main() — before V8 init — so that `nxjs.ini` (which sits
+	// next to it) could be read in time to influence the V8 flag/heap/JIT
+	// settings. See resolve_entrypoint() and its call site above.
 
 	{
 		Isolate::Scope iso_scope(iso);
@@ -1115,7 +1310,7 @@ int main(int argc, char *argv[]) {
 			Local<Object> init_obj = Object::New(iso);
 			nx_ctx->init_obj.Reset(iso, init_obj);
 			build_init_object(iso, context, init_obj, user_code_path, argc,
-			                  argv);
+			                  argv, &nx_ctx->config);
 			global->Set(context, nx_str(iso, "$"), init_obj).Check();
 
 			// Initialize the runtime (embedded runtime.js source). Name it
@@ -1316,6 +1511,7 @@ int main(int argc, char *argv[]) {
 	if (nx_ctx->spl_initialized) {
 		splExit();
 	}
+	nx_config_free(&nx_ctx->config);
 	free(nx_ctx);
 
 	// Must run while the socket layer is still up: libuv's async self-wakeup

--- a/source/types.h
+++ b/source/types.h
@@ -20,6 +20,8 @@
 #include <uv.h>
 #include <v8.h>
 
+#include "config.h"
+
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
@@ -168,6 +170,11 @@ typedef struct nx_context_s {
 	mbedtls_x509_crt ca_chain;
 
 	bool spl_initialized;
+
+	// Parsed `nxjs.ini` application config (effective values after clamping).
+	// Read very early in main(); the renderer mode is consulted later by the
+	// lazy framebuffer init.
+	nx_config_t config;
 } nx_context_t;
 
 // Fetch the per-isolate context (replaces JS_GetContextOpaque).

--- a/source/vendor/ini.h
+++ b/source/vendor/ini.h
@@ -1,0 +1,440 @@
+/* inih -- simple .INI file parser
+
+   inih is released under the New BSD license (see LICENSE.txt). Go to the project
+   home page for more info:
+
+   https://github.com/benhoyt/inih
+
+   Vendored into nx.js as a single-header library. Define INI_IMPLEMENTATION in
+   exactly ONE translation unit before including this file to pull in the
+   implementation; elsewhere include it normally for the declarations.
+*/
+
+#ifndef NX_VENDOR_INI_H
+#define NX_VENDOR_INI_H
+
+/* Make this header a system header to itself; nothing fancy. */
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Typedef for prototype of handler function. */
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O (see also
+   ini_parse_string). */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Same as ini_parse(), but takes a zero-terminated string with the INI data
+   instead of a file. Useful for parsing INI data from a network socket or
+   already in memory. */
+int ini_parse_string(const char* string, ini_handler handler, void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See https://github.com/benhoyt/inih/issues/21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Chars that begin a start-of-line comment. Per Python configparser, allow
+   both ; and # comments at the start of a line by default. */
+#ifndef INI_START_COMMENT_PREFIXES
+#define INI_START_COMMENT_PREFIXES ";#"
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Maximum line length for any line in INI file (stack or heap). Note that
+   this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+/* Nonzero to allow heap line buffer to grow via realloc(), zero for a
+   fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
+   zero. */
+#ifndef INI_ALLOW_REALLOC
+#define INI_ALLOW_REALLOC 0
+#endif
+
+/* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
+   is zero. */
+#ifndef INI_INITIAL_ALLOC
+#define INI_INITIAL_ALLOC 200
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Nonzero to call the handler at the start of each new section (with
+   name and value NULL). Default is to only call the handler on each
+   name=value pair. */
+#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
+#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#endif
+
+/* Nonzero to allow a name without a value (no '=' or ':' on the line) and
+   call the handler with value NULL in this case. Default is to treat
+   no-value lines as an error. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
+/* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
+   allocation functions (INI_USE_STACK must also be 0). These functions must
+   have the same signatures as malloc/free/realloc and behave in a compatible
+   way. */
+#ifndef INI_CUSTOM_ALLOCATOR
+#define INI_CUSTOM_ALLOCATOR 0
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/* ------------------------------------------------------------------------ */
+#ifdef INI_IMPLEMENTATION
+
+#include <ctype.h>
+#include <string.h>
+
+#if !INI_USE_STACK
+#if INI_CUSTOM_ALLOCATOR
+#include <stddef.h>
+void* ini_malloc(size_t size);
+void ini_free(void* ptr);
+void* ini_realloc(void* ptr, size_t size);
+#else
+#include <stdlib.h>
+#define ini_malloc malloc
+#define ini_free free
+#define ini_realloc realloc
+#endif
+#endif
+
+#define INI_MAX_SECTION 50
+#define INI_MAX_NAME 50
+
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+    const char* ptr;
+    size_t num_left;
+} ini_parse_string_ctx;
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* ini_rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* ini_lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to NUL at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* ini_find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) &&
+           !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Similar to strncpy, but ensures dest (size bytes) is NUL-terminated, and
+   doesn't pad with NULs. */
+static char* ini_strncpy0(char* dest, const char* src, size_t size)
+{
+    /* Could use strncpy internally, but it causes gcc warnings (see issue #91) */
+    size_t i;
+    for (i = 0; i < size - 1 && src[i]; i++)
+        dest[i] = src[i];
+    dest[i] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+    size_t max_line = INI_MAX_LINE;
+#else
+    char* line;
+    size_t max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+    char* new_line;
+    size_t offset;
+#endif
+    char section[INI_MAX_SECTION] = "";
+    char prev_name[INI_MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)ini_malloc(INI_INITIAL_ALLOC);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, (int)max_line, stream) != NULL) {
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+        offset = strlen(line);
+        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = ini_realloc(line, max_line);
+            if (!new_line) {
+                ini_free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+                break;
+            if (max_line >= INI_MAX_LINE)
+                break;
+            offset += strlen(line + offset);
+        }
+#endif
+
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = ini_lskip(ini_rstrip(start));
+
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (HANDLER(user, section, prev_name, start) == 0 && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = ini_find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                ini_strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+                if (HANDLER(user, section, NULL, NULL) == 0 && !error)
+                    error = lineno;
+#endif
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = ini_find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = ini_rstrip(start);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = ini_find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                value = ini_lskip(value);
+                ini_rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                ini_strncpy0(prev_name, name, sizeof(prev_name));
+                if (HANDLER(user, section, name, value) == 0 && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+                *end = '\0';
+                name = ini_rstrip(start);
+                if (HANDLER(user, section, name, NULL) == 0 && !error)
+                    error = lineno;
+#else
+                error = lineno;
+#endif
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    ini_free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+    ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+    const char* ctx_ptr = ctx->ptr;
+    size_t ctx_num_left = ctx->num_left;
+    char* strp = str;
+    char c;
+
+    if (ctx_num_left == 0 || num < 2)
+        return NULL;
+
+    while (num > 1 && ctx_num_left != 0) {
+        c = *ctx_ptr++;
+        ctx_num_left--;
+        *strp++ = c;
+        if (c == '\n')
+            break;
+        num--;
+    }
+
+    *strp = '\0';
+    ctx->ptr = ctx_ptr;
+    ctx->num_left = ctx_num_left;
+    return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+    ini_parse_string_ctx ctx;
+
+    ctx.ptr = string;
+    ctx.num_left = strlen(string);
+    return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+                            user);
+}
+
+#endif /* INI_IMPLEMENTATION */
+
+#endif /* NX_VENDOR_INI_H */


### PR DESCRIPTION
## Summary

Adds an optional **`nxjs.ini`** config file, read **next to the entrypoint**, that lets an app override runtime knobs which otherwise default from the memory regime:

```ini
[v8]
jit   = auto                       ; auto (regime-based) | on | off
flags = --max-old-space-size=256   ; appended AFTER the runtime's default V8 flags

[memory]
heap_limit = 256MiB                ; KiB/MiB/GiB or raw bytes; clamped to what fits

[renderer]
mode = auto                        ; auto | cpu | gpu (gpu falls back to raster on init fail)

[socket]                           ; field-level overrides on the regime base (lean/full)
tcp_tx_buf_size = 256KiB
tcp_rx_buf_size = 256KiB
tcp_tx_buf_max_size = 1MiB
tcp_rx_buf_max_size = 1MiB
udp_tx_buf_size = 9KiB
udp_rx_buf_size = 42KiB
sb_efficiency = 6
num_bsd_sessions = 3
service_type = auto                ; auto | user | system
```

## How it works

- **Vendored `inih`** (`source/vendor/ini.h`, single-header) + a new shared **`source/config.cc`/`.h`** (`nx_config_t` on `nx_context_t`): size-suffix parsing, entrypoint-relative path derivation, socket override + clamping.
- **Entrypoint resolution is hoisted above V8 init** (`resolve_entrypoint`) so `nxjs.ini` can be parsed with plain `fopen` **before** `V8::Initialize()`/`Isolate::New` — required because `[v8]`/`[memory]` must apply before the isolate exists. stderr is redirected to `nxjs-debug.log` earlier too, so config logs are captured.
- **Applied settings**: `jit` drives `can_jit` (which couples the V8 flags, heap `reserve`, and code-range size); app `flags` appended after defaults; `heap_limit` clamped to the backable ceiling + 32 MiB floor / 512 MiB cap; renderer `auto|cpu|gpu` (gpu still falls back to raster on init failure, so it can't hard-crash). JIT is honored verbatim — JIT in applet mode is fine for CPU rendering; only the known-unstable **applet + GPU + JIT** combo is warned about (still attempted).
- **`$.config`** exposes the **effective** (post-clamp) values: `{ jit, heapLimit, renderer, v8Flags, socket{...}, loaded }`.
- **Every value that can't be honored logs** a `[config] … not honored: <reason>` line to `nxjs-debug.log` (clamped heap, invalid value, GPU fallback, oversized socket reservation, etc.). A missing file is silent.
- **Host `nxjs-test`** reads no INI; its `build_init_object` exposes a default `$.config` of the same shape (kept in sync). `$.config` TS types added to `$.ts`.

## Testing

- ✅ **Device build compiles** (config.cc + the reordered main.cc against real libnx + V8; NRO built).
- ⚠️ **Host `nxjs-test` build and on-device verification are pending** — the host build environment and test hardware are currently unavailable. Planned before merge: build host nxjs-test (verify `$.config` shape + the host main.cc mirror compiles), and on-device per-setting repros logging `$.config` + the `[v8]`/`[skia]`/`[config]` lines for `jit=off`, `heap_limit` raise/lower (clamp logged), `renderer=cpu`/`gpu`, a `[socket]` override, malformed values, and a missing file.

## Notes

- Console theming via `nxjs.ini` (font size / theme / colors) is intentionally a **follow-up PR**.
- `@nx.js/runtime` **minor** changeset included.