### PR TITLE
feat: enable V8 JIT by default in applet mode (regime-aware code-arena headroom)

### DIFF
--- a/.changeset/applet-jit-heap.md
+++ b/.changeset/applet-jit-heap.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: forcing full V8 JIT in applet mode (`[v8] jit = on` in `nxjs.ini`) no longer crashes with a "Fatal OOM: Zone". The JIT memory reserve was a fixed 180 MiB — an application-mode figure dominated by the GPU/Mesa stack — which underflowed the applet regime's ~137 MiB of free RAM and collapsed the V8 heap to the 32 MiB floor, far too small for the JIT/WebAssembly compiler. The reserve is now regime-aware: applet mode (no GPU; raster) reserves only the 64 MiB JIT code range plus headroom, leaving a usable (~70+ MiB) heap, so full JIT — and therefore WebAssembly, which requires a code-generation backend — works in applet mode.

--- a/.changeset/jit-default-applet.md
+++ b/.changeset/jit-default-applet.md
@@ -1,0 +1,7 @@
+---
+"@nx.js/runtime": minor
+---
+
+feat: enable the V8 JIT by default in applet mode too. Previously applet mode (the low-memory regime) ran the jitless interpreter; it now runs full JIT in both regimes, which substantially speeds up JS execution in applet mode. This is safe now that the JIT code-arena headroom is regime-gated (applet reserves the 64 MiB code-range minimum, leaving room for the heap/canvas/sockets) — verified stable across the example apps on-device in applet mode. Applet mode still uses CPU raster rendering (chosen independently of JIT). Force the interpreter with `[v8] jit = off` in `nxjs.ini`.
+
+WebAssembly, which needs extra JIT code-arena headroom that applet mode can't afford by default, now fails fast with an explicit, actionable error (pointing at `[v8] wasm = on` / `code_headroom_mb`) instead of a cryptic `CompileError` or crash when used without that headroom (or when JIT is disabled). It works out of the box in application mode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,9 +202,25 @@ version = ^1                       ; semver requirement for the shared runtime N
 - **Every value that can't be honored is logged** to `nxjs-debug.log` as a
   `[config] … not honored: <reason>` line (clamped heap, invalid value, GPU
   init fallback, socket reservation too big, etc.). A missing file is silent.
-- `jit` is honored verbatim (no clamp): JIT works in applet mode for CPU
-  rendering; only **applet + GPU + JIT** is known to crash (jitCreate starves
-  Mesa) — that combo is warned about but still attempted.
+- **JIT is ON by default in BOTH regimes** (`jit = auto` → `can_jit = true`;
+  was regime-gated/jitless-in-applet before). Applet mode still uses CPU raster
+  rendering (chosen independently of JIT). `jit = off` forces the interpreter.
+  Only **applet + GPU + JIT** is known to crash (jitCreate starves Mesa) — that
+  combo (an explicit `[renderer] gpu` in applet) is warned about but attempted.
+- **WASM needs JIT code-arena headroom** beyond V8's 64 MiB code-range floor.
+  The libnx jit_* arena is dual-mapped (rx+rw → ~2× real), so the headroom is
+  regime-gated: application mode reserves 64 MiB (WASM works out of the box),
+  applet mode reserves **0** (WASM opt-in, since the dual-mapped headroom won't
+  fit applet's ~137 MiB free). Set `[v8] code_headroom_mb = N` (or `wasm = on`,
+  sugar for 64). When WASM is unavailable (jitless, or applet w/ 0 headroom),
+  `index.ts` wraps `WebAssembly.Module`/`compile`/`instantiate`(`Streaming`) to
+  throw a clear nx.js `CompileError` pointing at the `nxjs.ini` fix, gated on
+  `$.config.jit` / `$.config.codeHeadroomMb` — keep the host `$.config` mirror's
+  `codeHeadroomMb` non-zero (64) so the host harness keeps WASM enabled.
+- The historic applet-mode-JIT crashes were NOT the regime per se: nx.js used to
+  reserve the 64 MiB WASM headroom unconditionally → a ~256 MiB-real arena that
+  left ~10 MiB for everything in applet → bsdsocket/heap/Skia failures. Fixed by
+  regime-gating the headroom (commit 71eecc2).
 - The host `nxjs-test` reads **no** INI; its `build_init_object` exposes a
   default `$.config`. Keep that mirror in sync if you change `$.config`'s shape.
 - `[runtime]` is read by the **slim bootstrap launcher**, not the runtime. The
