### PR TITLE
feat: slim app packaging via a bootstrap launcher

### DIFF
--- a/.changeset/slim-bootstrap.md
+++ b/.changeset/slim-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/nro": minor
+---
+
+feat: slim app packaging via `nxjs-nro --slim` — builds a tiny launcher NRO (a few hundred KB) instead of embedding the full ~40 MB runtime; at boot it chainloads a shared runtime installed at `sdmc:/nx.js/nxjs-v<version>.nro`, selected by the `[runtime] version` semver requirement in the app's `romfs/nxjs.ini` (defaulting to caret-on-major). `create-nxjs-app` now prompts to package an app as slim or fat.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: bootstrap.nro
+          path: bootstrap-artifact
 
       - name: Download `nxjs.nsp`
         uses: actions/download-artifact@v4
@@ -117,7 +118,7 @@ jobs:
         run: pnpm build
 
       - name: Copy `nxjs.nro` + `bootstrap.nro` to "@nx.js/nro"
-        run: cp -v nxjs.nro bootstrap.nro packages/nro/dist
+        run: cp -v nxjs.nro bootstrap-artifact/bootstrap.nro packages/nro/dist
 
       - name: Copy files to "@nx.js/nsp"
         run: cp -rv build/exefs romfs nxjs.nacp icon.jpg packages/nsp
@@ -187,6 +188,11 @@ jobs:
           cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19
           cmake --build build -j"$(nproc)"
         working-directory: packages/runtime/test
+
+      - name: Run bootstrap launcher unit tests
+        # Host-compiled semver/version-matching tests for the slim bootstrap
+        # launcher (no Switch hardware / devkitPro needed).
+        run: ./bootstrap/test/run.sh
 
       - name: Run Tests
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,18 @@ jobs:
       - name: Build `nxjs.nro`
         run: make V=1
 
+      - name: Build slim `bootstrap.nro`
+        run: make -C bootstrap V=1
+
       - uses: actions/upload-artifact@v4
         with:
           name: nxjs.nro
           path: nxjs.nro
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bootstrap.nro
+          path: bootstrap/bootstrap.nro
 
       - uses: actions/upload-artifact@v4
         with:
@@ -77,6 +85,11 @@ jobs:
         with:
           name: nxjs.nro
 
+      - name: Download `bootstrap.nro`
+        uses: actions/download-artifact@v4
+        with:
+          name: bootstrap.nro
+
       - name: Download `nxjs.nsp`
         uses: actions/download-artifact@v4
         with:
@@ -103,8 +116,8 @@ jobs:
       - name: Build Packages
         run: pnpm build
 
-      - name: Copy `nxjs.nro` to "@nx.js/nro"
-        run: cp -v nxjs.nro packages/nro/dist
+      - name: Copy `nxjs.nro` + `bootstrap.nro` to "@nx.js/nro"
+        run: cp -v nxjs.nro bootstrap.nro packages/nro/dist
 
       - name: Copy files to "@nx.js/nsp"
         run: cp -rv build/exefs romfs nxjs.nacp icon.jpg packages/nsp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,9 @@ udp_rx_buf_size = 42KiB
 sb_efficiency = 6
 num_bsd_sessions = 3
 service_type = auto                ; auto | user | system
