### PR TITLE
feat: make slim the default nxjs-nro packaging mode

### DIFF
--- a/.changeset/nro-slim-default.md
+++ b/.changeset/nro-slim-default.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/nro": major
+---
+
+`nxjs-nro` now builds a **slim** NRO by default (a tiny launcher that chainloads a shared runtime installed at `sdmc:/nx.js/`), instead of a self-contained ~40 MB NRO. Pass `--fat` (or set `NXJS_FAT=1`) to embed the runtime as before. `--slim` / `NXJS_SLIM=1` are still accepted as no-ops. `create-nxjs-app` adds `--fat` to the generated `nro` script when the "Fat" packaging option is chosen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,9 +208,7 @@ version = ^1                       ; semver requirement for the shared runtime N
 
 An app can be packaged two ways:
 
-- **Fat** (default): `nxjs-nro` embeds the full ~40 MB runtime into the app's
-  NRO — self-contained, no external dependency.
-- **Slim**: `nxjs-nro --slim` builds a tiny launcher NRO (a few hundred KB)
+- **Slim** (default): `nxjs-nro` builds a tiny launcher NRO (a few hundred KB)
   whose code segment is `bootstrap/` (a pure-C libnx app, NO V8/Skia) and whose
   RomFS holds the app's `main.js` + assets + `nxjs.ini`. At boot the launcher:
   1. reads `[runtime] version` from its own `romfs:/nxjs.ini` (default baked at
@@ -222,11 +220,15 @@ An app can be packaged two ways:
   runtime's existing `mount_nro_romfs(argv[1])` mounts the slim NRO's RomFS as
   `romfs:` and runs `romfs:/main.js`. No satisfying runtime / not launched via
   hbloader ⇒ a clear on-screen error (wait for `+`), never a crash.
+- **Fat**: `nxjs-nro --fat` (or `NXJS_FAT=1`) embeds the full ~40 MB runtime
+  into the app's NRO — self-contained, no external dependency. (`--slim` /
+  `NXJS_SLIM=1` are still accepted as no-ops since slim is the default.)
 
 - **Build**: `make -C bootstrap` (devkitPro; `jq` derives the runtime major from
   `packages/runtime/package.json` → the baked `^major` default). CI builds
   `bootstrap.nro`, uploads it, and the release job copies it into
-  `packages/nro/dist/` next to `nxjs.nro` (so `@nx.js/nro --slim` can use it).
+  `packages/nro/dist/` next to `nxjs.nro` (so `@nx.js/nro` can use it as the
+  default slim base).
 - **Match logic** (`bootstrap/source/match.c`) is split from libnx so it's
   host-unit-tested: `bootstrap/test/run.sh` (no Switch needed).
 - **Prerelease note**: the vendored `semver.c` compares purely by precedence and

--- a/packages/create-nxjs-app/src/main.ts
+++ b/packages/create-nxjs-app/src/main.ts
@@ -222,13 +222,13 @@ try {
 	resolveProtocols(packageJson.dependencies, data.packages, data.catalog);
 	resolveProtocols(packageJson.devDependencies, data.packages, data.catalog);
 
-	// Slim packaging: build the app as a tiny launcher NRO that chainloads a
-	// shared runtime from sdmc:/nx.js/ (via `nxjs-nro --slim`). Fat keeps the
-	// default self-contained `nxjs-nro`.
-	if (packaging === 'slim' && packageJson.scripts?.nro) {
+	// `nxjs-nro` builds a slim NRO by default (a tiny launcher that chainloads a
+	// shared runtime from sdmc:/nx.js/). For the fat (self-contained) choice,
+	// add the explicit `--fat` flag to the `nro` script.
+	if (packaging === 'fat' && packageJson.scripts?.nro) {
 		const nro = packageJson.scripts.nro;
-		if (/\bnxjs-nro\b/.test(nro) && !/--slim\b/.test(nro)) {
-			packageJson.scripts.nro = `${nro} --slim`;
+		if (/\bnxjs-nro\b/.test(nro) && !/--fat\b/.test(nro)) {
+			packageJson.scripts.nro = `${nro} --fat`;
 		}
 	}
 

--- a/packages/nro/src/main.ts
+++ b/packages/nro/src/main.ts
@@ -20,11 +20,16 @@ const cwd = process.cwd();
 const appRoot = new URL(`${pathToFileURL(cwd)}/`);
 const isSrcMode = existsSync(new URL('../tsconfig.json', import.meta.url));
 
-// Slim mode: instead of embedding the full ~40 MB runtime, use the tiny
-// `bootstrap.nro` launcher as the base. The launcher chainloads a shared
-// runtime from `sdmc:/nx.js/` at boot. Enabled via `--slim` or `NXJS_SLIM=1`.
-const slim =
-	process.argv.slice(2).includes('--slim') || process.env.NXJS_SLIM === '1';
+// Packaging mode. SLIM is the default: instead of embedding the full ~40 MB
+// runtime, use the tiny `bootstrap.nro` launcher as the base — it chainloads a
+// shared runtime from `sdmc:/nx.js/` at boot. Pass `--fat` (or `NXJS_FAT=1`) to
+// build a self-contained NRO with the runtime embedded.
+//
+// `--slim` / `NXJS_SLIM=1` are still accepted (no-ops now that slim is the
+// default) for backwards compatibility with existing build scripts.
+const args = process.argv.slice(2);
+const fat = args.includes('--fat') || process.env.NXJS_FAT === '1';
+const slim = !fat;
 
 // The base NRO whose code segments we reuse: the bootstrap launcher (slim) or
 // the full runtime (fat).
@@ -49,7 +54,14 @@ if (slim) {
 	);
 	console.log(
 		chalk.dim(
-			'  Requires an nx.js runtime NRO installed at sdmc:/nx.js/nxjs-v<version>.nro\n',
+			'  Requires an nx.js runtime NRO installed at sdmc:/nx.js/nxjs-v<version>.nro.\n' +
+				'  Pass --fat for a self-contained NRO with the runtime embedded.\n',
+		),
+	);
+} else {
+	console.log(
+		chalk.bold(
+			`Building a ${chalk.cyan('fat')} NRO (self-contained; runtime embedded).`,
 		),
 	);
 }


### PR DESCRIPTION
## Summary

Slim is the recommended mode (it's the default option in the `create-nxjs-app` prompt), so the `nxjs-nro` CLI default now matches: **slim is the default**, and the self-contained build is the explicit opt-out via `--fat`.

| Invocation | Result |
|---|---|
| `nxjs-nro` (default) | **slim** — tiny launcher (~270 KB) that chainloads a shared runtime from `sdmc:/nx.js/` |
| `nxjs-nro --fat` / `NXJS_FAT=1` | self-contained ~40 MB NRO (runtime embedded) — the previous default |
| `nxjs-nro --slim` / `NXJS_SLIM=1` | still slim (accepted as a no-op for back-compat) |

`create-nxjs-app`: the **Fat** packaging choice now appends `--fat` to the generated `nro` script; the **Slim** choice leaves the bare `nxjs-nro` default.

## ⚠️ Breaking

Existing `"nro": "nxjs-nro"` scripts now produce a **slim** NRO that requires a shared runtime installed at `sdmc:/nx.js/nxjs-v<version>.nro`. Add `--fat` to restore the old self-contained output. Marked as a `major` changeset for `@nx.js/nro` (currently in `1.0.0-beta.N`).

## Verified

- `nxjs-nro` (no flag) → slim (270 KB), `--fat` → 40 MB self-contained, `--slim` → slim (no-op) — all confirmed on `hello-world`.
- Both packages typecheck; AGENTS.md updated to document the flipped default.