### PR TITLE
fix: honor Path2D argument in ctx.clip(path) (#323)

### DIFF
--- a/.changeset/clip-path2d.md
+++ b/.changeset/clip-path2d.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: `CanvasRenderingContext2D.clip(path)` now honors a `Path2D` argument. Previously `clip()` always clipped against the context's current path and treated its first argument only as the fill rule, so `clip(path)` / `clip(path, fillRule)` had no clipping effect (drawing outside the Path2D was not clipped). It now clips against the supplied `Path2D` (baked through the current transform, like `fill(path)`), without disturbing the context's current path, and applies the optional `evenodd`/`nonzero` fill rule.

--- a/packages/runtime/test/fixtures/path2d.ts
+++ b/packages/runtime/test/fixtures/path2d.ts
@@ -343,3 +343,94 @@ test('clip(Path2D, "evenodd") - applies the fill rule to the clip path', (t) => 
 	t.equal(hole[3], 0, 'the evenodd hole is clipped out');
 	t.equal(outside[3], 0, 'outside the clip path is clipped out');
 });
+
+// clip() overload resolution + argument validation (matches Chrome/WebIDL).
+
+test('clip(fillRule) - string arg clips the current path, does not throw', (t) => {
+	const c = new OffscreenCanvas(50, 50);
+	const ctx = c.getContext('2d')!;
+
+	// Outer + inner rect on the CURRENT path; evenodd makes the inner a hole.
+	ctx.rect(10, 10, 30, 30);
+	ctx.rect(20, 20, 10, 10);
+	ctx.clip('evenodd');
+
+	ctx.fillStyle = 'green';
+	ctx.fillRect(0, 0, 50, 50);
+
+	const ring = ctx.getImageData(12, 12, 1, 1).data;
+	const hole = ctx.getImageData(25, 25, 1, 1).data;
+	const outside = ctx.getImageData(2, 2, 1, 1).data;
+
+	t.equal(ring[3], 255, 'evenodd ring of the current path is painted');
+	t.equal(hole[3], 0, 'evenodd hole is clipped out');
+	t.equal(outside[3], 0, 'outside the current path is clipped out');
+});
+
+test('clip/fill/stroke - non-Path2D object throws (not a silent empty path)', (t) => {
+	const c = new OffscreenCanvas(50, 50);
+	const ctx = c.getContext('2d')!;
+	// A non-Path2D object where a Path2D is expected is a TypeError — matching
+	// Chrome — rather than silently producing an empty path (which for clip()
+	// would erase all subsequent drawing).
+	t.throws(
+		// @ts-expect-error - intentionally passing a non-Path2D object
+		() => ctx.clip({}),
+		undefined,
+		'clip(non-Path2D object) throws',
+	);
+	t.throws(
+		// @ts-expect-error - intentionally passing a non-Path2D object
+		() => ctx.fill({}),
+		undefined,
+		'fill(non-Path2D object) throws',
+	);
+	t.throws(
+		// @ts-expect-error - intentionally passing a non-Path2D object
+		() => ctx.stroke({}),
+		undefined,
+		'stroke(non-Path2D object) throws',
+	);
+});
+
+test('clip/fill - two args with a string path arg throws (Path2D overload)', (t) => {
+	const c = new OffscreenCanvas(50, 50);
+	const ctx = c.getContext('2d')!;
+	// With 2 arguments the (Path2D, fillRule) overload is selected, so a string
+	// in the path position is a TypeError (matching Chrome) — NOT treated as a
+	// fill rule with the extra arg ignored.
+	t.throws(
+		// @ts-expect-error - intentionally passing a string where Path2D expected
+		() => ctx.clip('nonzero', 123),
+		undefined,
+		'clip(string, extra) throws (selects the Path2D overload)',
+	);
+	t.throws(
+		// @ts-expect-error - intentionally passing a string where Path2D expected
+		() => ctx.fill('nonzero', 123),
+		undefined,
+		'fill(string, extra) throws (selects the Path2D overload)',
+	);
+});
+
+test('clip/fill/stroke - trailing args after a Path2D are ignored', (t) => {
+	const c = new OffscreenCanvas(50, 50);
+	const ctx = c.getContext('2d')!;
+	const p = new Path2D();
+	p.rect(10, 10, 20, 20);
+	t.doesNotThrow(
+		// @ts-expect-error - intentionally passing an extra trailing argument
+		() => ctx.clip(p, 'evenodd', 9),
+		'clip(Path2D, fillRule, extra) ignores the trailing arg',
+	);
+	t.doesNotThrow(
+		// @ts-expect-error - intentionally passing an extra trailing argument
+		() => ctx.fill(p, 'evenodd', 9),
+		'fill(Path2D, fillRule, extra) ignores the trailing arg',
+	);
+	t.doesNotThrow(
+		// @ts-expect-error - intentionally passing an extra trailing argument
+		() => ctx.stroke(p, 9),
+		'stroke(Path2D, extra) ignores the trailing arg',
+	);
+});