@@ -546,9 +562,10 @@ DEVKITPRO=/opt/devkitpro make -j4            # -> nxjs.nro / nxjs.elf
 5. **ALWAYS restore the throwaway afterward**: `git checkout -- apps/hello-world/`
    and delete any temp `romfs/` files you added. Never commit hello-world hacks.
 
-**Application vs applet mode matters** for memory/JIT/GPU paths: application mode
-(~3 GiB grant) runs full JIT + GPU canvas; applet mode (~380 MiB) runs jitless +
-raster. The user chooses how they launch it — ask which mode to test, and have
+**Application vs applet mode matters** for memory/GPU paths: application mode
+(~3 GiB grant) runs GPU canvas + WASM by default; applet mode (~380 MiB) runs
+raster + WASM opt-in. Both run full JIT by default now (applet was jitless
+before). The user chooses how they launch it — ask which mode to test, and have
 the repro log `Switch.memoryUsage()` / read `[v8]` lines from
 `sdmc:/switch/nxjs-debug.log` when memory behavior is relevant.
 

--- a/apps/wasm/.gitignore
+++ b/apps/wasm/.gitignore
@@ -1,4 +1,5 @@
 /*.nro
 /*.nsp
 /node_modules
-/romfs
+/romfs/main.js
+/romfs/main.js.map

--- a/apps/wasm/romfs/nxjs.ini
+++ b/apps/wasm/romfs/nxjs.ini
@@ -1,7 +1,7 @@
-; Force full V8 JIT. WebAssembly requires a code-generation backend, so it does
-; not work in V8's jitless mode — which the runtime selects by default in applet
-; mode (the low-memory regime). This app only uses console.log (no GPU canvas),
-; so forcing JIT on is safe even in applet mode (the known applet + GPU + JIT
-; crash does not apply here).
+; WebAssembly needs a V8 code-generation backend, so force full JIT (applet mode
+; runs jitless by default). WASM also needs extra JIT code-arena space for its
+; compiled module code; in applet mode that headroom defaults to 0, so opt in.
+; This app uses no GPU canvas, so JIT in applet mode is safe here.
 [v8]
 jit = on
+code_headroom_mb = 64

--- a/apps/wasm/romfs/nxjs.ini
+++ b/apps/wasm/romfs/nxjs.ini
@@ -1,7 +1,6 @@
-; WebAssembly needs a V8 code-generation backend, so force full JIT (applet mode
-; runs jitless by default). WASM also needs extra JIT code-arena space for its
-; compiled module code; in applet mode that headroom defaults to 0, so opt in.
-; This app uses no GPU canvas, so JIT in applet mode is safe here.
+; WebAssembly needs extra JIT code-arena space for its compiled module code. In
+; application mode that headroom is reserved by default, but in applet mode
+; (low-memory) it defaults to 0, so opt in here. (JIT itself is on by default in
+; both regimes.) This app uses no GPU canvas, so the extra arena is safe here.
 [v8]
-jit = on
 code_headroom_mb = 64

--- a/apps/wasm/romfs/nxjs.ini
+++ b/apps/wasm/romfs/nxjs.ini
@@ -1,0 +1,7 @@
+; Force full V8 JIT. WebAssembly requires a code-generation backend, so it does
+; not work in V8's jitless mode — which the runtime selects by default in applet
+; mode (the low-memory regime). This app only uses console.log (no GPU canvas),
+; so forcing JIT on is safe even in applet mode (the known applet + GPU + JIT
+; crash does not apply here).
+[v8]
+jit = on

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -89,6 +89,13 @@ export interface NxConsoleConfig {
 export interface NxConfig {
 	/** Whether V8 JIT is enabled (vs jitless interpreter). */
 	jit: boolean;
