### PR TITLE
feat: use the nx.js default icon for the slim bootstrap launcher

### DIFF
--- a/.changeset/bootstrap-nxjs-icon.md
+++ b/.changeset/bootstrap-nxjs-icon.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/nro": patch
+---
+
+fix: the slim bootstrap launcher (`bootstrap.nro`) now embeds the nx.js default icon (the same `icon.jpg` as `nxjs.nro`) instead of libnx's default, so slim apps without their own `icon.jpg` show the nx.js icon in the homebrew menu.

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -27,6 +27,10 @@ RUNTIME_PKG := $(MK_DIR)/../packages/runtime/package.json
 APP_TITLE   :=  nx.js app
 APP_AUTHOR  :=  TooTallNate
 APP_VERSION :=  `jq -r .version < $(RUNTIME_PKG)`
+# Use the shared nx.js default icon (the same icon.jpg embedded in nxjs.nro at
+# the repo root) for the slim launcher base, rather than libnx's default icon.
+# ICON is relative to this project dir (the devkitPro rules prepend TOPDIR).
+ICON        :=  ../icon.jpg
 RUNTIME_MAJOR := $(shell jq -r .version < $(RUNTIME_PKG) | sed 's/[.-].*//')
 # Default [runtime] version requirement baked into the launcher: caret-on-major.
 NXJS_RUNTIME_DEFAULT := ^$(RUNTIME_MAJOR)


### PR DESCRIPTION
## Summary

The slim bootstrap launcher (`bootstrap.nro`) was using libnx's default icon. This points its Makefile `ICON` at the repo-root `icon.jpg` — the same icon embedded in `nxjs.nro` — so the launcher (and slim apps built from it that don't ship their own `icon.jpg`) show the nx.js icon in hbmenu.

## Details

- `bootstrap/Makefile`: set `ICON := ../icon.jpg` (relative to the project dir; the devkitPro rules prepend `TOPDIR`).
- `@nx.js/nro --slim` already falls back to the base NRO's icon when an app has no `icon.jpg`, so slim apps now default to the nx.js icon (the "Default nx.js icon will be used" message is now accurate for slim too).

## Verified

- `bootstrap.nro` rebuilds; the embedded icon is **byte-identical** to `icon.jpg` (25757 bytes).
- A slim `hello-world` (no app icon) picks up the nx.js icon (25.15 kb) from the base.

`@nx.js/nro` patch changeset included.