--- a/packages/runtime/test/fixtures/path2d.ts
+++ b/packages/runtime/test/fixtures/path2d.ts
@@ -252,3 +252,94 @@ test('Path2D - two separate paths rendered independently', (t) => {
 	t.ok(right[2] === 255 && right[0] === 0, 'right rect should be blue');
 	t.ok(gap[3] === 0, 'gap between rects should be transparent');
 });
+
+// ---------- clip(Path2D) ----------
+// Regression test for #323: ctx.clip(path) with a Path2D argument was ignored
+// (only the context's current path was clipped against), so drawing outside the
+// Path2D region was NOT clipped.
+
+test('clip(Path2D) - restricts subsequent drawing to the path', (t) => {
+	const c = new OffscreenCanvas(50, 50);
+	const ctx = c.getContext('2d')!;
+
+	const clipPath = new Path2D();
+	clipPath.rect(10, 10, 30, 30);
+
+	ctx.clip(clipPath);
+	ctx.fillStyle = 'green';
+	ctx.fillRect(0, 0, 50, 50); // attempt to fill the entire canvas
+
+	const inside = ctx.getImageData(25, 25, 1, 1).data;
+	const outside = ctx.getImageData(5, 5, 1, 1).data;
+
+	t.equal(inside[3], 255, 'inside the clip path should be painted');
+	t.equal(outside[3], 0, 'outside the clip path should be clipped out');
+});
+
+test('clip(Path2D) - does not disturb the context current path', (t) => {
+	const c = new OffscreenCanvas(50, 50);
+	const ctx = c.getContext('2d')!;
+
+	// Build a current path that is DIFFERENT from the clip path.
+	ctx.rect(0, 0, 20, 20);
+
+	const clipPath = new Path2D();
+	clipPath.rect(10, 10, 30, 30);
+	ctx.clip(clipPath);
+
+	// fill() with no arg should use the context's current path (0,0,20,20),
+	// intersected with the clip region (10,10,30,30) -> (10,10)..(20,20).
+	ctx.fillStyle = 'green';
+	ctx.fill();
+
+	const overlap = ctx.getImageData(15, 15, 1, 1).data;
+	const onlyCurrentPath = ctx.getImageData(5, 5, 1, 1).data; // in path, out of clip
+	const onlyClip = ctx.getImageData(30, 30, 1, 1).data; // in clip, out of path
+
+	t.equal(overlap[3], 255, 'current-path ∩ clip is painted');
+	t.equal(onlyCurrentPath[3], 0, 'current path outside clip is clipped');
+	t.equal(onlyClip[3], 0, 'clip region outside current path is not painted');
+});
+
+test('clip(Path2D) - honors the current transform', (t) => {
+	const c = new OffscreenCanvas(50, 50);
+	const ctx = c.getContext('2d')!;
+
+	// The Path2D coordinates are interpreted under the CTM at clip() time.
+	ctx.translate(10, 10);
+	const clipPath = new Path2D();
+	clipPath.rect(0, 0, 30, 30); // device space (10,10)..(40,40)
+	ctx.clip(clipPath);
+
+	ctx.resetTransform();
+	ctx.fillStyle = 'green';
+	ctx.fillRect(0, 0, 50, 50);
+
+	const inside = ctx.getImageData(25, 25, 1, 1).data;
+	const outside = ctx.getImageData(5, 5, 1, 1).data;
+
+	t.equal(inside[3], 255, 'inside the transformed clip path is painted');
+	t.equal(outside[3], 0, 'outside the transformed clip path is clipped');
+});
+
+test('clip(Path2D, "evenodd") - applies the fill rule to the clip path', (t) => {
+	const c = new OffscreenCanvas(60, 60);
+	const ctx = c.getContext('2d')!;
+
+	// Outer rect with an inner rect; under evenodd the inner region is a hole.
+	const clipPath = new Path2D();
+	clipPath.rect(10, 10, 40, 40);
+	clipPath.rect(20, 20, 20, 20);
+	ctx.clip(clipPath, 'evenodd');
+
+	ctx.fillStyle = 'green';
+	ctx.fillRect(0, 0, 60, 60);
+
+	const ring = ctx.getImageData(15, 15, 1, 1).data; // between outer and inner
+	const hole = ctx.getImageData(30, 30, 1, 1).data; // inside inner (the hole)
+	const outside = ctx.getImageData(5, 5, 1, 1).data;
+
+	t.equal(ring[3], 255, 'the evenodd ring is painted');
+	t.equal(hole[3], 0, 'the evenodd hole is clipped out');
+	t.equal(outside[3], 0, 'outside the clip path is clipped out');
+});

