### PR TITLE
chore: eliminate C++ compile warnings

### DIFF
--- a/.changeset/clean-compile-warnings.md
+++ b/.changeset/clean-compile-warnings.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+chore: clean up all C++ compile warnings — consume the `[[nodiscard]]` results of V8 `Maybe::To()`/`MaybeLocal::ToLocal()` in audio/crypto/service (defaulting on failure), replace a truncating `strncpy` with `snprintf`, value-initialize the `sk_sp`-containing font-face struct with placement-new instead of `memset`, and suppress unavoidable third-party header warnings (Skia's `clang::reinitializes` attribute, V8's `GetIsolate()` strict-aliasing type-pun). The device build is now warning-free.

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,14 @@ CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -D_DEFAULT_SOURCE $(UV_CFLAGS) \
 SKIA_CFLAGS	:=	-DSK_GL -DSK_BUILD_FOR_UNIX -I$(PORTLIBS)/include/skia
 
 # V8's API is C++; nx.js native modules are C++ (.cc), no exceptions/RTTI, C++20.
-# -Wno-comment: V8 headers (v8-internal.h) contain ASCII-art block comments.
-CXXFLAGS	:=	$(CFLAGS) $(SKIA_CFLAGS) -fno-rtti -fno-exceptions -std=c++20 -Wno-comment
+# Third-party header noise we can't fix in our code:
+#   -Wno-comment: V8 headers (v8-internal.h) contain ASCII-art block comments.
+#   -Wno-attributes: Skia's SkTemplates.h uses the clang-only `clang::reinitializes`
+#     scoped attribute, which devkitPro GCC doesn't recognize.
+#   -Wno-strict-aliasing: V8's v8-function-callback.h PropertyCallbackInfo::
+#     GetIsolate() does a reinterpret_cast type-pun in the engine headers.
+CXXFLAGS	:=	$(CFLAGS) $(SKIA_CFLAGS) -fno-rtti -fno-exceptions -std=c++20 \
+			-Wno-comment -Wno-attributes -Wno-strict-aliasing
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=${DEVKITPRO}/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/source/audio.cc
+++ b/source/audio.cc
@@ -265,12 +265,20 @@ void nx_audio_decode(const FunctionCallbackInfo<Value> &info) {
 // Argument helpers.
 int arg_i32(const FunctionCallbackInfo<Value> &info, int i) {
 	int32_t v = 0;
-	(void)info[i]->Int32Value(info.GetIsolate()->GetCurrentContext()).To(&v);
+	if (!info[i]
+	         ->Int32Value(info.GetIsolate()->GetCurrentContext())
+	         .To(&v)) {
+		v = 0; // conversion threw/failed; default to 0
+	}
 	return v;
 }
 double arg_f64(const FunctionCallbackInfo<Value> &info, int i) {
 	double v = 0;
-	(void)info[i]->NumberValue(info.GetIsolate()->GetCurrentContext()).To(&v);
+	if (!info[i]
+	         ->NumberValue(info.GetIsolate()->GetCurrentContext())
+	         .To(&v)) {
+		v = 0; // conversion threw/failed; default to 0
+	}
 	return v;
 }
 

--- a/source/crypto.cc
+++ b/source/crypto.cc
@@ -584,7 +584,8 @@ bool nx_crypto_parse_cipher_params(Isolate *iso, Local<Value> algorithm,
 		    algo->Get(context, nx_str(iso, "tagLength")).ToLocal(&tag_val) &&
 		    !tag_val->IsUndefined() && !tag_val->IsNull()) {
 			uint32_t tag_bits = 0;
-			tag_val->Uint32Value(context).To(&tag_bits);
+			if (!tag_val->Uint32Value(context).To(&tag_bits))
+				tag_bits = 0;
 			gcm_params->tag_length = tag_bits / 8;
 		} else {
 			gcm_params->tag_length = 16;
@@ -607,11 +608,13 @@ bool nx_crypto_parse_cipher_params(Isolate *iso, Local<Value> algorithm,
 		}
 		if (!algo.IsEmpty() &&
 		    algo->Get(context, nx_str(iso, "sector")).ToLocal(&v)) {
-			v->Uint32Value(context).To(&sector);
+			if (!v->Uint32Value(context).To(&sector))
+				sector = 0;
 		}
 		if (!algo.IsEmpty() &&
 		    algo->Get(context, nx_str(iso, "sectorSize")).ToLocal(&v)) {
-			v->Uint32Value(context).To(&sector_size);
+			if (!v->Uint32Value(context).To(&sector_size))
+				sector_size = 0;
 		}
 		xts_params->is_nintendo = is_nintendo;
 		xts_params->sector = sector;
@@ -1209,7 +1212,8 @@ bool nx_crypto_parse_usages(Isolate *iso, Local<Value> usages_val,
 	if (!arr->Get(context, nx_str(iso, "length")).ToLocal(&len_val))
 		return true;
 	uint32_t n = 0;
-	len_val->Uint32Value(context).To(&n);
+	if (!len_val->Uint32Value(context).To(&n))
+		n = 0;
 	uint32_t mask = 0;
 	for (uint32_t i = 0; i < n; i++) {
 		Local<Value> uv;
@@ -1460,7 +1464,9 @@ void nx_crypto_key_new(const FunctionCallbackInfo<Value> &info) {
 		}
 		memcpy(hmac->key, key_data, key_size);
 		hmac->key_length = key_size;
-		strncpy(hmac->hash_name, hash_name, sizeof(hmac->hash_name) - 1);
+		// Copy at most size-1 bytes and always NUL-terminate (strncpy alone
+		// wouldn't terminate a src that fills the buffer -> -Wstringop-truncation).
+		snprintf(hmac->hash_name, sizeof(hmac->hash_name), "%s", hash_name);
 		kctx->handle = hmac;
 	} else if (strcmp(algo_name, "ECDSA") == 0 ||
 	           strcmp(algo_name, "ECDH") == 0) {
@@ -2212,15 +2218,22 @@ void nx_crypto_key_new_ec_private(const FunctionCallbackInfo<Value> &info) {
 	kctx->type = NX_CRYPTO_KEY_TYPE_PRIVATE;
 
 	Local<Object> algo = info[0].As<Object>();
+	// If a property access throws/returns empty, the handle stays empty and
+	// Utf8Value below yields "" (falls through to the ECDH default / curve
+	// lookup fails cleanly). The `if (!...)` consumes the [[nodiscard]] result.
 	Local<Value> name_val;
-	algo->Get(context, nx_str(iso, "name")).ToLocal(&name_val);
+	if (!algo->Get(context, nx_str(iso, "name")).ToLocal(&name_val)) {
+		// leave name_val empty
+	}
 	String::Utf8Value algo_name(iso, name_val);
 	kctx->algorithm = (*algo_name && strcmp(*algo_name, "ECDSA") == 0)
 	                      ? NX_CRYPTO_KEY_ALGORITHM_ECDSA
 	                      : NX_CRYPTO_KEY_ALGORITHM_ECDH;
 
 	Local<Value> curve_val;
-	algo->Get(context, nx_str(iso, "namedCurve")).ToLocal(&curve_val);
+	if (!algo->Get(context, nx_str(iso, "namedCurve")).ToLocal(&curve_val)) {
+		// leave curve_val empty
+	}
 	String::Utf8Value curve(iso, curve_val);
 	const char *curve_name = *curve;
 	mbedtls_ecp_group_id grp_id;
@@ -2493,7 +2506,8 @@ void nx_crypto_derive_bits(const FunctionCallbackInfo<Value> &info) {
 			uint32_t iterations = 0;
 			if (algo->Get(context, nx_str(iso, "iterations"))
 			        .ToLocal(&iter_val)) {
-				iter_val->Uint32Value(context).To(&iterations);
+				if (!iter_val->Uint32Value(context).To(&iterations))
+					iterations = 0;
 			}
 			data->iterations = iterations;
 		} else if (data->key->algorithm == NX_CRYPTO_KEY_ALGORITHM_HKDF) {

--- a/source/font.cc
+++ b/source/font.cc
@@ -4,6 +4,7 @@
 #include "util.h"
 #include "wrap.h"
 #include <harfbuzz/hb-ot.h>
+#include <new>
 #include <stdlib.h>
 #include <string.h>
 #include <switch.h>
@@ -43,7 +44,10 @@ void nx_new_font_face(const FunctionCallbackInfo<Value> &info) {
 	    (nx_font_face_t *)nx_alloc(iso, sizeof(nx_font_face_t));
 	if (!context)
 		return;
-	memset(context, 0, sizeof(nx_font_face_t));
+	// Placement-new to value-initialize: the struct holds an sk_sp<SkTypeface>
+	// (non-trivial), so memset() over it is UB (-Wclass-memaccess). The matching
+	// teardown is free_font_face(), which resets the sk_sp before free().
+	new (context) nx_font_face_t();
 	context->font_buffer = (FT_Byte *)nx_alloc(iso, bytes);
 	if (!context->font_buffer) {
 		free(context);

--- a/source/service.cc
+++ b/source/service.cc
@@ -86,8 +86,11 @@ void nx_service_dispatch_in_out(const FunctionCallbackInfo<Value> &info) {
 		Local<Object> opts = info[3].As<Object>();
 		Local<Value> v;
 		if (opts->Get(c, nx_str(iso, "targetSession")).ToLocal(&v) &&
-		    v->IsNumber())
-			(void)v->Uint32Value(c).To(&disp.target_session);
+		    v->IsNumber()) {
+			uint32_t ts = 0;
+			if (v->Uint32Value(c).To(&ts))
+				disp.target_session = ts;
+		}
 		disp.context = prop_u32(iso, opts, "context", 0);
 
 		// bufferAttrs (array of up to 8 numbers)
@@ -111,7 +114,8 @@ void nx_service_dispatch_in_out(const FunctionCallbackInfo<Value> &info) {
 			Local<Value> len_v;
 			if (!a->Get(c, nx_str(iso, "length")).ToLocal(&len_v))
 				return;
-			(void)len_v->Uint32Value(c).To(&length);
+			if (!len_v->Uint32Value(c).To(&length))
+				length = 0;
 			for (uint32_t i = 0; i < length && i < 8; i++) {
 				Local<Value> e;
 				if (a->Get(c, i).ToLocal(&e)) {
@@ -129,7 +133,8 @@ void nx_service_dispatch_in_out(const FunctionCallbackInfo<Value> &info) {
 			Local<Value> len_v;
 			if (!a->Get(c, nx_str(iso, "length")).ToLocal(&len_v))
 				return;
-			(void)len_v->Uint32Value(c).To(&disp.in_num_objects);
+			if (!len_v->Uint32Value(c).To(&disp.in_num_objects))
+				disp.in_num_objects = 0;
 			for (uint32_t i = 0; i < disp.in_num_objects && i < 8; i++) {
 				Local<Value> e;
 				if (!a->Get(c, i).ToLocal(&e))
@@ -149,7 +154,8 @@ void nx_service_dispatch_in_out(const FunctionCallbackInfo<Value> &info) {
 			Local<Value> len_v;
 			if (!a->Get(c, nx_str(iso, "length")).ToLocal(&len_v))
 				return;
-			(void)len_v->Uint32Value(c).To(&disp.out_num_objects);
+			if (!len_v->Uint32Value(c).To(&disp.out_num_objects))
+				disp.out_num_objects = 0;
 			for (uint32_t i = 0; i < disp.out_num_objects && i < 8; i++) {
 				Local<Value> e;
 				if (!a->Get(c, i).ToLocal(&e))


### PR DESCRIPTION
## Summary

The device `make` build emitted a pile of warnings; this cleans them all up so a clean build is **warning-free** (0 warnings, 0 errors verified locally).

## Our code

- **`-Wunused-result`** on V8 `Maybe::To()` / `MaybeLocal::ToLocal()` in `audio.cc`, `crypto.cc`, `service.cc` — a `(void)` cast does **not** silence GCC's `warn_unused_result`. Now the boolean result is consumed (`if (!…To(&v)) v = default;`), matching the codebase's existing checked-conversion convention (e.g. `prop_u32`). Behavior is unchanged: values still default on a failed/thrown conversion.
- **`-Wstringop-truncation`** in `crypto.cc`: `strncpy(dst, src, sizeof(dst)-1)` could leave `dst` un-terminated when `src` fills the buffer. Replaced with `snprintf`, which always NUL-terminates.
- **`-Wclass-memaccess`** in `font.cc`: `nx_font_face_t` holds an `sk_sp<SkTypeface>` (non-trivial), so `memset`-ing it is UB. Now value-initialized with placement-new (`new (context) nx_font_face_t()`); the matching `free_font_face()` already `.reset()`s the `sk_sp` before `free()`.

## Third-party headers (can't fix, suppressed in the Makefile)

- **`-Wno-attributes`** — Skia's `SkTemplates.h` uses the clang-only `clang::reinitializes` scoped attribute, which devkitPro GCC doesn't recognize.
- **`-Wno-strict-aliasing`** — V8's `v8-function-callback.h` `PropertyCallbackInfo::GetIsolate()` does a `reinterpret_cast` type-pun inside the engine headers (hit by virtually every TU).

Both are added next to the existing `-Wno-comment` (already used for V8's ASCII-art comments), with an explanatory comment.

## Testing

- ✅ Clean `make` from scratch: **0 warnings, 0 errors**, NRO builds.
- No functional change; `@nx.js/runtime` **patch** changeset included.