### PR TITLE
ci: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
     container: ghcr.io/tootallnate/pacman-packages@sha256:5fd521a2e2e884e41a42ce5bd412b17ae0498d5a5e61a66b6ca836b6b7bc66b8
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: package.json
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: "pnpm"
@@ -48,17 +48,17 @@ jobs:
       - name: Build slim `bootstrap.nro`
         run: make -C bootstrap V=1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: nxjs.nro
           path: nxjs.nro
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bootstrap.nro
           path: bootstrap/bootstrap.nro
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: nxjs.nsp
           path: |
@@ -78,21 +78,21 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download `nxjs.nro`
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nxjs.nro
 
       - name: Download `bootstrap.nro`
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bootstrap.nro
           path: bootstrap-artifact
 
       - name: Download `nxjs.nsp`
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nxjs.nsp
 
@@ -100,12 +100,12 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: package.json
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           cache: "pnpm"
@@ -153,7 +153,7 @@ jobs:
     container: ghcr.io/tootallnate/pacman-packages@sha256:5fd521a2e2e884e41a42ce5bd412b17ae0498d5a5e61a66b6ca836b6b7bc66b8
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install build + host toolchain deps
         run: |
@@ -168,12 +168,12 @@ jobs:
           # relocations that lld-16 cannot process — it would leave .init_array
           # unrelocated and the binary would crash at startup).
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: package.json
 

--- a/.github/workflows/type-diff.yml
+++ b/.github/workflows/type-diff.yml
@@ -12,23 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: pr
 
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: pr/package.json
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: pnpm


### PR DESCRIPTION
## Summary

GitHub is deprecating Node 20 actions (they'll be forced to Node 24 on 2026-06-16, and Node 20 removed from runners on 2026-09-16). The CI run surfaced the deprecation warning for `actions/checkout@v4`, `actions/setup-node@v4`, and `pnpm/action-setup@v4`.

Bumped every action to its latest major (all run on **Node 24**):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `pnpm/action-setup` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |

Also bumped the artifact actions — `@v4` of those was still on Node 20, so this clears the deprecation for them too. `changesets/action@v1` already runs on Node 24 and is left as-is.

## Compatibility checked

- Verified each new major's `action.yml` declares `using: node24`.
- `pnpm/action-setup@v6` resolves pnpm from the root `package.json` `packageManager` field (`pnpm@10.30.3`), which is set.
- `setup-node`'s `cache: "pnpm"` jobs all run `pnpm/action-setup` first (correct ordering preserved).
- Artifact usage is simple named single-file upload/download (no `merge-multiple`/`pattern`), compatible with the v7/v8 breaking changes.

CI-only change; no changeset needed.