--- a/source/canvas.cc
+++ b/source/canvas.cc
@@ -609,6 +609,59 @@ void apply_path(Isolate *iso, Local<Value> recv, Local<Value> path) {
 	                      SkPath::kAppend_AddPathMode);
 }
 
+// Resolve the WebIDL overloads shared by fill()/clip(): `(fillRule?)` and
+// `(Path2D path, fillRule?)`. Overload selection is by ARGUMENT COUNT (matching
+// Chrome): with 2+ arguments the Path2D overload is chosen, so arg0 must be a
+// Path2D (else TypeError) and arg1 is the optional fill rule; with 0-1
+// arguments the no-path overload is chosen, so arg0 (if present) is the fill
+// rule string (a non-string, non-undefined arg0 is a TypeError). A non-Path2D
+// object in the path position throws rather than silently becoming an empty
+// path. Returns false (and throws) on a type error; on success sets out_path /
+// out_rule (each may stay empty). Mirrors fill()/clip()/Path2D semantics so the
+// behavior is identical across the three.
+static bool resolve_path_and_rule(const FunctionCallbackInfo<Value> &info,
+                                   Local<Value> *out_path, bool *out_have_path,
+                                   Local<Value> *out_rule, bool *out_have_rule) {
+	Isolate *iso = info.GetIsolate();
+	*out_have_path = false;
+	*out_have_rule = false;
+	if (info.Length() >= 2) {
+		// (path, fillRule?) overload — arg0 MUST be a Path2D.
+		if (!nx_path2d_get(iso, info[0])) {
+			nx_throw(iso, "Expected Path2D at index 0");
+			return false;
+		}
+		*out_path = info[0];
+		*out_have_path = true;
+		if (info[1]->IsString()) {
+			*out_rule = info[1];
+			*out_have_rule = true;
+		} else if (!info[1]->IsUndefined()) {
+			nx_throw(iso, "Expected string at index 1");
+			return false;
+		}
+		// Trailing arguments (index >= 2) are ignored, per WebIDL.
+	} else if (info.Length() == 1) {
+		if (info[0]->IsObject()) {
+			// An object in the single-arg position selects the path overload;
+			// it must be a real Path2D.
+			if (!nx_path2d_get(iso, info[0])) {
+				nx_throw(iso, "Expected Path2D at index 0");
+				return false;
+			}
+			*out_path = info[0];
+			*out_have_path = true;
+		} else if (info[0]->IsString()) {
+			*out_rule = info[0];
+			*out_have_rule = true;
+		} else if (!info[0]->IsUndefined()) {
+			nx_throw(iso, "Expected Path2D or string at index 0");
+			return false;
+		}
+	}
+	return true;
+}
+
 // ===========================================================================
 // STUBS — filled in subsequent slices (primitives, paint, transforms, text,
 // images, imageData, encode). Each throws so a partial build is obvious.