+	/**
+	 * Effective extra JIT code-arena headroom (MiB) reserved for WebAssembly
+	 * beyond V8's 64 MiB code-range floor. 0 means WASM is effectively
+	 * unavailable (no room for its code space) — opt in via `[v8]
+	 * code_headroom_mb` / `wasm = on`. Always 0 when `jit` is false.
+	 */
+	codeHeadroomMb: number;
 	/** Effective V8 max heap size in bytes (post-clamp; the value actually passed to V8). */
 	heapLimit: number;
 	/** Requested renderer mode. */

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -104,6 +104,55 @@ import './navigator';
 import './source-map';
 import { $ } from './$';
 
+// WebAssembly availability guard.
+//
+// WASM requires V8's JIT (a code-generation backend) AND room in the JIT code
+// arena for its separate code space. Two configurations make it unavailable:
+//   - jitless mode (`[v8] jit = off`, or — without this guard — applet mode if
+//     JIT were disabled): V8 has no backend, so `new WebAssembly.Module()`
+//     throws an opaque CompileError.
+//   - applet mode with no WASM code headroom (the regime default,
+//     `$.config.codeHeadroomMb === 0`): there is no room reserved for WASM's
+//     code space, so compilation OOMs.
+// In both cases the native error is cryptic. Wrap the `WebAssembly` entry points
+// to fail fast with an actionable message pointing at the `nxjs.ini` fix.
+{
+	const WA: any = (globalThis as any).WebAssembly;
+	if (WA) {
+		const jit = $.config?.jit !== false;
+		const headroom = $.config?.codeHeadroomMb ?? 0;
+		let reason: string | undefined;
+		if (!jit) {
+			reason =
+				'WebAssembly requires the V8 JIT, which is disabled ' +
+				'(`[v8] jit = off` in nxjs.ini). Remove that override (or set ' +
+				'`jit = on`) to use WebAssembly.';
+		} else if (headroom === 0) {
+			reason =
+				'WebAssembly is disabled in this memory regime (applet mode) ' +
+				'because no JIT code-space headroom is reserved by default. ' +
+				'Enable it by adding to nxjs.ini:\n\n  [v8]\n  wasm = on\n\n' +
+				'(equivalently `code_headroom_mb = 64`). Note this needs the ' +
+				'extra memory, so prefer launching in full-memory/application ' +
+				'mode for WebAssembly-heavy apps.';
+		}
+		if (reason) {
+			const err = () => {
+				throw new WA.CompileError(`[nx.js] ${reason}`);
+			};
+			// Synchronous entry points throw; async ones reject.
+			const rej = () => Promise.reject(new WA.CompileError(`[nx.js] ${reason}`));
+			WA.Module = function () {
+				err();
+			} as any;
+			WA.compile = rej;
+			WA.instantiate = rej;
+			WA.compileStreaming = rej;
+			WA.instantiateStreaming = rej;
+		}
+	}
+}
+
 /**
  * The `import.meta` meta-property exposes context-specific metadata to a JavaScript module.
  * It contains information about the module, such as the module's URL.

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -404,6 +404,10 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 			conf->Set(context, nx_str(iso, k), v).Check();
 		};
 		cset("jit", Boolean::New(iso, true));
+		// Match the device application-mode default (64 MiB WASM headroom) so
+		// the runtime's WebAssembly-availability guard (see index.ts) keeps
+		// WASM enabled on the host harness — the wasm.ts fixture relies on it.
+		cset("codeHeadroomMb", Integer::NewFromUnsigned(iso, 64));
 		// Device exposes the effective (post-clamp) max heap in bytes, never 0;
 		// report the device application-regime cap (512 MiB) so host fixtures
 		// see the same semantics.

--- a/source/config.cc
+++ b/source/config.cc
@@ -136,6 +136,29 @@ static int ini_cb(void *user, const char *section, const char *name,
 		} else if (str_ieq(name, "flags")) {
 			free(cfg->v8_flags);
 			cfg->v8_flags = strdup(value);
+		} else if (str_ieq(name, "code_headroom_mb") ||
+		           str_ieq(name, "wasm")) {
+			// `wasm = on/off` is sugar for code_headroom_mb = 64 / 0.
+			if (str_ieq(name, "wasm")) {
+				if (str_ieq(value, "on") || str_ieq(value, "true") ||
+				    str_ieq(value, "1"))
+					cfg->code_headroom_mb = 64;
+				else if (str_ieq(value, "off") || str_ieq(value, "false") ||
+				         str_ieq(value, "0"))
+					cfg->code_headroom_mb = 0;
+				else
+					cfg_log("v8.wasm=\"%s\" not honored: invalid (use on|off)",
+					        value);
+			} else {
+				char *end = NULL;
+				unsigned long mb = strtoul(value, &end, 10);
+				if (end && *end == '\0' && mb <= 1024)
+					cfg->code_headroom_mb = (uint32_t)mb;
+				else
+					cfg_log("v8.code_headroom_mb=\"%s\" not honored: invalid "
+					        "(use 0-1024)",
+					        value);
+			}
 		} else {
 			cfg_log("v8.%s ignored: unknown key", name);
 		}
@@ -278,6 +301,7 @@ void nx_config_defaults(nx_config_t *cfg) {
 	cfg->renderer = NX_RENDER_AUTO;
 	cfg->v8_flags = NULL;
 	cfg->heap_limit = 0;
+	cfg->code_headroom_mb = NX_CODE_HEADROOM_AUTO;
 	cfg->loaded = false;
 }
 

--- a/source/config.h
+++ b/source/config.h
@@ -66,6 +66,11 @@ typedef enum {
 	NX_JIT_OFF,
 } nx_jit_mode_t;
 
+// Sentinel for nx_config_t::code_headroom_mb meaning "unset — pick a regime
+// default" (application: 64 MiB WASM headroom; applet: 0). UINT32_MAX so an
+// explicit `code_headroom_mb = 0` (disable) is distinguishable from unset.
+#define NX_CODE_HEADROOM_AUTO 0xFFFFFFFFu
+
 typedef enum {
 	NX_RENDER_AUTO = 0, // regime-based: raster in applet, GPU (w/ fallback) in app
 	NX_RENDER_CPU,      // force raster
@@ -130,6 +135,14 @@ typedef struct {
 	nx_jit_mode_t jit;
 	char *v8_flags;       // strdup'd app-provided flag string, or NULL
 	uint64_t heap_limit;  // requested heap max in bytes; 0 = use computed default
+	// Extra MiB of JIT code-arena space reserved for WebAssembly (WASM compiles
+	// its own code region from the libnx jit_* arena, which is dual-mapped so
+	// every MiB here costs ~2 MiB real). Sentinel NX_CODE_HEADROOM_AUTO means
+	// "pick a regime default" (application: 64, applet: 0 — applet's ~137 MiB
+	// can't afford the dual-mapped headroom, so WASM is opt-in there). A WASM
+	// app in applet mode sets e.g. `code_headroom_mb = 64`. 0 disables WASM
+	// code space (modules OOM at compile: "Allocate initial wasm code space").
+	uint32_t code_headroom_mb;
 	nx_render_mode_t renderer;
 	nx_socket_config_t socket;
 	nx_console_config_t console; // [console] styling, exposed on $.config.console
@@ -141,6 +154,7 @@ typedef struct {
 	// outcome isn't known until the lazy framebuffer init (it's logged there).
 	bool effective_jit;
 	uint64_t effective_heap_limit; // bytes actually passed to V8
+	uint32_t effective_code_headroom_mb; // WASM headroom actually applied (0 if !jit)
 } nx_config_t;
 
 // Initialize `cfg` to defaults (everything auto/unset).

--- a/source/main.cc
+++ b/source/main.cc
@@ -1221,10 +1221,12 @@ int main(int argc, char *argv[]) {
 		// headroom -> the 64 MiB code-range minimum, which fits): verified
 		// across the example apps on-device in applet mode (canvas, snake, svg,
 		// fonts, react, audio, http/websocket servers, repl — all stable with
-		// clean exit). Applet mode still uses CPU raster rendering (chosen
-		// independently of JIT) and keeps WASM opt-in (no code headroom by
-		// default; see the code-arena budget below). Apps can force the jitless
-		// interpreter with `[v8] jit = off`.
+		// clean exit). Applet mode still defaults to CPU raster rendering
+		// (chosen independently of JIT; an explicit `[renderer] gpu` can opt in
+		// to GPU even in applet — the known-unstable combo handled below) and
+		// keeps WASM opt-in (no code headroom by default; see the code-arena
+		// budget below). Apps can force the jitless interpreter with
+		// `[v8] jit = off`.
 		can_jit = true;
 		break;
 	}
@@ -1329,22 +1331,31 @@ int main(int argc, char *argv[]) {
 	// ("CALL_AND_RETRY_LAST"). So in applet mode clamp to real free RAM.
 	// Reserve headroom (outside the V8 managed heap) for the JIT code arena,
 	// GPU/Mesa, libuv, and native allocs — they share the process memory grant.
-	// The size depends on BOTH the JIT mode and the regime:
+	// The size depends on the JIT mode, the regime, and (in applet) whether GPU
+	// was explicitly requested:
 	//   - application + JIT: GPU/Mesa is the big consumer; reserve 180 MiB out
 	//     of the ~1 GiB address-space arena (heap then caps at 512 MiB below).
-	//   - applet + JIT: NO GPU (raster), so the only large reservation is the
-	//     64 MiB JIT code range (which libnx jitCreate dual-maps) plus libuv /
-	//     Skia raster / native. ~64 MiB leaves a usable heap from the ~137 MiB
-	//     applet grant. (The previous 180 MiB here was an application-mode
-	//     figure: it underflowed applet's free RAM to 0 and collapsed the heap
-	//     to the 32 MiB floor, which is too small for the JIT/Wasm compiler and
-	//     OOM'd — even though full JIT + a ~96 MiB heap is known to work in
-	//     applet mode. See the trifecta CPU example.)
+	//   - applet + JIT, default (raster): no GPU, so the only large reservation
+	//     is the 64 MiB JIT code range (which libnx jitCreate dual-maps) plus
+	//     libuv / Skia raster / native. ~64 MiB leaves a usable heap from the
+	//     ~137 MiB applet grant. (The previous 180 MiB here was an
+	//     application-mode figure: it underflowed applet's free RAM to 0 and
+	//     collapsed the heap to the 32 MiB floor, which is too small for the
+	//     JIT/Wasm compiler and OOM'd — even though full JIT + a ~96 MiB heap is
+	//     known to work in applet mode. See the trifecta CPU example.)
+	//   - applet + JIT + explicit `[renderer] gpu`: GPU/Mesa IS active (this is
+	//     the known-unstable combo warned about above). Use the larger 180 MiB
+	//     reserve so the V8 heap stays small and leaves Mesa as much room as
+	//     possible — the smaller raster reserve would grow the heap and starve
+	//     Mesa further. (`mem_free` - 180 underflows to the 32 MiB heap floor,
+	//     which is the right outcome here: minimal heap, maximal Mesa headroom.)
 	//   - jitless (either regime): no code range -> 48 MiB.
+	bool applet_gpu = tight_memory &&
+	                  nx_ctx->config.renderer == NX_RENDER_GPU;
 	u64 reserve;
 	if (!can_jit)
 		reserve = 48ull * 1024 * 1024;
-	else if (tight_memory)
+	else if (tight_memory && !applet_gpu)
 		reserve = 64ull * 1024 * 1024;
 	else
 		reserve = 180ull * 1024 * 1024;

--- a/source/main.cc
+++ b/source/main.cc
@@ -84,6 +84,14 @@ extern "C" const unsigned int nxjs_runtime_js_len;
 
 // switch-v8: release manual svcMapMemory arenas before returning to hbloader.
 extern "C" void horizon_mman_teardown(void);
+// switch-v8: tune the JIT code-arena budget BEFORE V8 init. wasm_headroom_mb is
+// extra code space for WebAssembly beyond V8's 64 MiB code-range floor; since
+// the libnx jit_* arena is dual-mapped (rx+rw) each MiB costs ~2 MiB real, so
+// 0 keeps the arena at the ~64 MiB minimum (~128 MiB real) instead of growing
+// it. max_code_mb is a hard ceiling (0 = automatic). See the headroom logic in
+// main() and apps/wasm/romfs/nxjs.ini.
+extern "C" void horizon_mman_set_code_budget(size_t wasm_headroom_mb,
+                                             size_t max_code_mb);
 
 // switch-v8: address space the mman reserved (from the STACK region) for V8's
 // object heap, in bytes (typically ~1 GiB; 0 if the reservation failed). Used to
@@ -853,6 +861,8 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 		cset("jit", Boolean::New(iso, cfg->effective_jit));
 		cset("heapLimit",
 		     Number::New(iso, (double)cfg->effective_heap_limit));
+		cset("codeHeadroomMb",
+		     Integer::NewFromUnsigned(iso, cfg->effective_code_headroom_mb));
 		const char *rmode = cfg->renderer == NX_RENDER_CPU   ? "cpu"
 		                    : cfg->renderer == NX_RENDER_GPU ? "gpu"
 		                                                     : "auto";
@@ -1217,6 +1227,33 @@ int main(int argc, char *argv[]) {
 		        "unstable (V8 jitCreate starves Mesa); may crash\n");
 		fflush(stderr);
 	}
+
+	// JIT code-arena budget. The libnx jit_* code arena is dual-mapped (rx+rw),
+	// so it costs ~2x its size in real memory: V8's 64 MiB code-range floor is
+	// ~128 MiB real, and the default 64 MiB WASM headroom on top would make it
+	// ~256 MiB — impossible in applet mode (~137 MiB free). That oversized arena
+	// was the root cause of applet+JIT failures (early bsdsocket crash for apps
+	// that didn't fit; a ~5s render-loop freeze as the heap gradually exhausted).
+	//
+	// So pick the WASM headroom by regime unless the app overrides it:
+	//   - application mode: 64 MiB (WASM works out of the box).
+	//   - applet mode: 0 (WASM is opt-in via [v8] code_headroom_mb / wasm=on;
+	//     applet can't afford the dual-mapped headroom by default).
+	// 0 headroom => 64 MiB arena (V8's minimum code range; cannot go lower).
+	uint32_t headroom_mb = 0;
+	if (can_jit) {
+		headroom_mb = nx_ctx->config.code_headroom_mb;
+		if (headroom_mb == NX_CODE_HEADROOM_AUTO)
+			headroom_mb = tight_memory ? 0u : 64u;
+		horizon_mman_set_code_budget(headroom_mb, 0);
+		fprintf(stderr, "[v8] code arena: WASM headroom = %u MiB%s\n",
+		        headroom_mb,
+		        nx_ctx->config.code_headroom_mb == NX_CODE_HEADROOM_AUTO
+		            ? " (regime default)"
+		            : " (config)");
+		fflush(stderr);
+	}
+	nx_ctx->config.effective_code_headroom_mb = headroom_mb;
 
 	if (can_jit) {
 		V8::SetFlagsFromString("--single-threaded --single-threaded-gc "

--- a/source/main.cc
+++ b/source/main.cc
@@ -1281,11 +1281,29 @@ int main(int argc, char *argv[]) {
 	// pure address space the device cannot back, so configuring a big heap makes
 	// V8 grow until physical commits fail and it fatally OOMs
 	// ("CALL_AND_RETRY_LAST"). So in applet mode clamp to real free RAM.
-	// Reserve headroom for the JIT code arena (~128 MiB real when can_jit),
-	// GPU/Mesa, libuv, and native allocs — they share the process memory.
+	// Reserve headroom (outside the V8 managed heap) for the JIT code arena,
+	// GPU/Mesa, libuv, and native allocs — they share the process memory grant.
+	// The size depends on BOTH the JIT mode and the regime:
+	//   - application + JIT: GPU/Mesa is the big consumer; reserve 180 MiB out
+	//     of the ~1 GiB address-space arena (heap then caps at 512 MiB below).
+	//   - applet + JIT: NO GPU (raster), so the only large reservation is the
+	//     64 MiB JIT code range (which libnx jitCreate dual-maps) plus libuv /
+	//     Skia raster / native. ~64 MiB leaves a usable heap from the ~137 MiB
+	//     applet grant. (The previous 180 MiB here was an application-mode
+	//     figure: it underflowed applet's free RAM to 0 and collapsed the heap
+	//     to the 32 MiB floor, which is too small for the JIT/Wasm compiler and
+	//     OOM'd — even though full JIT + a ~96 MiB heap is known to work in
+	//     applet mode. See the trifecta CPU example.)
+	//   - jitless (either regime): no code range -> 48 MiB.
+	u64 reserve;
+	if (!can_jit)
+		reserve = 48ull * 1024 * 1024;
+	else if (tight_memory)
+		reserve = 64ull * 1024 * 1024;
+	else
+		reserve = 180ull * 1024 * 1024;
 	{
 		u64 arena = (u64)horizon_mman_data_arena_size();
-		u64 reserve = (can_jit ? 180ull : 48ull) * 1024 * 1024;
 		u64 ceiling;
 		if (tight_memory) {
 			// Applet: bounded by real free physical RAM, not the address-space

--- a/source/main.cc
+++ b/source/main.cc
@@ -1216,7 +1216,16 @@ int main(int argc, char *argv[]) {
 		break;
 	case NX_JIT_AUTO:
 	default:
-		can_jit = !tight_memory;
+		// Full JIT in BOTH memory regimes by default. This is safe now that the
+		// JIT code-arena headroom is regime-gated (applet mode reserves 0 WASM
+		// headroom -> the 64 MiB code-range minimum, which fits): verified
+		// across the example apps on-device in applet mode (canvas, snake, svg,
+		// fonts, react, audio, http/websocket servers, repl — all stable with
+		// clean exit). Applet mode still uses CPU raster rendering (chosen
+		// independently of JIT) and keeps WASM opt-in (no code headroom by
+		// default; see the code-arena budget below). Apps can force the jitless
+		// interpreter with `[v8] jit = off`.
+		can_jit = true;
 		break;
 	}
 	nx_ctx->config.effective_jit = can_jit;


### PR DESCRIPTION
## Summary

Makes full V8 JIT the default in **both** memory regimes (it was jitless in applet mode), after fixing the memory bug that made applet-mode JIT unsafe.

### The fix that made it viable
The libnx jit_* code arena is **dual-mapped (rx+rw)**, so it costs ~2× its size in real memory. nx.js reserved the default 64 MiB WASM headroom on top of V8's 64 MiB code-range floor *unconditionally* → a ~256 MiB-real arena that left only ~10 MiB of applet's ~137 MiB free for the V8 heap, raster canvas, bsdsocket transfer memory, Skia, and fonts. That single oversize reservation caused all the applet+JIT failures (bsdsocket crash, the ~5s canvas freeze, etc.).

Now the WASM code headroom is **regime-gated + configurable** (`horizon_mman_set_code_budget`): application mode reserves 64 MiB (WASM out of the box), applet mode reserves 0 (64 MiB code arena = V8's minimum; WASM opt-in). Also right-sizes the per-regime JIT heap reserve.

### Enabling JIT by default
With the arena fixed, `jit = auto` now resolves to **JIT on in both regimes**. Applet mode still uses **CPU raster** rendering (chosen independently of JIT). `[v8] jit = off` forces the interpreter.

**On-device verification (applet mode, JIT default-on):** canvas, snake, svg, fonts, react (DOM shim), audio, http-server, websocket-server, repl — all run stably with a clean `+` exit. (virtual-keyboard runs too; its missing swkbd overlay is a separate, unrelated Skia issue.)

### Graceful WebAssembly messaging
WASM needs JIT code-arena headroom applet mode doesn't reserve by default. The `WebAssembly` entry points (`Module`/`compile`/`instantiate`/`*Streaming`) now throw a clear nx.js `CompileError` with an actionable fix (`[v8] wasm = on` / `code_headroom_mb`) when WASM is unavailable (jitless, or applet with 0 headroom) — instead of a cryptic native error or crash. Works out of the box in application mode. Exposed via the new `$.config.codeHeadroomMb`.

## Config

```ini
[v8]
jit = auto          ; auto (on in both regimes) | on | off
wasm = on           ; sugar for code_headroom_mb = 64 (opt into WASM in applet mode)
code_headroom_mb = 64
```

## Notes
- Requires `switch-v8 >= 15.0.243-9` (provides `horizon_mman_set_code_budget`).
- Host `nxjs-test` `$.config` mirror sets `codeHeadroomMb = 64` so the `wasm.ts` conformance fixture stays enabled.