+
+[runtime]                          ; consumed by the SLIM bootstrap launcher (not the runtime)
+version = ^1                       ; semver requirement for the shared runtime NRO
 ```
 
 - **Effective** (post-clamp) values are exposed to JS as `$.config`
@@ -197,6 +200,40 @@ service_type = auto                ; auto | user | system
   Mesa) — that combo is warned about but still attempted.
 - The host `nxjs-test` reads **no** INI; its `build_init_object` exposes a
   default `$.config`. Keep that mirror in sync if you change `$.config`'s shape.
+- `[runtime]` is read by the **slim bootstrap launcher**, not the runtime. The
+  runtime's parser recognizes + silently ignores it (the same `nxjs.ini` ships
+  inside a slim app's RomFS and is read by both).
+
+### Slim apps / bootstrap launcher (`bootstrap/`)
+
+An app can be packaged two ways:
+
+- **Fat** (default): `nxjs-nro` embeds the full ~40 MB runtime into the app's
+  NRO — self-contained, no external dependency.
+- **Slim**: `nxjs-nro --slim` builds a tiny launcher NRO (a few hundred KB)
+  whose code segment is `bootstrap/` (a pure-C libnx app, NO V8/Skia) and whose
+  RomFS holds the app's `main.js` + assets + `nxjs.ini`. At boot the launcher:
+  1. reads `[runtime] version` from its own `romfs:/nxjs.ini` (default baked at
+     build time = `^<runtime-major>`),
+  2. scans `sdmc:/nx.js/nxjs-v<full-version>.nro`, picks the **highest installed
+     version satisfying the specifier** (vendored `semver.c`),
+  3. `envSetNextLoad(<that runtime>, "\"<runtime>\" \"<self.nro>\"")` and exits.
+  hbloader then loads the runtime with `argv[1]` = the slim NRO, and the
+  runtime's existing `mount_nro_romfs(argv[1])` mounts the slim NRO's RomFS as
+  `romfs:` and runs `romfs:/main.js`. No satisfying runtime / not launched via
+  hbloader ⇒ a clear on-screen error (wait for `+`), never a crash.
+
+- **Build**: `make -C bootstrap` (devkitPro; `jq` derives the runtime major from
+  `packages/runtime/package.json` → the baked `^major` default). CI builds
+  `bootstrap.nro`, uploads it, and the release job copies it into
+  `packages/nro/dist/` next to `nxjs.nro` (so `@nx.js/nro --slim` can use it).
+- **Match logic** (`bootstrap/source/match.c`) is split from libnx so it's
+  host-unit-tested: `bootstrap/test/run.sh` (no Switch needed).
+- **Prerelease note**: the vendored `semver.c` compares purely by precedence and
+  does NOT apply node-semver's "prereleases excluded from non-prerelease ranges"
+  rule, so `^1` DOES match `1.0.0-beta.N` — intentional during the v1 beta.
+- SD-card convention (new): shared runtimes live at
+  `sdmc:/nx.js/nxjs-v<full-version>.nro`; multiple versions may coexist.
 
 ### ES module `import` (static + dynamic)
 

--- a/bootstrap/.gitignore
+++ b/bootstrap/.gitignore
@@ -1,0 +1,5 @@
+build/
+*.elf
+*.nro
+*.nacp
+*.map

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -1,0 +1,142 @@
+#---------------------------------------------------------------------------------
+# nx.js slim bootstrap launcher — a tiny homebrew NRO that chainloads the shared
+# nx.js runtime from sdmc:/nx.js/. Builds with the standard devkitPro switch
+# rules (libnx only — no V8/Skia), so the output is a few KB of code.
+#---------------------------------------------------------------------------------
+.SUFFIXES:
+
+ifeq ($(strip $(DEVKITPRO)),)
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitpro")
+endif
+
+export PATH := $(DEVKITPRO)/devkitA64/bin:$(DEVKITPRO)/tools/bin:$(PATH)
+
+# Absolute path to THIS Makefile's directory — captured before the switch_rules
+# include changes MAKEFILE_LIST, and valid in both the top-level and recursive
+# (build/) make invocations (where CURDIR changes).
+MK_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+TOPDIR ?= $(CURDIR)
+include $(DEVKITPRO)/libnx/switch_rules
+
+#---------------------------------------------------------------------------------
+# Metadata. APP_VERSION + the default runtime requirement track the runtime's
+# semver MAJOR (e.g. "1.0.0-beta.1" -> major "1" -> default "^1").
+#---------------------------------------------------------------------------------
+RUNTIME_PKG := $(MK_DIR)/../packages/runtime/package.json
+APP_TITLE   :=  nx.js app
+APP_AUTHOR  :=  TooTallNate
+APP_VERSION :=  `jq -r .version < $(RUNTIME_PKG)`
+RUNTIME_MAJOR := $(shell jq -r .version < $(RUNTIME_PKG) | sed 's/[.-].*//')
+# Default [runtime] version requirement baked into the launcher: caret-on-major.
+NXJS_RUNTIME_DEFAULT := ^$(RUNTIME_MAJOR)
+
+TARGET		:=	bootstrap
+BUILD		:=	build
+SOURCES		:=	source source/vendor
+INCLUDES	:=	source
+
+#---------------------------------------------------------------------------------
+ARCH	:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
+
+CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
+			$(ARCH) $(DEFINES) \
+			-DNXJS_RUNTIME_DEFAULT="\"$(NXJS_RUNTIME_DEFAULT)\""
+CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -D_DEFAULT_SOURCE
+
+CXXFLAGS	:=	$(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
+
+ASFLAGS	:=	-g $(ARCH)
+LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
+
+LIBS	:=	-lnx
+LIBDIRS	:=	$(PORTLIBS) $(LIBNX)
+
+#---------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#---------------------------------------------------------------------------------
+
+export OUTPUT	:=	$(CURDIR)/$(TARGET)
+export TOPDIR	:=	$(CURDIR)
+
+export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
+			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
+CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+
+ifeq ($(strip $(CPPFILES)),)
+	export LD	:=	$(CC)
+else
+	export LD	:=	$(CXX)
+endif
+
+export OFILES_SRC	:=	$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+export OFILES	:=	$(OFILES_SRC)
+
+export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)/$(BUILD)
+
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+export BUILD_EXEFS_SRC := $(TOPDIR)/$(EXEFS_SRC)
+
+ifeq ($(strip $(ICON)),)
+	icons := $(wildcard *.jpg)
+	ifneq (,$(findstring $(TARGET).jpg,$(icons)))
+		export APP_ICON := $(TOPDIR)/$(TARGET).jpg
+	else
+		ifneq (,$(findstring icon.jpg,$(icons)))
+			export APP_ICON := $(TOPDIR)/icon.jpg
+		endif
+	endif
+else
+	export APP_ICON := $(TOPDIR)/$(ICON)
+endif
+
+ifeq ($(strip $(NO_ICON)),)
+	export NROFLAGS += --icon=$(APP_ICON)
+endif
+
+ifeq ($(strip $(NO_NACP)),)
+	export NROFLAGS += --nacp=$(CURDIR)/$(TARGET).nacp
+endif
+
+ifneq ($(APP_TITLEID),)
+	export NACPFLAGS += --titleid=$(APP_TITLEID)
+endif
+
+.PHONY: $(BUILD) clean all
+
+all: $(BUILD)
+
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) $(TARGET).nro $(TARGET).nacp $(TARGET).elf
+
+#---------------------------------------------------------------------------------
+else
+.PHONY:	all
+
+DEPENDS	:=	$(OFILES:.o=.d)
+
+all	:	$(OUTPUT).nro
+
+$(OUTPUT).nro	:	$(OUTPUT).elf $(OUTPUT).nacp
+$(OUTPUT).elf	:	$(OFILES)
+
+$(OFILES_SRC)	:
+
+-include $(DEPENDS)
+
+#---------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,46 @@
+# nx.js slim bootstrap launcher
+
+A tiny homebrew NRO (pure C, libnx only — no V8/Skia) that does **not** embed the
+nx.js runtime. It chainloads a **shared** runtime NRO installed under
+`sdmc:/nx.js/` and hands it the app to run.
+
+This is the base used by `@nx.js/nro --slim`: the slim builder takes
+`bootstrap.nro`, stages the app's `main.js` + assets + `nxjs.ini` into its RomFS,
+and ships a NRO that's a few hundred KB instead of ~40 MB.
+
+## How it works
+
+1. The slim app NRO is launched from hbmenu.
+2. This launcher reads `[runtime] version` (a semver requirement) from its own
+   `romfs:/nxjs.ini` (default baked at build time: `^<runtime-major>`).
+3. It scans `sdmc:/nx.js/nxjs-v<full-version>.nro` and picks the **highest
+   installed version** that satisfies the requirement.
+4. `envSetNextLoad(<runtime>, "\"<runtime>\" \"<self.nro>\"")` + exit.
+5. hbloader loads the runtime with `argv[1]` = this NRO; the runtime mounts this
+   NRO's RomFS as `romfs:` and runs `romfs:/main.js`.
+
+If no compatible runtime is found (or it wasn't launched via hbloader), it shows
+an on-screen error and waits for **+** — it never crashes.
+
+## Build
+
+```sh
+make            # produces bootstrap.nro (DEVKITPRO must be set)
+```
+
+`jq` derives the runtime major from `../packages/runtime/package.json` for the
+baked default version requirement.
+
+## Test
+
+The version-matching logic (`source/match.c`) is split from libnx so it can run
+on the host without a Switch:
+
+```sh
+test/run.sh
+```
+
+## Vendored libraries
+
+- `source/vendor/semver.c` / `semver.h` — [h2non/semver.c](https://github.com/h2non/semver.c) (MIT)
+- `source/vendor/ini.h` — [benhoyt/inih](https://github.com/benhoyt/inih) (BSD-3), single-header

--- a/bootstrap/source/main.c
+++ b/bootstrap/source/main.c
@@ -1,0 +1,213 @@
+// nx.js slim bootstrap launcher.
+//
+// A tiny homebrew NRO that does NOT embed the nx.js runtime. Instead it
+// chainloads a SHARED runtime NRO installed under `sdmc:/nx.js/` and hands it
+// this NRO as the app to run (argv[1]). The runtime then mounts THIS NRO's
+// RomFS (which holds the app's `main.js` + assets) as `romfs:` and runs
+// `romfs:/main.js` — see `mount_nro_romfs()` / the argv[1] entrypoint path in
+// the runtime's `source/main.cc`.
+//
+// Runtime selection:
+//   - This NRO's RomFS may contain `nxjs.ini` with a `[runtime] version`
+//     semver specifier (e.g. "^1", ">=1.2", "1.0.0-beta.1"). Default: "^<major>"
+//     baked at build time (NXJS_RUNTIME_DEFAULT).
+//   - We enumerate `sdmc:/nx.js/nxjs-v<full-version>.nro`, parse each filename's
+//     version, and pick the HIGHEST installed version that satisfies the
+//     specifier.
+//   - Found -> envSetNextLoad(that runtime, "\"<runtime>\" \"<self>\"") + exit.
+//   - Not found / unsupported env -> on-screen error + wait for + to exit.
+//
+// This binary stays tiny: libnx + a vendored INI + semver parser, no V8/Skia.
+
+#include <dirent.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <switch.h>
+
+#include "match.h"
+
+#define INI_IMPLEMENTATION
+#include "vendor/ini.h"
+
+#ifndef NXJS_RUNTIME_DEFAULT
+#define NXJS_RUNTIME_DEFAULT "*"
+#endif
+
+#define RUNTIME_DIR "sdmc:/nx.js"
+#define RUNTIME_PREFIX "nxjs-v"
+#define RUNTIME_SUFFIX ".nro"
+
+// --- INI: pull [runtime] version --------------------------------------------
+
+typedef struct {
+	char version[128];
+	bool have_version;
+} launcher_cfg_t;
+
+static int ini_cb(void *user, const char *section, const char *name,
+                  const char *value) {
+	launcher_cfg_t *cfg = (launcher_cfg_t *)user;
+	if (!section || !name || !value)
+		return 1;
+	if (strcasecmp(section, "runtime") == 0 &&
+	    strcasecmp(name, "version") == 0) {
+		snprintf(cfg->version, sizeof(cfg->version), "%s", value);
+		cfg->have_version = true;
+	}
+	return 1; // keep parsing; we ignore everything else (the runtime reads it)
+}
+
+// --- Specifier parsing ------------------------------------------------------
+//
+// Specifier parsing + matching lives in match.c (nx_parse_spec /
+// nx_version_satisfies / nx_version_compare) so it can be unit-tested on the
+// host without libnx.
+
+// --- main -------------------------------------------------------------------
+
+static PadState g_pad;
+
+static void wait_for_plus_and_exit(void) {
+	padConfigureInput(1, HidNpadStyleSet_NpadStandard);
+	padInitializeDefault(&g_pad);
+	printf("\nPress + to exit.\n");
+	consoleUpdate(NULL);
+	while (appletMainLoop()) {
+		padUpdate(&g_pad);
+		if (padGetButtonsDown(&g_pad) & HidNpadButton_Plus)
+			break;
+		consoleUpdate(NULL);
+	}
+	consoleExit(NULL);
+}
+
+static void fail(const char *fmt, ...) {
+	consoleInit(NULL);
+	printf("nx.js slim launcher\n");
+	printf("-------------------\n\n");
+	va_list ap;
+	va_start(ap, fmt);
+	vprintf(fmt, ap);
+	va_end(ap);
+	wait_for_plus_and_exit();
+}
+
+int main(int argc, char *argv[]) {
+	// We must have been launched via hbloader (so we can chainload) and know
+	// our own NRO path (argv[0]) to hand to the runtime.
+	if (!envHasNextLoad()) {
+		fail("This environment can't chainload the nx.js runtime.\n"
+		     "Launch this app from the homebrew menu (hbmenu).\n");
+		return 0;
+	}
+	const char *self = (argc > 0 && argv[0] && argv[0][0]) ? argv[0] : NULL;
+	if (!self) {
+		fail("Could not determine this app's own path (argv[0] missing).\n");
+		return 0;
+	}
+
+	// Read the desired runtime version specifier from our own RomFS.
+	launcher_cfg_t cfg = {0};
+	snprintf(cfg.version, sizeof(cfg.version), "%s", NXJS_RUNTIME_DEFAULT);
+	if (R_SUCCEEDED(romfsMountSelf("romfs"))) {
+		ini_parse("romfs:/nxjs.ini", ini_cb, &cfg);
+		romfsUnmount("romfs");
+	}
+
+	// Validate the specifier up front (gives a clear error before scanning).
+	{
+		char op[4] = {0};
+		char ver[128] = {0};
+		if (!nx_parse_spec(cfg.version, op, sizeof(op), ver, sizeof(ver))) {
+			fail("Invalid [runtime] version specifier: \"%s\"\n", cfg.version);
+			return 0;
+		}
+	}
+
+	// Scan sdmc:/nx.js for nxjs-v<version>.nro and pick the highest match.
+	char best_path[FS_MAX_PATH] = {0};
+	char best_ver_str[128] = {0};
+	bool have_best = false;
+
+	DIR *dir = opendir(RUNTIME_DIR);
+	if (dir) {
+		struct dirent *ent;
+		size_t plen = strlen(RUNTIME_PREFIX);
+		size_t slen = strlen(RUNTIME_SUFFIX);
+		while ((ent = readdir(dir)) != NULL) {
+			const char *fn = ent->d_name;
+			size_t fnlen = strlen(fn);
+			if (fnlen <= plen + slen)
+				continue;
+			if (strncasecmp(fn, RUNTIME_PREFIX, plen) != 0)
+				continue;
+			if (strcasecmp(fn + fnlen - slen, RUNTIME_SUFFIX) != 0)
+				continue;
+			// Extract the version substring between prefix and suffix.
+			char vbuf[128];
+			size_t vlen = fnlen - plen - slen;
+			if (vlen == 0 || vlen >= sizeof(vbuf))
+				continue;
+			memcpy(vbuf, fn + plen, vlen);
+			vbuf[vlen] = '\0';
+			if (!nx_version_satisfies(vbuf, cfg.version))
+				continue;
+			if (!have_best || nx_version_compare(vbuf, best_ver_str) > 0) {
+				have_best = true;
+				snprintf(best_ver_str, sizeof(best_ver_str), "%s", vbuf);
+				snprintf(best_path, sizeof(best_path), "%s/%s", RUNTIME_DIR, fn);
+			}
+		}
+		closedir(dir);
+	}
+
+	if (!have_best) {
+		consoleInit(NULL);
+		printf("nx.js slim launcher\n");
+		printf("-------------------\n\n");
+		printf("No compatible nx.js runtime found.\n\n");
+		printf("Required: %s\n", cfg.version);
+		printf("Looked in: %s/%s*%s\n\n", RUNTIME_DIR, RUNTIME_PREFIX,
+		       RUNTIME_SUFFIX);
+		// List what IS installed, to help the user.
+		DIR *d2 = opendir(RUNTIME_DIR);
+		if (d2) {
+			struct dirent *e2;
+			bool any = false;
+			printf("Installed runtimes:\n");
+			while ((e2 = readdir(d2)) != NULL) {
+				if (strncasecmp(e2->d_name, RUNTIME_PREFIX,
+				                strlen(RUNTIME_PREFIX)) == 0) {
+					printf("  - %s\n", e2->d_name);
+					any = true;
+				}
+			}
+			if (!any)
+				printf("  (none)\n");
+			closedir(d2);
+		} else {
+			printf("(%s does not exist)\n", RUNTIME_DIR);
+		}
+		printf("\nInstall a runtime NRO to %s/ and try again.\n", RUNTIME_DIR);
+		wait_for_plus_and_exit();
+		return 0;
+	}
+
+	// Chainload: hand the runtime our own NRO as argv[1]. The runtime mounts
+	// our RomFS as `romfs:` and runs `romfs:/main.js`.
+	char args[FS_MAX_PATH * 2 + 8];
+	snprintf(args, sizeof(args), "\"%s\" \"%s\"", best_path, self);
+	Result rc = envSetNextLoad(best_path, args);
+	if (R_FAILED(rc)) {
+		fail("Failed to queue the nx.js runtime for launch (0x%x).\n"
+		     "Runtime: %s\n",
+		     rc, best_path);
+		return 0;
+	}
+	// Returning hands control back to hbloader, which loads the runtime NRO.
+	return 0;
+}

--- a/bootstrap/source/match.c
+++ b/bootstrap/source/match.c
@@ -68,15 +68,15 @@ bool nx_version_satisfies(const char *cand, const char *spec) {
 	char want_str[128] = {0};
 	if (!nx_parse_spec(spec, op, sizeof(op), want_str, sizeof(want_str)))
 		return false;
+	// NOTE: semver_parse() can allocate metadata/prerelease even when it
+	// returns an error (it slices +/- before parsing the numeric version), so
+	// always semver_free() — both structs are zero-initialized, and freeing a
+	// zeroed semver_t is a no-op.
 	semver_t want = {0};
-	if (semver_parse(want_str, &want) != 0)
-		return false;
 	semver_t c = {0};
-	if (semver_parse(cand, &c) != 0) {
-		semver_free(&want);
-		return false;
-	}
-	bool ok = semver_satisfies(c, want, op) != 0;
+	int pw = semver_parse(want_str, &want);
+	int pc = semver_parse(cand, &c);
+	bool ok = (pw == 0 && pc == 0) && semver_satisfies(c, want, op) != 0;
 	semver_free(&c);
 	semver_free(&want);
 	return ok;
@@ -95,9 +95,9 @@ int nx_version_compare(const char *a, const char *b) {
 		r = 1;
 	else
 		r = semver_compare(va, vb);
-	if (pa == 0)
-		semver_free(&va);
-	if (pb == 0)
-		semver_free(&vb);
+	// semver_parse() may allocate metadata/prerelease even on an error return,
+	// so always free (both structs are zero-initialized; freeing is a no-op).
+	semver_free(&va);
+	semver_free(&vb);
 	return r;
 }

--- a/bootstrap/source/match.c
+++ b/bootstrap/source/match.c
@@ -1,0 +1,103 @@
+#include "match.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "vendor/semver.h"
+
+void nx_normalize_version(const char *in, char *out, size_t out_sz) {
+	// Count the dotted numeric components before any '-'/'+'.
+	int dots = 0;
+	for (const char *q = in; *q && *q != '-' && *q != '+'; q++) {
+		if (*q == '.')
+			dots++;
+	}
+	if (dots >= 2) {
+		snprintf(out, out_sz, "%s", in);
+		return;
+	}
+	// Find where the core (major[.minor]) ends (start of -pre / +meta / NUL).
+	const char *rest = in;
+	while (*rest && *rest != '-' && *rest != '+')
+		rest++;
+	int core_len = (int)(rest - in);
+	if (dots == 0)
+		snprintf(out, out_sz, "%.*s.0.0%s", core_len, in, rest);
+	else // dots == 1
+		snprintf(out, out_sz, "%.*s.0%s", core_len, in, rest);
+}
+
+bool nx_parse_spec(const char *spec, char *op, size_t op_sz, char *ver,
+                   size_t ver_sz) {
+	while (*spec == ' ' || *spec == '\t' || *spec == 'v' || *spec == 'V')
+		spec++;
+	if (*spec == '*' || *spec == '\0') {
+		// Wildcard: match anything. Represent as ">= 0.0.0".
+		snprintf(op, op_sz, ">=");
+		snprintf(ver, ver_sz, "0.0.0");
+		return true;
+	}
+	// Leading operator?
+	if (spec[0] == '^' || spec[0] == '~' || spec[0] == '=') {
+		snprintf(op, op_sz, "%c", spec[0]);
+		spec++;
+	} else if (spec[0] == '>' || spec[0] == '<') {
+		if (spec[1] == '=') {
+			snprintf(op, op_sz, "%c=", spec[0]);
+			spec += 2;
+		} else {
+			snprintf(op, op_sz, "%c", spec[0]);
+			spec += 1;
+		}
+	} else {
+		// Bare version -> caret range.
+		snprintf(op, op_sz, "^");
+	}
+	while (*spec == ' ' || *spec == '\t' || *spec == 'v' || *spec == 'V')
+		spec++;
+	// Reject absurdly long inputs so normalization (which may append ".0.0")
+	// can't overflow/truncate the caller's buffer.
+	if (strlen(spec) >= 96)
+		return false;
+	nx_normalize_version(spec, ver, ver_sz);
+	return ver[0] != '\0';
+}
+
+bool nx_version_satisfies(const char *cand, const char *spec) {
+	char op[4] = {0};
+	char want_str[128] = {0};
+	if (!nx_parse_spec(spec, op, sizeof(op), want_str, sizeof(want_str)))
+		return false;
+	semver_t want = {0};
+	if (semver_parse(want_str, &want) != 0)
+		return false;
+	semver_t c = {0};
+	if (semver_parse(cand, &c) != 0) {
+		semver_free(&want);
+		return false;
+	}
+	bool ok = semver_satisfies(c, want, op) != 0;
+	semver_free(&c);
+	semver_free(&want);
+	return ok;
+}
+
+int nx_version_compare(const char *a, const char *b) {
+	semver_t va = {0}, vb = {0};
+	int pa = semver_parse(a, &va);
+	int pb = semver_parse(b, &vb);
+	int r;
+	if (pa != 0 && pb != 0)
+		r = 0;
+	else if (pa != 0)
+		r = -1;
+	else if (pb != 0)
+		r = 1;
+	else
+		r = semver_compare(va, vb);
+	if (pa == 0)
+		semver_free(&va);
+	if (pb == 0)
+		semver_free(&vb);
+	return r;
+}

--- a/bootstrap/source/match.h
+++ b/bootstrap/source/match.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Pure (no-libnx) runtime-version matching helpers for the slim bootstrap
+// launcher. Split out from main.c so they can be unit-tested on the host
+// (see bootstrap/test/), where libnx isn't available.
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Normalize a version-ish string into X.Y.Z[-pre][+meta] by padding missing
+// minor/patch with ".0". Writes into `out` (size `out_sz`).
+void nx_normalize_version(const char *in, char *out, size_t out_sz);
+
+// Parse a semver specifier (e.g. "^1", ">=1.2", "1.0.0-beta.1", "*", "1") into
+// an operator string (for semver_satisfies, e.g. "^", ">=", "=") and a
+// normalized X.Y.Z version string. Returns true on success.
+bool nx_parse_spec(const char *spec, char *op, size_t op_sz, char *ver,
+                   size_t ver_sz);
+
+// Given a runtime version string `cand` (e.g. "1.2.0", "1.0.0-beta.1") and a
+// specifier `spec`, return true if `cand` satisfies `spec`.
+bool nx_version_satisfies(const char *cand, const char *spec);
+
+// Compare two version strings: -1 if a<b, 0 if equal, 1 if a>b. Invalid
+// versions sort lowest.
+int nx_version_compare(const char *a, const char *b);
+
+#ifdef __cplusplus
+}
+#endif

--- a/bootstrap/source/vendor/ini.h
+++ b/bootstrap/source/vendor/ini.h
@@ -1,0 +1,440 @@
+/* inih -- simple .INI file parser
+
+   inih is released under the New BSD license (see LICENSE.txt). Go to the project
+   home page for more info:
+
+   https://github.com/benhoyt/inih
+
+   Vendored into nx.js as a single-header library. Define INI_IMPLEMENTATION in
+   exactly ONE translation unit before including this file to pull in the
+   implementation; elsewhere include it normally for the declarations.
+*/
+
+#ifndef NX_VENDOR_INI_H
+#define NX_VENDOR_INI_H
+
+/* Make this header a system header to itself; nothing fancy. */
+
+#include <stdio.h>
+
+/* Nonzero if ini_handler callback should accept lineno parameter. */
+#ifndef INI_HANDLER_LINENO
+#define INI_HANDLER_LINENO 0
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Typedef for prototype of handler function. */
+#if INI_HANDLER_LINENO
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value,
+                           int lineno);
+#else
+typedef int (*ini_handler)(void* user, const char* section,
+                           const char* name, const char* value);
+#endif
+
+/* Typedef for prototype of fgets-style reader function. */
+typedef char* (*ini_reader)(char* str, int num, void* stream);
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's configparser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+int ini_parse(const char* filename, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user);
+
+/* Same as ini_parse(), but takes an ini_reader function pointer instead of
+   filename. Used for implementing custom or string-based I/O (see also
+   ini_parse_string). */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user);
+
+/* Same as ini_parse(), but takes a zero-terminated string with the INI data
+   instead of a file. Useful for parsing INI data from a network socket or
+   already in memory. */
+int ini_parse_string(const char* string, ini_handler handler, void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   configparser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See https://github.com/benhoyt/inih/issues/21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Chars that begin a start-of-line comment. Per Python configparser, allow
+   both ; and # comments at the start of a line by default. */
+#ifndef INI_START_COMMENT_PREFIXES
+#define INI_START_COMMENT_PREFIXES ";#"
+#endif
+
+/* Nonzero to allow inline comments (with valid inline comment characters
+   specified by INI_INLINE_COMMENT_PREFIXES). Set to 0 to turn off and match
+   Python 3.2+ configparser behaviour. */
+#ifndef INI_ALLOW_INLINE_COMMENTS
+#define INI_ALLOW_INLINE_COMMENTS 1
+#endif
+#ifndef INI_INLINE_COMMENT_PREFIXES
+#define INI_INLINE_COMMENT_PREFIXES ";"
+#endif
+
+/* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Maximum line length for any line in INI file (stack or heap). Note that
+   this must be 3 more than the longest line (due to '\r', '\n', and '\0'). */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+/* Nonzero to allow heap line buffer to grow via realloc(), zero for a
+   fixed-size buffer of INI_MAX_LINE bytes. Only applies if INI_USE_STACK is
+   zero. */
+#ifndef INI_ALLOW_REALLOC
+#define INI_ALLOW_REALLOC 0
+#endif
+
+/* Initial size in bytes for heap line buffer. Only applies if INI_USE_STACK
+   is zero. */
+#ifndef INI_INITIAL_ALLOC
+#define INI_INITIAL_ALLOC 200
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Nonzero to call the handler at the start of each new section (with
+   name and value NULL). Default is to only call the handler on each
+   name=value pair. */
+#ifndef INI_CALL_HANDLER_ON_NEW_SECTION
+#define INI_CALL_HANDLER_ON_NEW_SECTION 0
+#endif
+
+/* Nonzero to allow a name without a value (no '=' or ':' on the line) and
+   call the handler with value NULL in this case. Default is to treat
+   no-value lines as an error. */
+#ifndef INI_ALLOW_NO_VALUE
+#define INI_ALLOW_NO_VALUE 0
+#endif
+
+/* Nonzero to use custom ini_malloc, ini_free, and ini_realloc memory
+   allocation functions (INI_USE_STACK must also be 0). These functions must
+   have the same signatures as malloc/free/realloc and behave in a compatible
+   way. */
+#ifndef INI_CUSTOM_ALLOCATOR
+#define INI_CUSTOM_ALLOCATOR 0
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/* ------------------------------------------------------------------------ */
+#ifdef INI_IMPLEMENTATION
+
+#include <ctype.h>
+#include <string.h>
+
+#if !INI_USE_STACK
+#if INI_CUSTOM_ALLOCATOR
+#include <stddef.h>
+void* ini_malloc(size_t size);
+void ini_free(void* ptr);
+void* ini_realloc(void* ptr, size_t size);
+#else
+#include <stdlib.h>
+#define ini_malloc malloc
+#define ini_free free
+#define ini_realloc realloc
+#endif
+#endif
+
+#define INI_MAX_SECTION 50
+#define INI_MAX_NAME 50
+
+/* Used by ini_parse_string() to keep track of string parsing state. */
+typedef struct {
+    const char* ptr;
+    size_t num_left;
+} ini_parse_string_ctx;
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* ini_rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* ini_lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char (of chars) or inline comment in given string,
+   or pointer to NUL at end of string if neither found. Inline comment must
+   be prefixed by a whitespace character to register as a comment. */
+static char* ini_find_chars_or_comment(const char* s, const char* chars)
+{
+#if INI_ALLOW_INLINE_COMMENTS
+    int was_space = 0;
+    while (*s && (!chars || !strchr(chars, *s)) &&
+           !(was_space && strchr(INI_INLINE_COMMENT_PREFIXES, *s))) {
+        was_space = isspace((unsigned char)(*s));
+        s++;
+    }
+#else
+    while (*s && (!chars || !strchr(chars, *s))) {
+        s++;
+    }
+#endif
+    return (char*)s;
+}
+
+/* Similar to strncpy, but ensures dest (size bytes) is NUL-terminated, and
+   doesn't pad with NULs. */
+static char* ini_strncpy0(char* dest, const char* src, size_t size)
+{
+    /* Could use strncpy internally, but it causes gcc warnings (see issue #91) */
+    size_t i;
+    for (i = 0; i < size - 1 && src[i]; i++)
+        dest[i] = src[i];
+    dest[i] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
+                     void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+    size_t max_line = INI_MAX_LINE;
+#else
+    char* line;
+    size_t max_line = INI_INITIAL_ALLOC;
+#endif
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+    char* new_line;
+    size_t offset;
+#endif
+    char section[INI_MAX_SECTION] = "";
+    char prev_name[INI_MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)ini_malloc(INI_INITIAL_ALLOC);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+#if INI_HANDLER_LINENO
+#define HANDLER(u, s, n, v) handler(u, s, n, v, lineno)
+#else
+#define HANDLER(u, s, n, v) handler(u, s, n, v)
+#endif
+
+    /* Scan through stream line by line */
+    while (reader(line, (int)max_line, stream) != NULL) {
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+        offset = strlen(line);
+        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = ini_realloc(line, max_line);
+            if (!new_line) {
+                ini_free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+                break;
+            if (max_line >= INI_MAX_LINE)
+                break;
+            offset += strlen(line + offset);
+        }
+#endif
+
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = ini_lskip(ini_rstrip(start));
+
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (HANDLER(user, section, prev_name, start) == 0 && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = ini_find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                ini_strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+                if (HANDLER(user, section, NULL, NULL) == 0 && !error)
+                    error = lineno;
+#endif
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = ini_find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = ini_rstrip(start);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = ini_find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                value = ini_lskip(value);
+                ini_rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                ini_strncpy0(prev_name, name, sizeof(prev_name));
+                if (HANDLER(user, section, name, value) == 0 && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+                *end = '\0';
+                name = ini_rstrip(start);
+                if (HANDLER(user, section, name, NULL) == 0 && !error)
+                    error = lineno;
+#else
+                error = lineno;
+#endif
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    ini_free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file, ini_handler handler, void* user)
+{
+    return ini_parse_stream((ini_reader)fgets, file, handler, user);
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename, ini_handler handler, void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, user);
+    fclose(file);
+    return error;
+}
+
+/* An ini_reader function to read the next line from a string buffer. This
+   is the fgets() equivalent used by ini_parse_string(). */
+static char* ini_reader_string(char* str, int num, void* stream) {
+    ini_parse_string_ctx* ctx = (ini_parse_string_ctx*)stream;
+    const char* ctx_ptr = ctx->ptr;
+    size_t ctx_num_left = ctx->num_left;
+    char* strp = str;
+    char c;
+
+    if (ctx_num_left == 0 || num < 2)
+        return NULL;
+
+    while (num > 1 && ctx_num_left != 0) {
+        c = *ctx_ptr++;
+        ctx_num_left--;
+        *strp++ = c;
+        if (c == '\n')
+            break;
+        num--;
+    }
+
+    *strp = '\0';
+    ctx->ptr = ctx_ptr;
+    ctx->num_left = ctx_num_left;
+    return str;
+}
+
+/* See documentation in header file. */
+int ini_parse_string(const char* string, ini_handler handler, void* user) {
+    ini_parse_string_ctx ctx;
+
+    ctx.ptr = string;
+    ctx.num_left = strlen(string);
+    return ini_parse_stream((ini_reader)ini_reader_string, &ctx, handler,
+                            user);
+}
+
+#endif /* INI_IMPLEMENTATION */
+
+#endif /* NX_VENDOR_INI_H */

--- a/bootstrap/source/vendor/semver.c
+++ b/bootstrap/source/vendor/semver.c
@@ -1,0 +1,638 @@
+/*
+ * semver.c
+ *
+ * Copyright (c) 2015-2017 Tomas Aparicio
+ * MIT licensed
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "semver.h"
+
+#define SLICE_SIZE   50
+#define DELIMITER    "."
+#define PR_DELIMITER "-"
+#define MT_DELIMITER "+"
+#define NUMBERS      "0123456789"
+#define ALPHA        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#define DELIMITERS   DELIMITER PR_DELIMITER MT_DELIMITER
+#define VALID_CHARS  NUMBERS ALPHA DELIMITERS
+
+static const size_t MAX_SIZE     = sizeof(char) * 255;
+static const int MAX_SAFE_INT = (unsigned int) -1 >> 1;
+
+/**
+ * Define comparison operators, storing the
+ * ASCII code per each symbol in hexadecimal notation.
+ */
+
+enum operators {
+  SYMBOL_GT = 0x3e,
+  SYMBOL_LT = 0x3c,
+  SYMBOL_EQ = 0x3d,
+  SYMBOL_TF = 0x7e,
+  SYMBOL_CF = 0x5e
+};
+
+/**
+ * Private helpers
+ */
+
+/*
+ * Remove [begin:len-begin] from str by moving len data from begin+len to begin.
+ * If len is negative cut out to the end of the string.
+ */
+static int
+strcut (char *str, int begin, int len) {
+  size_t l;
+  l = strlen(str);
+
+  if((int)l < 0 || (int)l > MAX_SAFE_INT) return -1;
+
+  if (len < 0) len = l - begin + 1;
+  if (begin + len > (int)l) len = l - begin;
+  memmove(str + begin, str + begin + len, l - len + 1 - begin);
+
+  return len;
+}
+
+static int
+contains (const char c, const char *matrix, size_t len) {
+  size_t x;
+  for (x = 0; x < len; x++)
+    if ((char) matrix[x] == c) return 1;
+  return 0;
+}
+
+static int
+has_valid_chars (const char *str, const char *matrix) {
+  size_t i, len, mlen;
+  len = strlen(str);
+  mlen = strlen(matrix);
+
+  for (i = 0; i < len; i++)
+    if (contains(str[i], matrix, mlen) == 0)
+      return 0;
+
+  return 1;
+}
+
+static int
+binary_comparison (int x, int y) {
+  if (x == y) return 0;
+  if (x > y) return 1;
+  return -1;
+}
+
+static int
+parse_int (const char *s) {
+  int valid, num;
+  valid = has_valid_chars(s, NUMBERS);
+  if (valid == 0) return -1;
+
+  num = strtol(s, NULL, 10);
+  if (num > MAX_SAFE_INT) return -1;
+
+  return num;
+}
+
+/*
+ * Return a string allocated on the heap with the content from sep to end and
+ * terminate buf at sep.
+ */
+static char *
+parse_slice (char *buf, char sep) {
+  char *pr, *part;
+  int plen;
+
+  /* Find separator in buf */
+  pr = strchr(buf, sep);
+  if (pr == NULL) return NULL;
+  /* Length from separator to end of buf */
+  plen = strlen(pr);
+
+  /* Copy from buf into new string */
+  part = (char*)calloc(plen + 1, sizeof(*part));
+  if (part == NULL) return NULL;
+  memcpy(part, pr + 1, plen);
+  /* Null terminate new string */
+  part[plen] = '\0';
+
+  /* Terminate buf where separator was */
+  *pr = '\0';
+
+  return part;
+}
+
+/**
+ * Parses a string as semver expression.
+ *
+ * Returns:
+ *
+ * `0` - Parsed successfully
+ * `-1` - In case of error
+ */
+
+int
+semver_parse (const char *str, semver_t *ver) {
+  int valid, res;
+  size_t len;
+  char *buf;
+  valid = semver_is_valid(str);
+  if (!valid) return -1;
+
+  len = strlen(str);
+  buf = (char*)calloc(len + 1, sizeof(*buf));
+  if (buf == NULL) return -1;
+  strcpy(buf, str);
+
+  ver->metadata = parse_slice(buf, MT_DELIMITER[0]);
+  ver->prerelease = parse_slice(buf, PR_DELIMITER[0]);
+
+  res = semver_parse_version(buf, ver);
+  free(buf);
+#if DEBUG > 0
+  printf("[debug] semver.c %s = %d.%d.%d, %s %s\n", str, ver->major, ver->minor, ver->patch, ver->prerelease, ver->metadata);
+#endif
+  return res;
+}
+
+/**
+ * Parses a given string as semver expression.
+ *
+ * Returns:
+ *
+ * `0` - Parsed successfully
+ * `-1` - Parse error or invalid
+ */
+
+int
+semver_parse_version (const char *str, semver_t *ver) {
+  size_t len;
+  int index, value;
+  char *slice, *next, *endptr;
+  slice = (char *) str;
+  index = 0;
+
+  while (slice != NULL && index++ < 4) {
+    next = strchr(slice, DELIMITER[0]);
+    if (next == NULL)
+      len = strlen(slice);
+    else
+      len = next - slice;
+    if (len > SLICE_SIZE) return -1;
+
+    /* Cast to integer and store */
+    value = strtol(slice, &endptr, 10);
+    if (endptr != next && *endptr != '\0') return -1;
+
+    switch (index) {
+      case 1: ver->major = value; break;
+      case 2: ver->minor = value; break;
+      case 3: ver->patch = value; break;
+    }
+
+    /* Continue with the next slice */
+    if (next == NULL)
+      slice = NULL;
+    else
+      slice = next + 1;
+  }
+
+  return 0;
+}
+
+static int
+compare_prerelease (char *x, char *y) {
+  char *lastx, *lasty, *xptr, *yptr, *endptr;
+  int xlen, ylen, xisnum, yisnum, xnum, ynum;
+  int xn, yn, min, res;
+  if (x == NULL && y == NULL) return 0;
+  if (y == NULL && x) return -1;
+  if (x == NULL && y) return 1;
+
+  lastx = x;
+  lasty = y;
+  xlen = strlen(x);
+  ylen = strlen(y);
+
+  while (1) {
+    if ((xptr = strchr(lastx, DELIMITER[0])) == NULL)
+      xptr = x + xlen;
+    if ((yptr = strchr(lasty, DELIMITER[0])) == NULL)
+      yptr = y + ylen;
+
+    xnum = strtol(lastx, &endptr, 10);
+    xisnum = endptr == xptr ? 1 : 0;
+    ynum = strtol(lasty, &endptr, 10);
+    yisnum = endptr == yptr ? 1 : 0;
+
+    if (xisnum && !yisnum) return -1;
+    if (!xisnum && yisnum) return 1;
+
+    if (xisnum && yisnum) {
+      /* Numerical comparison */
+      if (xnum != ynum) return xnum < ynum ? -1 : 1;
+    } else {
+      /* String comparison */
+      xn = xptr - lastx;
+      yn = yptr - lasty;
+      min = xn < yn ? xn : yn;
+      if ((res = strncmp(lastx, lasty, min))) return res < 0 ? -1 : 1;
+      if (xn != yn) return xn < yn ? -1 : 1;
+    }
+
+    lastx = xptr + 1;
+    lasty = yptr + 1;
+    if (lastx == x + xlen + 1 && lasty == y + ylen + 1) break;
+    if (lastx == x + xlen + 1) return -1;
+    if (lasty == y + ylen + 1) return 1;
+  }
+
+  return 0;
+}
+
+int
+semver_compare_prerelease (semver_t x, semver_t y) {
+  return compare_prerelease(x.prerelease, y.prerelease);
+}
+
+/**
+ * Performs a major, minor and patch binary comparison (x, y).
+ * This function is mostly used internally
+ *
+ * Returns:
+ *
+ * `0` - If versiona are equal
+ * `1` - If x is higher than y
+ * `-1` - If x is lower than y
+ */
+
+int
+semver_compare_version (semver_t x, semver_t y) {
+  int res;
+
+  if ((res = binary_comparison(x.major, y.major)) == 0) {
+    if ((res = binary_comparison(x.minor, y.minor)) == 0) {
+      return binary_comparison(x.patch, y.patch);
+    }
+  }
+
+  return res;
+}
+
+/**
+ * Compare two semantic versions (x, y).
+ *
+ * Returns:
+ * - `1` if x is higher than y
+ * - `0` if x is equal to y
+ * - `-1` if x is lower than y
+ */
+
+int
+semver_compare (semver_t x, semver_t y) {
+  int res;
+
+  if ((res = semver_compare_version(x, y)) == 0) {
+    return semver_compare_prerelease(x, y);
+  }
+
+  return res;
+}
+
+/**
+ * Performs a `greater than` comparison
+ */
+
+int
+semver_gt (semver_t x, semver_t y) {
+  return semver_compare(x, y) == 1;
+}
+
+/**
+ * Performs a `lower than` comparison
+ */
+
+int
+semver_lt (semver_t x, semver_t y) {
+  return semver_compare(x, y) == -1;
+}
+
+/**
+ * Performs a `equality` comparison
+ */
+
+int
+semver_eq (semver_t x, semver_t y) {
+  return semver_compare(x, y) == 0;
+}
+
+/**
+ * Performs a `non equal to` comparison
+ */
+
+int
+semver_neq (semver_t x, semver_t y) {
+  return semver_compare(x, y) != 0;
+}
+
+/**
+ * Performs a `greater than or equal` comparison
+ */
+
+int
+semver_gte (semver_t x, semver_t y) {
+  return semver_compare(x, y) >= 0;
+}
+
+/**
+ * Performs a `lower than or equal` comparison
+ */
+
+int
+semver_lte (semver_t x, semver_t y) {
+  return semver_compare(x, y) <= 0;
+}
+
+/**
+ * Checks if version `x` can be satisfied by `y`
+ * performing a comparison with caret operator.
+ *
+ * See: https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4
+ *
+ * Returns:
+ *
+ * `1` - Can be satisfied
+ * `0` - Cannot be satisfied
+ */
+
+int
+semver_satisfies_caret (semver_t x, semver_t y) {
+  /* Major versions must always match. */
+  if (x.major == y.major) {
+    /* If major version is 0, minor versions must match */
+    if (x.major == 0) {
+        /* If minor version is 0, patch must match */
+        if (x.minor == 0){
+          return (x.minor == y.minor) && (x.patch == y.patch);
+        }
+        /* If minor version is not 0, patch must be >= */
+        else if (x.minor == y.minor){
+          return x.patch >= y.patch;
+        }
+        else{
+          return 0;
+        }
+      }
+    else if (x.minor > y.minor){
+      return 1;
+    }
+    else if (x.minor == y.minor)
+    {
+      return x.patch >= y.patch;
+    }
+    else {
+      return 0;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Checks if version `x` can be satisfied by `y`
+ * performing a comparison with tilde operator.
+ *
+ * See: https://docs.npmjs.com/misc/semver#tilde-ranges-1-2-3-1-2-1
+ *
+ * Returns:
+ *
+ * `1` - Can be satisfied
+ * `0` - Cannot be satisfied
+ */
+
+int
+semver_satisfies_patch (semver_t x, semver_t y) {
+  return x.major == y.major
+      && x.minor == y.minor;
+}
+
+/**
+ * Checks if both versions can be satisfied
+ * based on the given comparison operator.
+ *
+ * Allowed operators:
+ *
+ * - `=`  - Equality
+ * - `>=` - Higher or equal to
+ * - `<=` - Lower or equal to
+ * - `<`  - Lower than
+ * - `>`  - Higher than
+ * - `^`  - Caret comparison (see https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4)
+ * - `~`  - Tilde comparison (see https://docs.npmjs.com/misc/semver#tilde-ranges-1-2-3-1-2-1)
+ *
+ * Returns:
+ *
+ * `1` - Can be satisfied
+ * `0` - Cannot be satisfied
+ */
+
+int
+semver_satisfies (semver_t x, semver_t y, const char *op) {
+  int first, second;
+  /* Extract the comparison operator */
+  first = op[0];
+  second = op[1];
+
+  /* Caret operator */
+  if (first == SYMBOL_CF)
+    return semver_satisfies_caret(x, y);
+
+  /* Tilde operator */
+  if (first == SYMBOL_TF)
+    return semver_satisfies_patch(x, y);
+
+  /* Strict equality */
+  if (first == SYMBOL_EQ)
+    return semver_eq(x, y);
+
+  /* Greater than or equal comparison */
+  if (first == SYMBOL_GT) {
+    if (second == SYMBOL_EQ) {
+      return semver_gte(x, y);
+    }
+    return semver_gt(x, y);
+  }
+
+  /* Lower than or equal comparison */
+  if (first == SYMBOL_LT) {
+    if (second == SYMBOL_EQ) {
+      return semver_lte(x, y);
+    }
+    return semver_lt(x, y);
+  }
+
+  return 0;
+}
+
+/**
+ * Free heep allocated memory of a given semver.
+ * This is just a convenient function that you
+ * should call when you're done.
+ */
+
+void
+semver_free (semver_t *x) {
+  if (x->metadata) {
+    free(x->metadata);
+    x->metadata = NULL;
+  }
+  if (x->prerelease) {
+    free(x->prerelease);
+    x->prerelease = NULL;
+  }
+}
+
+/**
+ * Renders
+ */
+
+static void
+concat_num (char * str, int x, char * sep) {
+  char buf[SLICE_SIZE] = {0};
+  if (sep == NULL) sprintf(buf, "%d", x);
+  else sprintf(buf, "%s%d", sep, x);
+  strcat(str, buf);
+}
+
+static void
+concat_char (char * str, char * x, char * sep) {
+  char buf[SLICE_SIZE] = {0};
+  sprintf(buf, "%s%s", sep, x);
+  strcat(str, buf);
+}
+
+/**
+ * Render a given semver as string
+ */
+
+void
+semver_render (semver_t *x, char *dest) {
+  concat_num(dest, x->major, NULL);
+  concat_num(dest, x->minor, DELIMITER);
+  concat_num(dest, x->patch, DELIMITER);
+  if (x->prerelease) concat_char(dest, x->prerelease, PR_DELIMITER);
+  if (x->metadata) concat_char(dest, x->metadata, MT_DELIMITER);
+}
+
+/**
+ * Version bump helpers
+ */
+
+void
+semver_bump (semver_t *x) {
+  x->major++;
+}
+
+void
+semver_bump_minor (semver_t *x) {
+  x->minor++;
+}
+
+void
+semver_bump_patch (semver_t *x) {
+  x->patch++;
+}
+
+/**
+ * Helpers
+ */
+
+static int
+has_valid_length (const char *s) {
+  return strlen(s) <= MAX_SIZE;
+}
+
+/**
+ * Checks if a given semver string is valid
+ *
+ * Returns:
+ *
+ * `1` - Valid expression
+ * `0` - Invalid
+ */
+
+int
+semver_is_valid (const char *s) {
+  return has_valid_length(s)
+      && has_valid_chars(s, VALID_CHARS);
+}
+
+/**
+ * Removes non-valid characters in the given string.
+ *
+ * Returns:
+ *
+ * `0`  - Valid
+ * `-1` - Invalid input
+ */
+
+int
+semver_clean (char *s) {
+  size_t i, len, mlen;
+  int res;
+  if (has_valid_length(s) == 0) return -1;
+
+  len = strlen(s);
+  mlen = strlen(VALID_CHARS);
+
+  for (i = 0; i < len; i++) {
+    if (contains(s[i], VALID_CHARS, mlen) == 0) {
+      res = strcut(s, i, 1);
+      if(res == -1) return -1;
+      --len; --i;
+    }
+  }
+
+  return 0;
+}
+
+static int
+char_to_int (const char * str) {
+  int buf;
+  size_t i,len, mlen;
+  buf = 0;
+  len = strlen(str);
+  mlen = strlen(VALID_CHARS);
+
+  for (i = 0; i < len; i++)
+    if (contains(str[i], VALID_CHARS, mlen))
+      buf += (int) str[i];
+
+  return buf;
+}
+
+/**
+ * Render a given semver as numeric value.
+ * Useful for ordering and filtering.
+ */
+
+int
+semver_numeric (semver_t *x) {
+  int num;
+  char buf[SLICE_SIZE * 3];
+  memset(&buf, 0, SLICE_SIZE * 3);
+
+  if (x->major) concat_num(buf, x->major, NULL);
+  if (x->major || x->minor) concat_num(buf, x->minor, NULL);
+  if (x->major || x->minor || x->patch) concat_num(buf, x->patch, NULL);
+
+  num = parse_int(buf);
+  if(num == -1) return -1;
+
+  if (x->prerelease) num += char_to_int(x->prerelease);
+  if (x->metadata) num += char_to_int(x->metadata);
+
+  return num;
+}

--- a/bootstrap/source/vendor/semver.h
+++ b/bootstrap/source/vendor/semver.h
@@ -1,0 +1,105 @@
+/*
+ * semver.h
+ *
+ * Copyright (c) 2015-2017 Tomas Aparicio
+ * MIT licensed
+ */
+
+#ifndef __SEMVER_H
+#define __SEMVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef SEMVER_VERSION
+#define SEMVER_VERSION "0.2.0"
+#endif
+
+/**
+ * semver_t struct
+ */
+
+typedef struct semver_version_s {
+  int major;
+  int minor;
+  int patch;
+  char * metadata;
+  char * prerelease;
+} semver_t;
+
+/**
+ * Set prototypes
+ */
+
+int
+semver_satisfies (semver_t x, semver_t y, const char *op);
+
+int
+semver_satisfies_caret (semver_t x, semver_t y);
+
+int
+semver_satisfies_patch (semver_t x, semver_t y);
+
+int
+semver_compare (semver_t x, semver_t y);
+
+int
+semver_compare_version (semver_t x, semver_t y);
+
+int
+semver_compare_prerelease (semver_t x, semver_t y);
+
+int
+semver_gt (semver_t x, semver_t y);
+
+int
+semver_gte (semver_t x, semver_t y);
+
+int
+semver_lt (semver_t x, semver_t y);
+
+int
+semver_lte (semver_t x, semver_t y);
+
+int
+semver_eq (semver_t x, semver_t y);
+
+int
+semver_neq (semver_t x, semver_t y);
+
+int
+semver_parse (const char *str, semver_t *ver);
+
+int
+semver_parse_version (const char *str, semver_t *ver);
+
+void
+semver_render (semver_t *x, char *dest);
+
+int
+semver_numeric (semver_t *x);
+
+void
+semver_bump (semver_t *x);
+
+void
+semver_bump_minor (semver_t *x);
+
+void
+semver_bump_patch (semver_t *x);
+
+void
+semver_free (semver_t *x);
+
+int
+semver_is_valid (const char *s);
+
+int
+semver_clean (char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/bootstrap/test/match-test.c
+++ b/bootstrap/test/match-test.c
@@ -1,0 +1,103 @@
+// Host unit test for the slim launcher's runtime-version matching logic
+// (bootstrap/source/match.c). Compiles + runs on the host (no libnx), so the
+// semver specifier handling can be verified without Switch hardware.
+//
+// Build & run:
+//   cc -I../source -o /tmp/match-test match-test.c ../source/match.c \
+//      ../source/vendor/semver.c && /tmp/match-test
+//
+// (See bootstrap/test/run.sh.)
+
+#include <stdio.h>
+#include <string.h>
+
+#include "match.h"
+
+static int failures = 0;
+static int checks = 0;
+
+static void expect_satisfies(const char *cand, const char *spec, bool want) {
+	checks++;
+	bool got = nx_version_satisfies(cand, spec);
+	if (got != want) {
+		failures++;
+		printf("FAIL: nx_version_satisfies(\"%s\", \"%s\") = %d, expected %d\n",
+		       cand, spec, got, want);
+	}
+}
+
+static void expect_cmp(const char *a, const char *b, int want_sign) {
+	checks++;
+	int r = nx_version_compare(a, b);
+	int sign = (r > 0) - (r < 0);
+	if (sign != want_sign) {
+		failures++;
+		printf("FAIL: nx_version_compare(\"%s\", \"%s\") sign = %d, expected %d\n",
+		       a, b, sign, want_sign);
+	}
+}
+
+int main(void) {
+	// --- Bare specifier => caret-on-major semantics ---
+	expect_satisfies("1.0.0", "1", true);
+	expect_satisfies("1.5.9", "1", true);
+	expect_satisfies("2.0.0", "1", false);
+	expect_satisfies("0.9.0", "1", false);
+
+	// --- Caret ---
+	expect_satisfies("1.2.3", "^1.2.0", true);
+	expect_satisfies("1.9.9", "^1.2.0", true);
+	expect_satisfies("2.0.0", "^1.2.0", false);
+	expect_satisfies("1.1.0", "^1.2.0", false); // below the floor
+
+	// --- Tilde (patch-level within minor) ---
+	expect_satisfies("1.2.9", "~1.2.0", true);
+	expect_satisfies("1.3.0", "~1.2.0", false);
+
+	// --- Comparators ---
+	expect_satisfies("1.2.0", ">=1.2.0", true);
+	expect_satisfies("1.5.0", ">=1.2.0", true);
+	expect_satisfies("1.1.0", ">=1.2.0", false);
+	expect_satisfies("2.0.0", ">1", true);
+	expect_satisfies("0.9.0", "<1", true);
+	expect_satisfies("1.0.0", "<1", false);
+	expect_satisfies("1.0.0", "=1.0.0", true);
+	expect_satisfies("1.0.1", "=1.0.0", false);
+
+	// --- Wildcard ---
+	expect_satisfies("0.0.1", "*", true);
+	expect_satisfies("99.5.2", "*", true);
+
+	// --- Partial versions in specifier (minor) ---
+	expect_satisfies("1.2.5", "1.2", true);  // bare 1.2 => ^1.2.0
+	// Caret allows minor/patch bumps within the same major, so 1.3.0 DOES
+	// satisfy ^1.2.0 (== >=1.2.0 <2.0.0).
+	expect_satisfies("1.3.0", "1.2", true);
+	expect_satisfies("2.0.0", "1.2", false); // major bump is out of range
+
+	// --- Prerelease ---
+	// NOTE: the vendored semver.c does NOT implement node-semver's rule that a
+	// prerelease is excluded from a non-prerelease range. It compares purely by
+	// precedence, so a bare "1" (=> ^1.0.0) DOES match a "1.0.0-beta.N" build.
+	// During the v1 beta this is intentionally convenient: an app requesting
+	// "^1" can run on the only existing (prerelease) runtime.
+	expect_satisfies("1.0.0-beta.1", "1", true);
+	// Explicit prerelease ranges also work by precedence.
+	expect_satisfies("1.0.0-beta.2", ">=1.0.0-beta.1", true);
+	expect_satisfies("1.0.0-beta.1", ">=1.0.0-beta.1", true);
+	expect_satisfies("1.0.0-beta.1", ">=1.0.0-beta.2", false);
+
+	// --- Comparison / "pick highest" ordering ---
+	expect_cmp("1.2.0", "1.10.0", -1);  // numeric, not lexical
+	expect_cmp("1.10.0", "1.2.0", 1);
+	expect_cmp("1.0.0", "1.0.0", 0);
+	expect_cmp("2.0.0", "1.9.9", 1);
+	// Prerelease sorts below its release.
+	expect_cmp("1.0.0-beta.1", "1.0.0", -1);
+	expect_cmp("1.0.0-beta.2", "1.0.0-beta.1", 1);
+	// Invalid versions sort lowest.
+	expect_cmp("not-a-version", "1.0.0", -1);
+
+	printf("%d checks, %d failures\n", checks, failures);
+	return failures == 0 ? 0 : 1;
+}

--- a/bootstrap/test/run.sh
+++ b/bootstrap/test/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build + run the host unit test for the slim launcher's version matching.
+# Uses the host C compiler (no devkitPro / libnx needed).
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CC="${CC:-cc}"
+OUT="$(mktemp -d)/match-test"
+
+"$CC" -std=gnu11 -Wall -Wextra -I../source \
+	-o "$OUT" \
+	match-test.c ../source/match.c ../source/vendor/semver.c
+
+"$OUT"

--- a/packages/create-nxjs-app/src/main.ts
+++ b/packages/create-nxjs-app/src/main.ts
@@ -154,6 +154,27 @@ try {
 		throw packageManager;
 	}
 
+	// Ask whether to build a "slim" or "fat" NRO.
+	const packaging = await clack.select({
+		message: 'How should the app be packaged?',
+		options: [
+			{
+				label: 'Slim',
+				value: 'slim',
+				hint: 'tiny NRO; shares one runtime installed at sdmc:/nx.js/ (recommended)',
+			},
+			{
+				label: 'Fat',
+				value: 'fat',
+				hint: 'self-contained ~40 MB NRO with the runtime embedded',
+			},
+		],
+		initialValue: 'slim',
+	});
+	if (clack.isCancel(packaging)) {
+		throw packaging;
+	}
+
 	// Wait for cloning to complete
 	const spinner = clack.spinner();
 	spinner.start(
@@ -200,6 +221,17 @@ try {
 
 	resolveProtocols(packageJson.dependencies, data.packages, data.catalog);
 	resolveProtocols(packageJson.devDependencies, data.packages, data.catalog);
+
+	// Slim packaging: build the app as a tiny launcher NRO that chainloads a
+	// shared runtime from sdmc:/nx.js/ (via `nxjs-nro --slim`). Fat keeps the
+	// default self-contained `nxjs-nro`.
+	if (packaging === 'slim' && packageJson.scripts?.nro) {
+		const nro = packageJson.scripts.nro;
+		if (/\bnxjs-nro\b/.test(nro) && !/--slim\b/.test(nro)) {
+			packageJson.scripts.nro = `${nro} --slim`;
+		}
+	}
+
 	await fs.writeFile(
 		packageJsonUrl,
 		`${JSON.stringify(
@@ -245,6 +277,18 @@ try {
 	console.log(chalk.bold('Next steps'));
 	console.log();
 	const cmd = chalk.yellow;
+	if (packaging === 'slim') {
+		console.log(
+			` • ${chalk.cyan('Slim')} packaging: install an nx.js runtime NRO at ${cmd(
+				'sdmc:/nx.js/nxjs-v<version>.nro',
+			)}`,
+		);
+		console.log(
+			`   on your SD card (the app's NRO chainloads it). The required version`,
+		);
+		console.log(`   is set in ${cmd('romfs/nxjs.ini')} under ${cmd('[runtime]')}.`);
+		console.log();
+	}
 	if (packageManager === 'skip') {
 		console.log(` • Run the following command: ${cmd(`cd ${slugifiedName}`)}`);
 		console.log(` • Install dependencies using your preferred package manager`);

--- a/packages/nro/src/main.ts
+++ b/packages/nro/src/main.ts
@@ -19,13 +19,40 @@ import terminalImage from 'terminal-image';
 const cwd = process.cwd();
 const appRoot = new URL(`${pathToFileURL(cwd)}/`);
 const isSrcMode = existsSync(new URL('../tsconfig.json', import.meta.url));
-const nxjsNroUrl = new URL(
-	isSrcMode ? '../../../nxjs.nro' : '../dist/nxjs.nro',
+
+// Slim mode: instead of embedding the full ~40 MB runtime, use the tiny
+// `bootstrap.nro` launcher as the base. The launcher chainloads a shared
+// runtime from `sdmc:/nx.js/` at boot. Enabled via `--slim` or `NXJS_SLIM=1`.
+const slim =
+	process.argv.slice(2).includes('--slim') || process.env.NXJS_SLIM === '1';
+
+// The base NRO whose code segments we reuse: the bootstrap launcher (slim) or
+// the full runtime (fat).
+const baseName = slim ? 'bootstrap.nro' : 'nxjs.nro';
+const baseNroUrl = new URL(
+	isSrcMode
+		? slim
+			? '../../../bootstrap/bootstrap.nro'
+			: '../../../nxjs.nro'
+		: `../dist/${baseName}`,
 	import.meta.url,
 );
-const nxjsNroBuffer = readFileSync(nxjsNroUrl);
+const nxjsNroBuffer = readFileSync(baseNroUrl);
 const nxjsNroBlob = new Blob([nxjsNroBuffer]);
 const nxjsNro = await NRO.decode(nxjsNroBlob);
+
+if (slim) {
+	console.log(
+		chalk.bold(
+			`Building a ${chalk.cyan('slim')} NRO (shared runtime via bootstrap launcher).`,
+		),
+	);
+	console.log(
+		chalk.dim(
+			'  Requires an nx.js runtime NRO installed at sdmc:/nx.js/nxjs-v<version>.nro\n',
+		),
+	);
+}
 
 // Icon
 let icon = nxjsNro.icon;
@@ -70,7 +97,12 @@ for (const [k, v] of updated) {
 // RomFS
 const romfsDir = new URL('romfs/', appRoot);
 const romfsDirPath = fileURLToPath(romfsDir);
-const romfs = await RomFS.decode(nxjsNro.romfs!);
+// Fat base (nxjs.nro) ships a RomFS (runtime.js.map, GeistMono.ttf) to merge
+// the app's files into. The slim base (bootstrap.nro) has no RomFS, so start
+// from an empty tree.
+const romfs: RomFS.RomFsEntry = nxjsNro.romfs
+	? await RomFS.decode(nxjsNro.romfs)
+	: Object.create(null);
 console.log();
 console.log(chalk.bold('RomFS Files:'));
 
@@ -104,6 +136,33 @@ try {
 } catch (err: any) {
 	// Don't crash if there is no `romfs` directory
 	if (err.code !== 'ENOENT') throw err;
+}
+
+// Slim apps need an `nxjs.ini` with a `[runtime] version` semver requirement in
+// their RomFS — the bootstrap launcher reads it to pick which shared runtime to
+// chainload. If the app didn't provide one (no `romfs/nxjs.ini` with a
+// [runtime] section), write a default caret-on-major requirement derived from
+// this @nx.js/nro package's version (which tracks the runtime).
+if (slim) {
+	const existingIni = romfs['nxjs.ini'];
+	const existingIniText =
+		existingIni instanceof Blob ? await existingIni.text() : '';
+	const hasRuntimeSection = /^\s*\[runtime\]/im.test(existingIniText);
+	if (!hasRuntimeSection) {
+		const selfPkg = JSON.parse(
+			readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+		);
+		const major = String(selfPkg.version).replace(/[.-].*/, '');
+		const runtimeReq = `^${major}`;
+		// Prepend a [runtime] section, preserving any existing ini content.
+		const merged =
+			`[runtime]\n; nx.js shared runtime version requirement (semver).\nversion = ${runtimeReq}\n` +
+			(existingIniText ? `\n${existingIniText}` : '');
+		romfs['nxjs.ini'] = new Blob([merged]);
+		console.log(
+			`  ${chalk.cyan('nxjs.ini')} (generated; [runtime] version = ${runtimeReq})`,
+		);
+	}
 }
 
 const outputNroName = `${packageJson.name}.nro`;

--- a/source/config.cc
+++ b/source/config.cc
@@ -180,6 +180,14 @@ static int ini_cb(void *user, const char *section, const char *name,
 		return 1;
 	}
 
+	// [runtime] is consumed by the slim bootstrap LAUNCHER (it selects which
+	// shared runtime NRO to chainload), not by the runtime itself. The same
+	// nxjs.ini ships inside a slim app's RomFS and is read here too, so accept
+	// and ignore the section silently rather than logging it as unknown.
+	if (str_ieq(section, "runtime")) {
+		return 1;
+	}
+
 	cfg_log("[%s] section ignored: unknown", section);
 	return 1;
 }

--- a/source/config.h
+++ b/source/config.h
@@ -28,6 +28,9 @@
 //   num_bsd_sessions    = 3
 //   service_type        = auto   ; auto | user | system
 //
+//   [runtime]                    ; consumed by the slim bootstrap LAUNCHER, not
+//   version = ^1                 ; the runtime; recognized+ignored here.
+//
 // Parsing happens VERY early in main() (before V8::Initialize), using plain
 // fopen via the bundled inih parser, because the V8 flag/heap settings must be
 // applied before the isolate is created. The JS `fetch`/`readFileSync` layer


### PR DESCRIPTION
## Summary

Adds a **slim** packaging mode so an app NRO no longer has to embed the full ~40 MB runtime. A tiny pure-C launcher chainloads a **shared** runtime installed at `sdmc:/nx.js/nxjs-v<version>.nro`.

> **Base branch:** this is stacked on `feat/nxjs-ini-config` (#359) — it reuses the `nxjs.ini`/inih infrastructure and adds a `[runtime]` section. Merge after #359.

## How it works

1. The slim app NRO is launched from hbmenu.
2. The launcher (`bootstrap/`, libnx-only — no V8/Skia) reads `[runtime] version` (a semver requirement) from its own `romfs:/nxjs.ini` (default baked at build = `^<runtime-major>`).
3. It scans `sdmc:/nx.js/nxjs-v<full-version>.nro` and picks the **highest installed version** satisfying the requirement (vendored `h2non/semver.c`).
4. `envSetNextLoad(<runtime>, "\"<runtime>\" \"<self.nro>\"")` + exit.
5. hbloader loads the runtime with `argv[1]` = the slim NRO; the runtime's existing `mount_nro_romfs(argv[1])` mounts the slim NRO's RomFS as `romfs:` and runs `romfs:/main.js`. **No runtime execution-path changes.**

No compatible runtime / not launched via hbloader ⇒ a clear on-screen error (wait for `+`), never a crash.

## Components

- **`bootstrap/`** — the launcher (`source/main.c`), a minimal devkitPro `Makefile`, vendored `semver.c` (MIT) + `ini.h` (BSD-3). The version-matching logic is split into `source/match.c` (no libnx) so it's **host-unit-tested** (`bootstrap/test/run.sh`, 34 checks).
- **`@nx.js/nro --slim`** — uses `bootstrap.nro` as the base instead of `nxjs.nro`; stages the app's `romfs/` and writes a default `[runtime] version = ^<major>` `nxjs.ini` if the app has none. Verified locally: `hello-world` → **251 KB** NRO (vs ~40 MB fat).
- **`create-nxjs-app`** — prompts to package **Slim** (default) or **Fat**; slim sets the `nro` script to `nxjs-nro --slim` and prints SD-card install guidance.
- **Runtime config parser** — recognizes + silently ignores the `[runtime]` section (the same `nxjs.ini` ships in the slim RomFS and is read by both).
- **CI** — builds `bootstrap.nro` (devkitPro container) and copies it into `packages/nro/dist/` on release, next to `nxjs.nro`.

## SD-card convention (new)

Shared runtimes live at `sdmc:/nx.js/nxjs-v<full-version>.nro` (e.g. `nxjs-v1.0.0-beta.1.nro`); multiple versions may coexist. No download feature yet — the runtime NRO is assumed to already be installed.

## Testing

- ✅ `make -C bootstrap` → `bootstrap.nro` (256 KB, clean).
- ✅ `@nx.js/nro --slim` on hello-world → 251 KB NRO; decoded RomFS contains `main.js`, `main.js.map`, generated `nxjs.ini` (`[runtime] version = ^1`).
- ✅ Host semver-match unit test: 34/34 (`bootstrap/test/run.sh`).
- ✅ `@nx.js/nro` + `create-nxjs-app` TypeScript builds clean; runtime device build compiles with the `[runtime]` parser change.
- ⚠️ **On-device chainload verification pending** (hardware unavailable). To verify: install the runtime at `sdmc:/nx.js/nxjs-v1.0.0-beta.1.nro`, launch a slim hello-world, confirm it boots; rename the runtime away to confirm the error path.

## Notes

- The vendored `semver.c` compares purely by precedence and does **not** apply node-semver's "prereleases excluded from non-prerelease ranges" rule, so `^1` matches `1.0.0-beta.N` — **intentional** during the v1 beta (otherwise a slim app couldn't find the only existing prerelease runtime). Documented in AGENTS.md + the host test.
- `@nx.js/nro` **minor** changeset (create-nxjs-app bumps with it via the fixed group).