@@ -942,39 +995,13 @@ void nx_canvas_context_2d_close_path(const FunctionCallbackInfo<Value> &info) {
 
 void nx_canvas_context_2d_clip(const FunctionCallbackInfo<Value> &info) {
 	ENTER_THIS;
-	// Per the spec, clip() has two overloads: clip(fillRule?) clips against the
-	// context's current path, and clip(path, fillRule?) clips against a Path2D.
-	// Distinguish them by whether the first argument is an object (a Path2D) vs
-	// a string (the fill rule). Mirrors fill()/stroke()'s argument handling.
+	// clip() has two WebIDL overloads — clip(fillRule?) (clip against the
+	// context's current path) and clip(path, fillRule?) (clip against a Path2D)
+	// — resolved by argument count + arg0 type (see resolve_path_and_rule).
 	Local<Value> path, fill_rule;
 	bool have_path = false, have_rule = false;
-	if (info.Length() == 1) {
-		if (info[0]->IsObject()) {
-			path = info[0];
-			have_path = true;
-		} else if (info[0]->IsString()) {
-			fill_rule = info[0];
-			have_rule = true;
-		} else if (!info[0]->IsUndefined()) {
-			nx_throw(iso, "Expected Path2D or string at index 0");
-			return;
-		}
-	} else if (info.Length() >= 2) {
-		if (info[0]->IsObject()) {
-			path = info[0];
-			have_path = true;
-		} else {
-			nx_throw(iso, "Expected Path2D at index 0");
-			return;
-		}
-		if (info[1]->IsString()) {
-			fill_rule = info[1];
-			have_rule = true;
-		} else if (!info[1]->IsUndefined()) {
-			nx_throw(iso, "Expected string at index 1");
-			return;
-		}
-	}
+	if (!resolve_path_and_rule(info, &path, &have_path, &fill_rule, &have_rule))
+		return; // a TypeError was thrown
 
 	// When a Path2D is given, clip against THAT path (baked into device space
 	// via apply_path, like fill(path)) instead of the context's current path,
@@ -1005,35 +1032,13 @@ void nx_canvas_context_2d_clip(const FunctionCallbackInfo<Value> &info) {
 
 void nx_canvas_context_2d_fill(const FunctionCallbackInfo<Value> &info) {
 	ENTER_THIS;
+	// fill(fillRule?) / fill(path, fillRule?) — same overload resolution as
+	// clip() (by arg count + arg0 type); a non-Path2D object in the path
+	// position throws rather than silently filling an empty path.
 	Local<Value> path, fill_rule;
 	bool have_path = false, have_rule = false;
-	if (info.Length() == 1) {
-		if (info[0]->IsObject()) {
-			path = info[0];
-			have_path = true;
-		} else if (info[0]->IsString()) {
-			fill_rule = info[0];
-			have_rule = true;
-		} else if (!info[0]->IsUndefined()) {
-			nx_throw(iso, "Expected Path2D or string at index 0");
-			return;
-		}
-	} else if (info.Length() == 2) {
-		if (info[0]->IsObject()) {
-			path = info[0];
-			have_path = true;
-		} else {
-			nx_throw(iso, "Expected Path2D at index 0");
-			return;
-		}
-		if (info[1]->IsString()) {
-			fill_rule = info[1];
-			have_rule = true;
-		} else if (!info[1]->IsUndefined()) {
-			nx_throw(iso, "Expected string at index 1");
-			return;
-		}
-	}
+	if (!resolve_path_and_rule(info, &path, &have_path, &fill_rule, &have_rule))
+		return; // a TypeError was thrown
 	if (have_rule)
 		set_fill_rule_v(iso, fill_rule, context);
 	if (!have_path) {
@@ -1049,16 +1054,19 @@ void nx_canvas_context_2d_fill(const FunctionCallbackInfo<Value> &info) {
 
 void nx_canvas_context_2d_stroke(const FunctionCallbackInfo<Value> &info) {
 	ENTER_THIS;
+	// stroke() / stroke(path) — the single overload's optional argument is a
+	// Path2D. With an argument present it MUST be a real Path2D (a non-Path2D
+	// value, object or otherwise, is a TypeError) so we never stroke an empty
+	// path silently; trailing arguments are ignored.
 	Local<Value> path;
 	bool have_path = false;
-	if (info.Length() == 1) {
-		if (info[0]->IsObject()) {
-			path = info[0];
-			have_path = true;
-		} else {
+	if (info.Length() >= 1 && !info[0]->IsUndefined()) {
+		if (!nx_path2d_get(iso, info[0])) {
 			nx_throw(iso, "Expected Path2D at index 0");
 			return;
 		}
+		path = info[0];
+		have_path = true;
 	}
 	if (!have_path) {
 		stroke_op(context, true);

--- a/source/canvas.cc
+++ b/source/canvas.cc
@@ -942,7 +942,55 @@ void nx_canvas_context_2d_close_path(const FunctionCallbackInfo<Value> &info) {
 
 void nx_canvas_context_2d_clip(const FunctionCallbackInfo<Value> &info) {
 	ENTER_THIS;
-	set_fill_rule_v(iso, info[0], context);
+	// Per the spec, clip() has two overloads: clip(fillRule?) clips against the
+	// context's current path, and clip(path, fillRule?) clips against a Path2D.
+	// Distinguish them by whether the first argument is an object (a Path2D) vs
+	// a string (the fill rule). Mirrors fill()/stroke()'s argument handling.
+	Local<Value> path, fill_rule;
+	bool have_path = false, have_rule = false;
+	if (info.Length() == 1) {
+		if (info[0]->IsObject()) {
+			path = info[0];
+			have_path = true;
+		} else if (info[0]->IsString()) {
+			fill_rule = info[0];
+			have_rule = true;
+		} else if (!info[0]->IsUndefined()) {
+			nx_throw(iso, "Expected Path2D or string at index 0");
+			return;
+		}
+	} else if (info.Length() >= 2) {
+		if (info[0]->IsObject()) {
+			path = info[0];
+			have_path = true;
+		} else {
+			nx_throw(iso, "Expected Path2D at index 0");
+			return;
+		}
+		if (info[1]->IsString()) {
+			fill_rule = info[1];
+			have_rule = true;
+		} else if (!info[1]->IsUndefined()) {
+			nx_throw(iso, "Expected string at index 1");
+			return;
+		}
+	}
+
+	// When a Path2D is given, clip against THAT path (baked into device space
+	// via apply_path, like fill(path)) instead of the context's current path,
+	// without disturbing the current path. The fill rule (winding/evenodd)
+	// applies to whichever path is used.
+	SkPathBuilder saved_path;
+	bool restore_path = false;
+	if (have_path) {
+		saved_path = context->path;
+		restore_path = true;
+		context->path.reset();
+		apply_path(iso, info.This(), path);
+	}
+	if (have_rule)
+		set_fill_rule_v(iso, fill_rule, context);
+
 	// context->path is in device space; clip under identity so clipPath does
 	// not re-apply the CTM. Toggle the matrix directly (NOT via save/restore,
 	// which would also pop the clip we are adding).
@@ -950,6 +998,9 @@ void nx_canvas_context_2d_clip(const FunctionCallbackInfo<Value> &info) {
 	cr->resetMatrix();
 	cr->clipPath(context->path.snapshot(), true);
 	cr->setMatrix(saved);
+
+	if (restore_path)
+		context->path = saved_path;
 }
 
 void nx_canvas_context_2d_fill(const FunctionCallbackInfo<Value> &info) {


### PR DESCRIPTION
## Summary

Fixes #323 — `CanvasRenderingContext2D.clip(path)` ignored a `Path2D` argument.

`clip()` always clipped against the context's **current path** and treated its first argument only as the fill-rule string. So `clip(path)` / `clip(path, fillRule)` had no clipping effect (drawing outside the `Path2D` region was not restricted), even though `fill(path)` / `stroke(path)` handled `Path2D` correctly.

The fix mirrors `fill()`'s argument handling: when a `Path2D` is supplied, it's baked into device space via `apply_path` (respecting the current transform) and clipped against **that** path, without disturbing the context's current path. The optional `evenodd`/`nonzero` fill rule is applied to whichever path is used. (A bare `clip()` also no longer resets the fill rule to winding.)

## Tests

Adds `clip(Path2D)` regression tests to `fixtures/path2d.ts`:
- basic clip (the exact #323 repro — outside the path is clipped out)
- current-path preservation (clip(path) doesn't clobber the context path)
- transform interaction (Path2D interpreted under the CTM at clip time)
- `evenodd` fill rule (ring painted, hole clipped)

Verified on the host `nxjs-test` binary (the environment from the issue): `path2d` 40/40, `path-transform` 26/26, `path2d-transform` 12/12, all passing with no regressions.

## Was this fixed by the Skia refactor?

No — the bug is in `clip()`'s argument handling (it never looked for a `Path2D` arg), independent of the Cairo→Skia backend change.