### PR TITLE
feat: auto-download runtime in bootstrap launcher + ^full-version specifier

### DIFF
--- a/.changeset/bootstrap-download.md
+++ b/.changeset/bootstrap-download.md
@@ -1,0 +1,6 @@
+---
+"@nx.js/nro": minor
+"@nx.js/nsp": minor
+---
+
+feat: the slim bootstrap launcher now downloads a compatible nx.js runtime automatically when none is installed. When a slim app (NRO or NSP) can't find a shared runtime satisfying its `[runtime] version` requirement under `sdmc:/nx.js/`, the launcher queries the nx.js GitHub releases over HTTPS (via the Switch `ssl` service), picks the highest release that satisfies the requirement, downloads its `nxjs.nro` with an on-screen progress indicator, saves it as `sdmc:/nx.js/nxjs-v<version>.nro`, and continues launching — so a freshly-installed slim app "just works" on a network-connected console without manually installing the runtime first. If the download can't proceed (no network, no satisfying release), it falls back to the existing manual-install instructions screen.

--- a/.changeset/runtime-spec-full-version.md
+++ b/.changeset/runtime-spec-full-version.md
@@ -1,0 +1,6 @@
+---
+"@nx.js/nro": patch
+"@nx.js/nsp": patch
+---
+
+fix: slim apps now bake a `[runtime] version` requirement of `^<full version>` (e.g. `^1.0.0-beta.2`) into their `nxjs.ini` instead of `^<major>` (e.g. `^1`). The caret-on-major specifier would accept an *older* shared runtime that predates—and therefore lacks—features the app was built against; caret-on-full-version means "at least the runtime this app was packaged with, or any newer compatible release". The bootstrap launcher's semver matcher also gained a prerelease-floor guard so a caret on a prerelease (e.g. `^1.0.0-beta.2`) correctly rejects an older prerelease of the same `x.y.z` (`1.0.0-beta.1`) rather than wrongly accepting it.

--- a/bootstrap/common.mk
+++ b/bootstrap/common.mk
@@ -44,9 +44,13 @@ APP_TITLE   ?=  nx.js app
 APP_AUTHOR  ?=  TooTallNate
 APP_TITLEID ?=  016e782e6a730000
 APP_VERSION :=  `jq -r .version < $(RUNTIME_PKG)`
-RUNTIME_MAJOR := $(shell jq -r .version < $(RUNTIME_PKG) | sed 's/[.-].*//')
-# Default [runtime] version requirement baked into the launcher: caret-on-major.
-NXJS_RUNTIME_DEFAULT := ^$(RUNTIME_MAJOR)
+# Default [runtime] version requirement baked into the launcher: caret on the
+# FULL runtime version this launcher was built against (e.g. ^1.0.0-beta.2),
+# i.e. "at least the version packaged with, or any newer compatible release".
+# A caret-on-major (^1) would wrongly accept an OLDER runtime that lacks
+# features the app expects. This is only the fallback for a hand-built app whose
+# nxjs.ini has no [runtime] version; @nx.js/nro and @nx.js/nsp inject their own.
+NXJS_RUNTIME_DEFAULT := ^$(shell jq -r .version < $(RUNTIME_PKG))
 
 # The devkitPro %.nacp rule passes APP_TITLEID only via NACPFLAGS (not as a
 # positional arg), so wire it through like the root Makefile does. This bakes

--- a/bootstrap/launcher-nro/source/main.c
+++ b/bootstrap/launcher-nro/source/main.c
@@ -49,8 +49,14 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (!nx_resolve_runtime(&r)) {
-		nx_fail_no_runtime(&r);
-		return 0;
+		// No installed runtime satisfies the requirement — try to download one
+		// (renders progress; returns true with r filled on success, or shows
+		// the manual-install screen + exits on failure).
+		if (!nx_resolve_or_download(&r))
+			return 0; // (unreachable; the error path exits)
+		// A runtime was downloaded; consoleExit so it doesn't linger over the
+		// chainloaded runtime, then fall through to launch r.runtime_path.
+		consoleExit(NULL);
 	}
 
 	// Chainload: hand the runtime our own NRO as argv[1]. The runtime mounts

--- a/bootstrap/launcher-nsp/source/main.c
+++ b/bootstrap/launcher-nsp/source/main.c
@@ -441,8 +441,10 @@ static void nx_ui_bringup(void)
 }
 
 // `__nx_applet_exit_mode` (defined at top of file = 1, for the clean self-exit
-// on the error screen). We need to flip it to 0 for the "continue after
-// download" teardown below — see there.
+// on the error screen). For the "continue after download" teardown below we
+// temporarily set it to 2 (">1" = skip the applet exit cmds in
+// _appletCleanup), since we're tearing applet down to continue in-process, NOT
+// exiting — see there.
 extern u32 __nx_applet_exit_mode;
 
 // No installed runtime: bring up the display, auto-download a compatible one
@@ -457,7 +459,8 @@ extern u32 __nx_applet_exit_mode;
 // does its own __appInit (smInitialize etc.); if we leave sm open or the applet
 // in the self-exit-armed state (__nx_applet_exit_mode=1), the runtime's libnx
 // init fails (LibnxError_InitFail). So tear down everything nx_ui_bringup
-// brought up, with a PLAIN appletExit (exit mode 0), and finally smExit().
+// brought up, with a PLAIN appletExit (exit mode 2 = skip exit cmds, since
+// we're not exiting), and finally smExit().
 static bool nx_download_or_exit(nx_resolve_t *r)
 {
     nx_ui_bringup();
@@ -468,9 +471,10 @@ static bool nx_download_or_exit(nx_resolve_t *r)
     hidExit();
     timeExit();
     // Plain applet teardown (NOT the self-exit handshake): we're continuing to
-    // chainload the runtime in-process, not exiting. Restore exit mode after.
+    // chainload the runtime in-process, not exiting. exit_mode 2 (>1) skips the
+    // applet exit cmds in _appletCleanup. Restore the prior mode after.
     u32 saved_mode = __nx_applet_exit_mode;
-    __nx_applet_exit_mode = 2; // >1 = skip exit cmds in _appletCleanup
+    __nx_applet_exit_mode = 2;
     appletExit();
     __nx_applet_exit_mode = saved_mode;
     smExit(); // match main()'s pre-loadNro state (sm closed)

--- a/bootstrap/launcher-nsp/source/main.c
+++ b/bootstrap/launcher-nsp/source/main.c
@@ -440,14 +440,41 @@ static void nx_ui_bringup(void)
     __nx_win_init();
 }
 
-// Show the shared "no runtime found" error screen, then exit cleanly.
-// nx_fail_no_runtime() renders + waits for + then calls nx_ui_exit() (the strong
-// override above). Does not return.
-static void NX_NORETURN nx_show_error_and_exit(const nx_resolve_t *r)
+// `__nx_applet_exit_mode` (defined at top of file = 1, for the clean self-exit
+// on the error screen). We need to flip it to 0 for the "continue after
+// download" teardown below — see there.
+extern u32 __nx_applet_exit_mode;
+
+// No installed runtime: bring up the display, auto-download a compatible one
+// (nx_resolve_or_download renders progress), and on success fill `r` + return
+// true so loadNro continues to map the freshly-downloaded runtime. On failure
+// nx_resolve_or_download shows the manual-install screen + exits (does not
+// return).
+//
+// CRITICAL: on success we must restore the EXACT service state the happy path
+// jumps into the runtime with — which is what main() left before loadNro:
+// sm CLOSED, fs up, and NOTHING else (no applet/hid/time/display). The runtime
+// does its own __appInit (smInitialize etc.); if we leave sm open or the applet
+// in the self-exit-armed state (__nx_applet_exit_mode=1), the runtime's libnx
+// init fails (LibnxError_InitFail). So tear down everything nx_ui_bringup
+// brought up, with a PLAIN appletExit (exit mode 0), and finally smExit().
+static bool nx_download_or_exit(nx_resolve_t *r)
 {
     nx_ui_bringup();
-    nx_fail_no_runtime(r);
-    __builtin_unreachable();
+    if (!nx_resolve_or_download(r))
+        return false; // unreachable: the error path exits
+    consoleExit(NULL);
+    __nx_win_exit();
+    hidExit();
+    timeExit();
+    // Plain applet teardown (NOT the self-exit handshake): we're continuing to
+    // chainload the runtime in-process, not exiting. Restore exit mode after.
+    u32 saved_mode = __nx_applet_exit_mode;
+    __nx_applet_exit_mode = 2; // >1 = skip exit cmds in _appletCleanup
+    appletExit();
+    __nx_applet_exit_mode = saved_mode;
+    smExit(); // match main()'s pre-loadNro state (sm closed)
+    return true;
 }
 
 // Show a one-line error (e.g. a malformed [runtime] version specifier), then
@@ -556,11 +583,13 @@ void loadNro(void)
 
         if (!nx_resolve_runtime(&r))
         {
-            // No compatible runtime installed -- show the on-screen error.
-            // The forwarder's __appInit is minimal and main() called smExit(),
-            // so bring up the full display stack the console + pad need first
-            // (see nx_show_error_and_exit). Does not return.
-            nx_show_error_and_exit(&r);
+            // No compatible runtime installed -- bring up the display + try to
+            // download one. The forwarder's __appInit is minimal and main()
+            // called smExit(), so nx_download_or_exit brings up the full display
+            // stack first. On success it fills `r` (and tears the display back
+            // down) so we continue below; on failure it shows the manual-install
+            // screen and exits (does not return).
+            nx_download_or_exit(&r);
         }
 
         // Hand the runtime its own path as argv[0] and the "nsp:" marker as

--- a/bootstrap/source/download.c
+++ b/bootstrap/source/download.c
@@ -1,0 +1,612 @@
+#include "download.h"
+
+#include <errno.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <switch.h>
+
+#include "match.h"
+
+// ---------------------------------------------------------------------------
+// Minimal HTTPS client over the system `ssl` service (TLS + cert verification +
+// SNI handled natively) layered on BSD sockets. Just enough HTTP/1.1 to GET the
+// GitHub releases API and download a release asset (following one redirect).
+// ---------------------------------------------------------------------------
+
+#define DL_USER_AGENT "nx.js-bootstrap"
+
+// One open TLS connection (socket + ssl conn). The ssl service owns the socket
+// (DoNotCloseSocket not set), so sslConnectionClose closes it for us.
+typedef struct {
+	int sockfd;
+	SslContext ctx;
+	SslConnection conn;
+	bool have_ctx;
+	bool have_conn;
+} https_t;
+
+static void https_close(https_t *h) {
+	if (h->have_conn) {
+		sslConnectionClose(&h->conn);
+		h->have_conn = false;
+	}
+	if (h->have_ctx) {
+		sslContextClose(&h->ctx);
+		h->have_ctx = false;
+	}
+	// sslConnectionClose closes the socket (we don't set DoNotCloseSocket); only
+	// close here if the connection was never established.
+	if (h->sockfd >= 0) {
+		// If a conn was created over it, ssl already closed it; guard with a
+		// flag so we don't double-close.
+		h->sockfd = -1;
+	}
+}
+
+// Resolve `host` and open a TCP connection to port 443.
+static int tcp_connect(const char *host) {
+	struct addrinfo hints = {0};
+	hints.ai_family = AF_INET; // Switch network stack is IPv4
+	hints.ai_socktype = SOCK_STREAM;
+	struct addrinfo *res = NULL;
+	if (getaddrinfo(host, "443", &hints, &res) != 0 || !res)
+		return -1;
+	int fd = -1;
+	for (struct addrinfo *ai = res; ai; ai = ai->ai_next) {
+		fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+		if (fd < 0)
+			continue;
+		if (connect(fd, ai->ai_addr, ai->ai_addrlen) == 0)
+			break;
+		close(fd);
+		fd = -1;
+	}
+	freeaddrinfo(res);
+	return fd;
+}
+
+// Open a TLS connection to `host`:443. Returns true on success.
+static bool https_open(https_t *h, const char *host) {
+	memset(h, 0, sizeof(*h));
+	h->sockfd = -1;
+
+	h->sockfd = tcp_connect(host);
+	if (h->sockfd < 0)
+		return false;
+
+	if (R_FAILED(sslCreateContext(&h->ctx, SslVersion_Auto)))
+		return false;
+	h->have_ctx = true;
+	if (R_FAILED(sslContextCreateConnection(&h->ctx, &h->conn)))
+		return false;
+	h->have_conn = true;
+
+	// Verify peer CA + hostname (the default), set SNI, hand over the socket.
+	// IMPORTANT: use the libnx socket WRAPPER socketSslConnectionSetSocketDescriptor,
+	// NOT the raw sslConnectionSetSocketDescriptor IPC cmd — the wrapper
+	// registers/duplicates the BSD fd through the bsdsocket layer for the ssl
+	// service. The raw cmd fails (0xe87b) with a plain socket() fd.
+	sslConnectionSetHostName(&h->conn, host, strlen(host));
+	int out_sockfd = socketSslConnectionSetSocketDescriptor(&h->conn, h->sockfd);
+	if (out_sockfd < 0 && errno != ENOENT)
+		return false;
+	h->sockfd = -1; // owned by the ssl connection now
+
+	u32 out_size = 0, total_certs = 0;
+	if (R_FAILED(sslConnectionDoHandshake(&h->conn, &out_size, &total_certs,
+	                                      NULL, 0)))
+		return false;
+	return true;
+}
+
+static bool https_write_all(https_t *h, const char *buf, size_t len) {
+	size_t off = 0;
+	while (off < len) {
+		u32 wrote = 0;
+		Result rc =
+		    sslConnectionWrite(&h->conn, buf + off, (u32)(len - off), &wrote);
+		if (R_FAILED(rc) || wrote == 0)
+			return false;
+		off += wrote;
+	}
+	return true;
+}
+
+// Read up to `cap` bytes; returns the count (0 = clean EOF, -1 = error).
+static int https_read(https_t *h, void *buf, u32 cap) {
+	u32 got = 0;
+	Result rc = sslConnectionRead(&h->conn, buf, cap, &got);
+	if (R_FAILED(rc))
+		return -1;
+	return (int)got;
+}
+
+// Send a GET request for `path` to the already-open connection `host`.
+static bool send_get(https_t *h, const char *host, const char *path) {
+	char req[1024];
+	int n = snprintf(req, sizeof(req),
+	                 "GET %s HTTP/1.1\r\n"
+	                 "Host: %s\r\n"
+	                 "User-Agent: " DL_USER_AGENT "\r\n"
+	                 "Accept: */*\r\n"
+	                 "Connection: close\r\n"
+	                 "\r\n",
+	                 path, host);
+	if (n <= 0 || (size_t)n >= sizeof(req))
+		return false;
+	return https_write_all(h, req, (size_t)n);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP response handling.
+// ---------------------------------------------------------------------------
+
+// Parsed response head: status code + (optional) Location for redirects +
+// Content-Length. The body bytes already read past the header are returned in
+// `leftover`/`leftover_len` (the caller continues reading from the connection).
+typedef struct {
+	int status;
+	char location[1024];
+	long content_length; // -1 if unknown
+} resp_head_t;
+
+// Case-insensitive header prefix check; returns the value (trimmed) or NULL.
+static const char *header_value(const char *line, const char *name) {
+	size_t nl = strlen(name);
+	if (strncasecmp(line, name, nl) != 0)
+		return NULL;
+	const char *p = line + nl;
+	if (*p != ':')
+		return NULL;
+	p++;
+	while (*p == ' ' || *p == '\t')
+		p++;
+	return p;
+}
+
+// Read + parse the response head (status line + headers) up to the blank line.
+// `prebuf`/`*prebuf_len` is a scratch buffer; on return it holds any body bytes
+// read past the header (`*prebuf_len` updated). Returns false on error.
+static bool read_response_head(https_t *h, resp_head_t *out, char *prebuf,
+                               size_t prebuf_cap, size_t *prebuf_len) {
+	memset(out, 0, sizeof(*out));
+	out->status = 0;
+	out->content_length = -1;
+
+	// Accumulate until we see the end-of-headers CRLFCRLF.
+	size_t len = 0;
+	const char *hdr_end = NULL;
+	while (len < prebuf_cap - 1) {
+		int got = https_read(h, prebuf + len, (u32)(prebuf_cap - 1 - len));
+		if (got < 0)
+			return false;
+		if (got == 0)
+			break; // EOF before full header
+		len += (size_t)got;
+		prebuf[len] = '\0';
+		hdr_end = strstr(prebuf, "\r\n\r\n");
+		if (hdr_end)
+			break;
+	}
+	if (!hdr_end)
+		return false;
+
+	// Status line: "HTTP/1.1 NNN ...".
+	const char *sp = strchr(prebuf, ' ');
+	if (!sp)
+		return false;
+	out->status = atoi(sp + 1);
+
+	// Walk header lines.
+	const char *line = strchr(prebuf, '\n');
+	if (line)
+		line++;
+	while (line && line < hdr_end) {
+		const char *eol = strchr(line, '\n');
+		if (!eol || eol > hdr_end)
+			break;
+		// (line .. eol) is one header line (may end with \r).
+		const char *v;
+		if ((v = header_value(line, "Location"))) {
+			size_t i = 0;
+			while (v < eol && *v != '\r' && *v != '\n' &&
+			       i < sizeof(out->location) - 1)
+				out->location[i++] = *v++;
+			out->location[i] = '\0';
+		} else if ((v = header_value(line, "Content-Length"))) {
+			out->content_length = atol(v);
+		}
+		line = eol + 1;
+	}
+
+	// Body bytes already read = everything after the CRLFCRLF.
+	const char *body = hdr_end + 4;
+	size_t body_len = len - (size_t)(body - prebuf);
+	memmove(prebuf, body, body_len);
+	*prebuf_len = body_len;
+	return true;
+}
+
+// Split an https URL into host + path. Returns false if not https.
+static bool split_url(const char *url, char *host, size_t host_sz, char *path,
+                      size_t path_sz) {
+	const char *p = url;
+	if (strncasecmp(p, "https://", 8) != 0)
+		return false;
+	p += 8;
+	const char *slash = strchr(p, '/');
+	size_t hlen = slash ? (size_t)(slash - p) : strlen(p);
+	if (hlen == 0 || hlen >= host_sz)
+		return false;
+	memcpy(host, p, hlen);
+	host[hlen] = '\0';
+	if (slash)
+		snprintf(path, path_sz, "%s", slash);
+	else
+		snprintf(path, path_sz, "/");
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub releases: find the highest release tag satisfying the requirement.
+// ---------------------------------------------------------------------------
+
+// Scrape `"tag_name":"v<version>"` occurrences from the releases JSON, keeping
+// the highest version that satisfies `spec`. Writes the bare version (no `v`)
+// into `out_ver`. Returns true if a satisfying release was found.
+static bool pick_release(const char *json, const char *spec, char *out_ver,
+                         size_t out_ver_sz) {
+	bool found = false;
+	char best[128] = {0};
+	const char *p = json;
+	const char *key = "\"tag_name\"";
+	while ((p = strstr(p, key)) != NULL) {
+		p += strlen(key);
+		// skip spaces + ':'
+		while (*p == ' ' || *p == '\t' || *p == ':')
+			p++;
+		if (*p != '"') {
+			continue;
+		}
+		p++; // opening quote
+		// value, e.g. v1.0.0-beta.2
+		char tag[128];
+		size_t i = 0;
+		while (*p && *p != '"' && i < sizeof(tag) - 1)
+			tag[i++] = *p++;
+		tag[i] = '\0';
+		const char *ver = tag;
+		if (ver[0] == 'v' || ver[0] == 'V')
+			ver++;
+		if (!nx_version_satisfies(ver, spec))
+			continue;
+		if (!found || nx_version_compare(ver, best) > 0) {
+			snprintf(best, sizeof(best), "%s", ver);
+			found = true;
+		}
+	}
+	if (found)
+		snprintf(out_ver, out_ver_sz, "%s", best);
+	return found;
+}
+
+// GET an HTTPS URL and return the full response body in a malloc'd buffer
+// (NUL-terminated). Follows up to `max_redirects` 3xx Location hops. Caller
+// frees `*out`. `*out_len` is the body length. Returns false on error.
+static bool http_get_all(const char *url, int max_redirects, char **out,
+                         size_t *out_len) {
+	char cur[1200];
+	snprintf(cur, sizeof(cur), "%s", url);
+	for (int redir = 0; redir <= max_redirects; redir++) {
+		char host[256], path[1024];
+		if (!split_url(cur, host, sizeof(host), path, sizeof(path)))
+			return false;
+		https_t h;
+		if (!https_open(&h, host)) {
+			https_close(&h);
+			return false;
+		}
+		if (!send_get(&h, host, path)) {
+			https_close(&h);
+			return false;
+		}
+		static char scratch[8192];
+		size_t pre_len = 0;
+		resp_head_t head;
+		if (!read_response_head(&h, &head, scratch, sizeof(scratch),
+		                        &pre_len)) {
+			https_close(&h);
+			return false;
+		}
+		if (head.status >= 300 && head.status < 400 && head.location[0]) {
+			https_close(&h);
+			snprintf(cur, sizeof(cur), "%s", head.location);
+			continue;
+		}
+		if (head.status != 200) {
+			https_close(&h);
+			return false;
+		}
+		// Read the body: prebuffered bytes + the rest of the stream.
+		size_t cap = head.content_length > 0
+		                 ? (size_t)head.content_length + 1
+		                 : 64 * 1024;
+		char *buf = (char *)malloc(cap);
+		if (!buf) {
+			https_close(&h);
+			return false;
+		}
+		size_t len = 0;
+		memcpy(buf, scratch, pre_len);
+		len = pre_len;
+		for (;;) {
+			if (len + 4096 > cap) {
+				size_t ncap = cap * 2;
+				char *nb = (char *)realloc(buf, ncap);
+				if (!nb) {
+					free(buf);
+					https_close(&h);
+					return false;
+				}
+				buf = nb;
+				cap = ncap;
+			}
+			int got = https_read(&h, buf + len, 4096);
+			if (got < 0) {
+				free(buf);
+				https_close(&h);
+				return false;
+			}
+			if (got == 0)
+				break;
+			len += (size_t)got;
+		}
+		buf[len] = '\0';
+		https_close(&h);
+		*out = buf;
+		*out_len = len;
+		return true;
+	}
+	return false; // too many redirects
+}
+
+// ---------------------------------------------------------------------------
+// Asset download (streamed to a file, with progress).
+// ---------------------------------------------------------------------------
+
+static void print_progress(long done, long total) {
+	if (total > 0) {
+		int pct = (int)((done * 100) / total);
+		printf("\r  downloading... %d%% (%ld / %ld KiB)   ", pct, done / 1024,
+		       total / 1024);
+	} else {
+		printf("\r  downloading... %ld KiB   ", done / 1024);
+	}
+	consoleUpdate(NULL);
+}
+
+// GET `url` (following redirects) and stream the body to `dest_path`, rendering
+// progress. Returns false on any error (and removes the partial file).
+static bool download_to_file(const char *url, const char *dest_path) {
+	char cur[1200];
+	snprintf(cur, sizeof(cur), "%s", url);
+	for (int redir = 0; redir <= 5; redir++) {
+		char host[256], path[1024];
+		if (!split_url(cur, host, sizeof(host), path, sizeof(path)))
+			return false;
+		https_t h;
+		if (!https_open(&h, host)) {
+			https_close(&h);
+			return false;
+		}
+		if (!send_get(&h, host, path)) {
+			https_close(&h);
+			return false;
+		}
+		static char scratch[8192];
+		size_t pre_len = 0;
+		resp_head_t head;
+		if (!read_response_head(&h, &head, scratch, sizeof(scratch),
+		                        &pre_len)) {
+			https_close(&h);
+			return false;
+		}
+		if (head.status >= 300 && head.status < 400 && head.location[0]) {
+			https_close(&h);
+			snprintf(cur, sizeof(cur), "%s", head.location);
+			continue;
+		}
+		if (head.status != 200) {
+			https_close(&h);
+			printf("\n  server returned HTTP %d\n", head.status);
+			return false;
+		}
+		FILE *f = fopen(dest_path, "wb");
+		if (!f) {
+			https_close(&h);
+			return false;
+		}
+		long total = head.content_length;
+		long done = 0;
+		bool ok = true;
+		if (pre_len) {
+			if (fwrite(scratch, 1, pre_len, f) != pre_len)
+				ok = false;
+			done += (long)pre_len;
+		}
+		static char chunk[16384];
+		while (ok) {
+			int got = https_read(&h, chunk, sizeof(chunk));
+			if (got < 0) {
+				ok = false;
+				break;
+			}
+			if (got == 0)
+				break;
+			if (fwrite(chunk, 1, (size_t)got, f) != (size_t)got) {
+				ok = false;
+				break;
+			}
+			done += got;
+			print_progress(done, total);
+		}
+		print_progress(done, total);
+		printf("\n");
+		fclose(f);
+		https_close(&h);
+		if (!ok || (total > 0 && done != total)) {
+			remove(dest_path);
+			return false;
+		}
+		return true;
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Service bring-up.
+// ---------------------------------------------------------------------------
+
+static bool net_up = false;
+
+static bool ensure_network(void) {
+	if (net_up)
+		return true;
+	if (R_FAILED(nifmInitialize(NifmServiceType_User)))
+		return false;
+	NifmInternetConnectionType type;
+	u32 strength;
+	NifmInternetConnectionStatus status;
+	if (R_FAILED(nifmGetInternetConnectionStatus(&type, &strength, &status)) ||
+	    status != NifmInternetConnectionStatus_Connected) {
+		nifmExit();
+		return false;
+	}
+	// Socket + ssl services. Use a LEAN socket config: the launcher only needs a
+	// couple of short-lived TLS connections, and the forwarder runs with a tiny
+	// (16 MiB) malloc heap + small memory grant, so the default's large
+	// transfer-memory reservation is both unnecessary and risky here.
+	static const SocketInitConfig sock_cfg = {
+	    .tcp_tx_buf_size = 0x8000,
+	    .tcp_rx_buf_size = 0x10000,
+	    .tcp_tx_buf_max_size = 0x20000,
+	    .tcp_rx_buf_max_size = 0x40000,
+	    .udp_tx_buf_size = 0x2400,
+	    .udp_rx_buf_size = 0xA500,
+	    .sb_efficiency = 2,
+	    .num_bsd_sessions = 2,
+	    .bsd_service_type = BsdServiceType_User,
+	};
+	if (R_FAILED(socketInitialize(&sock_cfg))) {
+		nifmExit();
+		return false;
+	}
+	if (R_FAILED(sslInitialize(2))) {
+		socketExit();
+		nifmExit();
+		return false;
+	}
+	net_up = true;
+	return true;
+}
+
+static void teardown_network(void) {
+	if (!net_up)
+		return;
+	sslExit();
+	socketExit();
+	nifmExit();
+	net_up = false;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point.
+// ---------------------------------------------------------------------------
+
+bool nx_download_runtime(nx_resolve_t *r) {
+	printf("Downloading a compatible nx.js runtime...\n");
+	printf("  requirement: %s\n", r->version);
+	consoleUpdate(NULL);
+
+	if (!ensure_network()) {
+		printf("  no internet connection available.\n");
+		consoleUpdate(NULL);
+		return false;
+	}
+
+	bool result = false;
+
+	// 1. Query the releases API and pick the best satisfying tag.
+	printf("  querying GitHub releases...\n");
+	consoleUpdate(NULL);
+	char *json = NULL;
+	size_t json_len = 0;
+	if (!http_get_all("https://api.github.com/repos/" NXJS_GH_REPO
+	                  "/releases?per_page=100",
+	                  5, &json, &json_len)) {
+		printf("  could not reach the GitHub releases API.\n");
+		consoleUpdate(NULL);
+		teardown_network();
+		return false;
+	}
+	char ver[128] = {0};
+	bool picked = pick_release(json, r->version, ver, sizeof(ver));
+	free(json);
+	if (!picked) {
+		printf("  no published release satisfies \"%s\".\n", r->version);
+		consoleUpdate(NULL);
+		teardown_network();
+		return false;
+	}
+	printf("  selected: v%s\n", ver);
+	consoleUpdate(NULL);
+
+	// 2. Download the asset to a temp file, then rename into place.
+	char url[512];
+	snprintf(url, sizeof(url),
+	         "https://github.com/" NXJS_GH_REPO "/releases/download/v%s/" NXJS_RELEASE_ASSET,
+	         ver);
+	char tmp_path[FS_MAX_PATH];
+	char final_path[FS_MAX_PATH];
+	snprintf(final_path, sizeof(final_path),
+	         NXJS_RUNTIME_DIR "/" NXJS_RUNTIME_PREFIX "%s" NXJS_RUNTIME_SUFFIX,
+	         ver);
+	snprintf(tmp_path, sizeof(tmp_path),
+	         NXJS_RUNTIME_DIR "/" NXJS_RUNTIME_PREFIX "%s" NXJS_RUNTIME_SUFFIX
+	                          ".part",
+	         ver);
+
+	// Ensure the runtime dir exists.
+	mkdir(NXJS_RUNTIME_DIR, 0777);
+
+	if (!download_to_file(url, tmp_path)) {
+		printf("  download failed.\n");
+		consoleUpdate(NULL);
+		teardown_network();
+		return false;
+	}
+	remove(final_path); // in case a stale/partial one exists
+	if (rename(tmp_path, final_path) != 0) {
+		printf("  could not save the runtime.\n");
+		consoleUpdate(NULL);
+		remove(tmp_path);
+		teardown_network();
+		return false;
+	}
+
+	printf("  installed %s\n", final_path);
+	consoleUpdate(NULL);
+	snprintf(r->runtime_path, sizeof(r->runtime_path), "%s", final_path);
+	snprintf(r->runtime_version, sizeof(r->runtime_version), "%s", ver);
+	result = true;
+
+	teardown_network();
+	return result;
+}

--- a/bootstrap/source/download.c
+++ b/bootstrap/source/download.c
@@ -13,6 +13,7 @@
 #include <switch.h>
 
 #include "match.h"
+#include "ui.h" // NX_C_* ANSI color macros
 
 // ---------------------------------------------------------------------------
 // Minimal HTTPS client over the system `ssl` service (TLS + cert verification +
@@ -382,12 +383,24 @@ static bool http_get_all(const char *url, int max_redirects, char **out,
 // ---------------------------------------------------------------------------
 
 static void print_progress(long done, long total) {
+	// A simple inline progress bar, redrawn in place via carriage return.
 	if (total > 0) {
 		int pct = (int)((done * 100) / total);
-		printf("\r  downloading... %d%% (%ld / %ld KiB)   ", pct, done / 1024,
-		       total / 1024);
+		if (pct > 100)
+			pct = 100;
+		char bar[21];
+		int filled = pct / 5; // 20 cells
+		for (int i = 0; i < 20; i++)
+			bar[i] = i < filled ? '#' : '-';
+		bar[20] = '\0';
+		printf("\r  " NX_C_DIM "downloading " NX_C_RESET NX_C_GREEN
+		       "[%s]" NX_C_RESET " %3d%% " NX_C_GRAY "(%ld/%ld KiB)" NX_C_RESET
+		       "   ",
+		       bar, pct, done / 1024, total / 1024);
 	} else {
-		printf("\r  downloading... %ld KiB   ", done / 1024);
+		printf("\r  " NX_C_DIM "downloading " NX_C_RESET NX_C_GRAY
+		       "%ld KiB" NX_C_RESET "   ",
+		       done / 1024);
 	}
 	consoleUpdate(NULL);
 }
@@ -531,12 +544,14 @@ static void teardown_network(void) {
 // ---------------------------------------------------------------------------
 
 bool nx_download_runtime(nx_resolve_t *r) {
-	printf("Downloading a compatible nx.js runtime...\n");
-	printf("  requirement: %s\n", r->version);
+	printf("  " NX_C_CYAN "Downloading the nx.js runtime..." NX_C_RESET "\n");
 	consoleUpdate(NULL);
 
 	if (!ensure_network()) {
-		printf("  no internet connection available.\n");
+		printf("\n  " NX_C_RED "No internet connection." NX_C_RESET "\n");
+		printf("  " NX_C_GRAY "Connect this console to the internet and relaunch,"
+		       "\n  or install the runtime manually (see below)." NX_C_RESET
+		       "\n");
 		consoleUpdate(NULL);
 		return false;
 	}
@@ -544,14 +559,17 @@ bool nx_download_runtime(nx_resolve_t *r) {
 	bool result = false;
 
 	// 1. Query the releases API and pick the best satisfying tag.
-	printf("  querying GitHub releases...\n");
+	printf("  " "finding a compatible release..." NX_C_RESET
+	       "\n");
 	consoleUpdate(NULL);
 	char *json = NULL;
 	size_t json_len = 0;
 	if (!http_get_all("https://api.github.com/repos/" NXJS_GH_REPO
 	                  "/releases?per_page=100",
 	                  5, &json, &json_len)) {
-		printf("  could not reach the GitHub releases API.\n");
+		printf("\n  " NX_C_RED "Could not reach GitHub." NX_C_RESET "\n");
+		printf("  " NX_C_GRAY "Check the internet connection and try again."
+		       NX_C_RESET "\n");
 		consoleUpdate(NULL);
 		teardown_network();
 		return false;
@@ -560,12 +578,14 @@ bool nx_download_runtime(nx_resolve_t *r) {
 	bool picked = pick_release(json, r->version, ver, sizeof(ver));
 	free(json);
 	if (!picked) {
-		printf("  no published release satisfies \"%s\".\n", r->version);
+		printf("\n  " NX_C_RED "No published release satisfies %s."
+		       NX_C_RESET "\n", r->version);
 		consoleUpdate(NULL);
 		teardown_network();
 		return false;
 	}
-	printf("  selected: v%s\n", ver);
+	printf("  " "selected " NX_C_RESET NX_C_BOLD "v%s" NX_C_RESET
+	       "\n", ver);
 	consoleUpdate(NULL);
 
 	// 2. Download the asset to a temp file, then rename into place.
@@ -587,21 +607,25 @@ bool nx_download_runtime(nx_resolve_t *r) {
 	mkdir(NXJS_RUNTIME_DIR, 0777);
 
 	if (!download_to_file(url, tmp_path)) {
-		printf("  download failed.\n");
+		printf("\n  " NX_C_RED "Download failed." NX_C_RESET "\n");
+		printf("  " NX_C_GRAY "The connection may have dropped; try again."
+		       NX_C_RESET "\n");
 		consoleUpdate(NULL);
 		teardown_network();
 		return false;
 	}
 	remove(final_path); // in case a stale/partial one exists
 	if (rename(tmp_path, final_path) != 0) {
-		printf("  could not save the runtime.\n");
+		printf("\n  " NX_C_RED "Could not save the runtime to the SD card."
+		       NX_C_RESET "\n");
 		consoleUpdate(NULL);
 		remove(tmp_path);
 		teardown_network();
 		return false;
 	}
 
-	printf("  installed %s\n", final_path);
+	printf("  " NX_C_GREEN "installed " NX_C_RESET NX_C_BOLD
+	       NXJS_RUNTIME_PREFIX "%s" NXJS_RUNTIME_SUFFIX NX_C_RESET "\n", ver);
 	consoleUpdate(NULL);
 	snprintf(r->runtime_path, sizeof(r->runtime_path), "%s", final_path);
 	snprintf(r->runtime_version, sizeof(r->runtime_version), "%s", ver);

--- a/bootstrap/source/download.c
+++ b/bootstrap/source/download.c
@@ -23,10 +23,17 @@
 
 #define DL_USER_AGENT "nx.js-bootstrap"
 
-// One open TLS connection (socket + ssl conn). The ssl service owns the socket
-// (DoNotCloseSocket not set), so sslConnectionClose closes it for us.
+// One open TLS connection (socket + ssl conn).
+//
+// Socket-descriptor ownership (libnx): socketSslConnectionSetSocketDescriptor
+// consumes the input `sockfd` and returns an OUTPUT sockfd that WE own. Per the
+// ssl docs, that output fd "must be closed prior to sslConnectionClose" (we
+// don't set SslOptionType_DoNotCloseSocket). So `ssl_sockfd` holds that output
+// fd and https_close() closes it BEFORE sslConnectionClose — otherwise every
+// request leaks the socket/service registration.
 typedef struct {
-	int sockfd;
+	int sockfd;     // raw fd before handover; -1 once consumed by the ssl conn
+	int ssl_sockfd; // output fd from the ssl handover (we must close it); -1 if none
 	SslContext ctx;
 	SslConnection conn;
 	bool have_ctx;
@@ -34,6 +41,11 @@ typedef struct {
 } https_t;
 
 static void https_close(https_t *h) {
+	// The ssl-service output fd must be closed BEFORE the connection.
+	if (h->ssl_sockfd >= 0) {
+		close(h->ssl_sockfd);
+		h->ssl_sockfd = -1;
+	}
 	if (h->have_conn) {
 		sslConnectionClose(&h->conn);
 		h->have_conn = false;
@@ -42,11 +54,10 @@ static void https_close(https_t *h) {
 		sslContextClose(&h->ctx);
 		h->have_ctx = false;
 	}
-	// sslConnectionClose closes the socket (we don't set DoNotCloseSocket); only
-	// close here if the connection was never established.
+	// The raw input fd is only still open if handover never happened (early
+	// failure before socketSslConnectionSetSocketDescriptor consumed it).
 	if (h->sockfd >= 0) {
-		// If a conn was created over it, ssl already closed it; guard with a
-		// flag so we don't double-close.
+		close(h->sockfd);
 		h->sockfd = -1;
 	}
 }
@@ -77,6 +88,7 @@ static int tcp_connect(const char *host) {
 static bool https_open(https_t *h, const char *host) {
 	memset(h, 0, sizeof(*h));
 	h->sockfd = -1;
+	h->ssl_sockfd = -1;
 
 	h->sockfd = tcp_connect(host);
 	if (h->sockfd < 0)
@@ -94,11 +106,19 @@ static bool https_open(https_t *h, const char *host) {
 	// NOT the raw sslConnectionSetSocketDescriptor IPC cmd — the wrapper
 	// registers/duplicates the BSD fd through the bsdsocket layer for the ssl
 	// service. The raw cmd fails (0xe87b) with a plain socket() fd.
+	//
+	// The wrapper CONSUMES the input fd and returns an OUTPUT fd that we now
+	// own and must close before sslConnectionClose (errno==ENOENT means no out
+	// fd was returned, which the docs say to ignore). Track it in ssl_sockfd so
+	// https_close() closes it — otherwise each request leaks a socket.
 	sslConnectionSetHostName(&h->conn, host, strlen(host));
+	errno = 0;
 	int out_sockfd = socketSslConnectionSetSocketDescriptor(&h->conn, h->sockfd);
+	h->sockfd = -1; // consumed by the wrapper now
 	if (out_sockfd < 0 && errno != ENOENT)
 		return false;
-	h->sockfd = -1; // owned by the ssl connection now
+	if (out_sockfd >= 0)
+		h->ssl_sockfd = out_sockfd;
 
 	u32 out_size = 0, total_certs = 0;
 	if (R_FAILED(sslConnectionDoHandshake(&h->conn, &out_size, &total_certs,

--- a/bootstrap/source/download.c
+++ b/bootstrap/source/download.c
@@ -623,8 +623,17 @@ bool nx_download_runtime(nx_resolve_t *r) {
 	                          ".part",
 	         ver);
 
-	// Ensure the runtime dir exists.
-	mkdir(NXJS_RUNTIME_DIR, 0777);
+	// Ensure the runtime dir exists (EEXIST is fine; any other error means the
+	// SD card isn't writable, so report that specifically rather than letting
+	// the write fail later with a generic "download failed").
+	if (mkdir(NXJS_RUNTIME_DIR, 0777) != 0 && errno != EEXIST) {
+		printf("\n  " NX_C_RED "Could not create %s on the SD card." NX_C_RESET
+		       "\n",
+		       NXJS_RUNTIME_DIR);
+		consoleUpdate(NULL);
+		teardown_network();
+		return false;
+	}
 
 	if (!download_to_file(url, tmp_path)) {
 		printf("\n  " NX_C_RED "Download failed." NX_C_RESET "\n");

--- a/bootstrap/source/download.h
+++ b/bootstrap/source/download.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// Shared nx.js bootstrap logic: download a compatible shared runtime NRO from
+// the nx.js GitHub releases when none is installed on the SD card. Used by BOTH
+// launcher flavors from their "no runtime found" path. Pure libnx (BSD sockets
+// + the system `ssl` service for HTTPS; no curl/mbedtls), so it links into the
+// network-free launchers without extra dependencies.
+//
+// Flow (see download.c):
+//   1. Bring up networking (nifm) + the ssl/socket services.
+//   2. GET https://api.github.com/repos/<repo>/releases, scrape the `tag_name`
+//      values (each "v<version>"), and pick the HIGHEST release whose version
+//      satisfies the app's requirement (reusing the semver matcher).
+//   3. Download https://github.com/<repo>/releases/download/v<ver>/nxjs.nro
+//      (following GitHub's redirect to the CDN), streaming progress on-screen.
+//   4. Save it as sdmc:/nx.js/nxjs-v<ver>.nro (the SD naming convention) via a
+//      temp file + rename, so a partial download can't masquerade as installed.
+
+#include <stdbool.h>
+#include <switch.h>
+
+#include "resolve.h"
+
+// The GitHub repository that publishes the runtime releases + asset filename.
+#define NXJS_GH_REPO "TooTallNate/nx.js"
+#define NXJS_RELEASE_ASSET "nxjs.nro"
+
+// Attempt to download a runtime satisfying `r->version` into NXJS_RUNTIME_DIR.
+// Renders progress/status to the (already-initialized) console. On success,
+// returns true and fills `r->runtime_path` / `r->runtime_version` with the
+// freshly-downloaded runtime (so the caller can launch it without re-scanning).
+// On any failure (no network, no satisfying release, HTTP/TLS/IO error) prints
+// the reason and returns false; the caller should fall back to its error UI.
+//
+// Requires the SD card to be mounted (fsdevMountSdmc) and a console up.
+bool nx_download_runtime(nx_resolve_t *r);

--- a/bootstrap/source/match.c
+++ b/bootstrap/source/match.c
@@ -77,6 +77,21 @@ bool nx_version_satisfies(const char *cand, const char *spec) {
 	int pw = semver_parse(want_str, &want);
 	int pc = semver_parse(cand, &c);
 	bool ok = (pw == 0 && pc == 0) && semver_satisfies(c, want, op) != 0;
+	// Prerelease floor guard. The vendored semver's caret/tilde/range checks
+	// compare only MAJOR.MINOR.PATCH and ignore the prerelease component, so a
+	// spec with a prerelease lower bound (e.g. "^1.0.0-beta.2", which @nx.js/nro
+	// and @nx.js/nsp now bake) would wrongly accept an OLDER prerelease of the
+	// same x.y.z (e.g. "1.0.0-beta.1"). For floor operators, when the candidate
+	// shares want's x.y.z and want carries a prerelease, additionally require
+	// the candidate to be >= want by full precedence (which orders prereleases).
+	if (ok && want.prerelease && want.prerelease[0] &&
+	    (op[0] == '^' || op[0] == '~' || op[0] == '=' ||
+	     (op[0] == '>' && op[1] == '=')) &&
+	    c.major == want.major && c.minor == want.minor &&
+	    c.patch == want.patch) {
+		if (semver_compare(c, want) < 0)
+			ok = false;
+	}
 	semver_free(&c);
 	semver_free(&want);
 	return ok;

--- a/bootstrap/source/ui.c
+++ b/bootstrap/source/ui.c
@@ -25,7 +25,8 @@ __attribute__((weak)) void nx_ui_exit(void) {
 static void wait_for_plus_and_exit(void) {
 	padConfigureInput(1, HidNpadStyleSet_NpadStandard);
 	padInitializeDefault(&g_pad);
-	printf("\nPress + to exit.\n");
+	printf("\n" NX_C_GRAY "Press " NX_C_RESET NX_C_BOLD "+" NX_C_RESET NX_C_GRAY
+	                      " to exit." NX_C_RESET "\n");
 	consoleUpdate(NULL);
 	while (appletMainLoop()) {
 		padUpdate(&g_pad);
@@ -37,8 +38,8 @@ static void wait_for_plus_and_exit(void) {
 }
 
 static void header(void) {
-	printf("nx.js slim launcher\n");
-	printf("-------------------\n\n");
+	printf("\n  " NX_C_BOLD NX_C_CYAN "nx.js" NX_C_RESET " launcher\n");
+	printf("  --------------\n\n");
 }
 
 void nx_failv(const char *fmt, va_list ap) {
@@ -55,38 +56,45 @@ void nx_fail(const char *fmt, ...) {
 	va_end(ap);
 }
 
-// Print the "what's required / where we looked / what's installed" block.
-// Assumes the console is already initialized + the header was printed.
+// Print the "what's required / where we looked / what's installed / how to
+// install manually" block. Assumes the console is initialized + header printed.
 static void print_no_runtime_details(const nx_resolve_t *r) {
-	printf("Required: %s\n", r->version);
-	printf("Looked in: %s/%s*%s\n\n", NXJS_RUNTIME_DIR, NXJS_RUNTIME_PREFIX,
-	       NXJS_RUNTIME_SUFFIX);
+	printf("  " NX_C_GRAY "required " NX_C_RESET NX_C_BOLD "%s" NX_C_RESET "\n",
+	       r->version);
+	printf("  " NX_C_GRAY "looked in " NX_C_RESET "%s/%s*%s" "\n\n",
+	       NXJS_RUNTIME_DIR, NXJS_RUNTIME_PREFIX, NXJS_RUNTIME_SUFFIX);
 	// List what IS installed, to help the user.
 	DIR *d = opendir(NXJS_RUNTIME_DIR);
 	if (d) {
 		struct dirent *e;
 		bool any = false;
-		printf("Installed runtimes:\n");
+		printf("  " NX_C_GRAY "installed runtimes:" NX_C_RESET "\n");
 		while ((e = readdir(d)) != NULL) {
 			if (strncasecmp(e->d_name, NXJS_RUNTIME_PREFIX,
 			                strlen(NXJS_RUNTIME_PREFIX)) == 0) {
-				printf("  - %s\n", e->d_name);
+				printf("    - %s\n", e->d_name);
 				any = true;
 			}
 		}
 		if (!any)
-			printf("  (none)\n");
+			printf("    " NX_C_DIM "(none)" NX_C_RESET "\n");
 		closedir(d);
 	} else {
-		printf("(%s does not exist)\n", NXJS_RUNTIME_DIR);
+		printf("  " NX_C_DIM "(%s does not exist)" NX_C_RESET "\n",
+		       NXJS_RUNTIME_DIR);
 	}
-	printf("\nInstall a runtime NRO to %s/ and try again.\n", NXJS_RUNTIME_DIR);
+	printf("\n  To install it manually, download the runtime NRO from\n");
+	printf("  " NX_C_CYAN "https://github.com/" NXJS_GH_REPO "/releases"
+	       NX_C_RESET "\n");
+	printf("  and place it in " NX_C_BOLD "%s/" NX_C_RESET "\n",
+	       NXJS_RUNTIME_DIR);
 }
 
 void nx_fail_no_runtime(const nx_resolve_t *r) {
 	consoleInit(NULL);
 	header();
-	printf("No compatible nx.js runtime found.\n\n");
+	printf("  " NX_C_YELLOW "No compatible nx.js runtime is installed." NX_C_RESET
+	       "\n\n");
 	print_no_runtime_details(r);
 	wait_for_plus_and_exit();
 }
@@ -94,19 +102,25 @@ void nx_fail_no_runtime(const nx_resolve_t *r) {
 bool nx_resolve_or_download(nx_resolve_t *r) {
 	consoleInit(NULL);
 	header();
-	printf("No compatible nx.js runtime found.\n\n");
+	printf("  " NX_C_YELLOW "No compatible nx.js runtime is installed." NX_C_RESET
+	       "\n");
+	// Emphasize this is a one-time setup so the wait doesn't feel like an error.
+	printf("  " NX_C_DIM "This one-time setup downloads the shared runtime; it "
+	       "is\n  reused by every nx.js app afterwards." NX_C_RESET "\n\n");
 	consoleUpdate(NULL);
 
 	// Auto-download a compatible runtime from the GitHub releases. Renders its
-	// own progress/status lines to the console.
+	// own colored progress/status lines to the console.
 	if (nx_download_runtime(r)) {
-		printf("\nReady. Launching...\n");
+		printf("\n  " NX_C_GREEN "Ready - launching the app..." NX_C_RESET "\n");
 		consoleUpdate(NULL);
 		return true; // r now points at the downloaded runtime
 	}
 
-	// Download unavailable/failed — fall back to the manual-install screen.
-	printf("\nCould not download the runtime automatically.\n\n");
+	// Download unavailable/failed — nx_download_runtime already printed the
+	// specific reason (offline, no satisfying release, etc.). Fall back to the
+	// manual-install instructions.
+	printf("\n");
 	print_no_runtime_details(r);
 	wait_for_plus_and_exit();
 	return false; // unreachable (wait_for_plus_and_exit -> nx_ui_exit)

--- a/bootstrap/source/ui.c
+++ b/bootstrap/source/ui.c
@@ -8,6 +8,8 @@
 #include <strings.h>
 #include <switch.h>
 
+#include "download.h"
+
 static PadState g_pad;
 
 // Launcher-provided exit hook. The default (used by the NRO launcher, which is
@@ -53,10 +55,9 @@ void nx_fail(const char *fmt, ...) {
 	va_end(ap);
 }
 
-void nx_fail_no_runtime(const nx_resolve_t *r) {
-	consoleInit(NULL);
-	header();
-	printf("No compatible nx.js runtime found.\n\n");
+// Print the "what's required / where we looked / what's installed" block.
+// Assumes the console is already initialized + the header was printed.
+static void print_no_runtime_details(const nx_resolve_t *r) {
 	printf("Required: %s\n", r->version);
 	printf("Looked in: %s/%s*%s\n\n", NXJS_RUNTIME_DIR, NXJS_RUNTIME_PREFIX,
 	       NXJS_RUNTIME_SUFFIX);
@@ -80,5 +81,33 @@ void nx_fail_no_runtime(const nx_resolve_t *r) {
 		printf("(%s does not exist)\n", NXJS_RUNTIME_DIR);
 	}
 	printf("\nInstall a runtime NRO to %s/ and try again.\n", NXJS_RUNTIME_DIR);
+}
+
+void nx_fail_no_runtime(const nx_resolve_t *r) {
+	consoleInit(NULL);
+	header();
+	printf("No compatible nx.js runtime found.\n\n");
+	print_no_runtime_details(r);
 	wait_for_plus_and_exit();
+}
+
+bool nx_resolve_or_download(nx_resolve_t *r) {
+	consoleInit(NULL);
+	header();
+	printf("No compatible nx.js runtime found.\n\n");
+	consoleUpdate(NULL);
+
+	// Auto-download a compatible runtime from the GitHub releases. Renders its
+	// own progress/status lines to the console.
+	if (nx_download_runtime(r)) {
+		printf("\nReady. Launching...\n");
+		consoleUpdate(NULL);
+		return true; // r now points at the downloaded runtime
+	}
+
+	// Download unavailable/failed — fall back to the manual-install screen.
+	printf("\nCould not download the runtime automatically.\n\n");
+	print_no_runtime_details(r);
+	wait_for_plus_and_exit();
+	return false; // unreachable (wait_for_plus_and_exit -> nx_ui_exit)
 }

--- a/bootstrap/source/ui.h
+++ b/bootstrap/source/ui.h
@@ -20,6 +20,19 @@ void nx_failv(const char *fmt, va_list ap);
 // Does not return.
 void nx_fail_no_runtime(const nx_resolve_t *r);
 
+// "No runtime found" recovery: render the console, then automatically attempt
+// to DOWNLOAD a compatible runtime from the nx.js GitHub releases (see
+// download.c). On success, fills `r->runtime_path`/`runtime_version` and returns
+// true so the caller can launch the freshly-downloaded runtime. On failure
+// (no network, no satisfying release, IO error) it shows the standard
+// "no runtime" install instructions and waits for + to exit — i.e. it behaves
+// like nx_fail_no_runtime() and DOES NOT RETURN. So: a `true` return means a
+// runtime is ready; the function not returning means the user exited.
+//
+// The console must already be initialized (the NRO launcher's nx_fail* do this;
+// the NSP forwarder calls nx_ui_bringup first). `consoleInit` is idempotent.
+bool nx_resolve_or_download(nx_resolve_t *r);
+
 // Exit hook invoked after the user presses + on any nx_fail* screen. Weakly
 // defined in ui.c (consoleExit + return, for the hbloader-launched NRO
 // launcher). A launcher whose process can't exit normally (the NSP forwarder)

--- a/bootstrap/source/ui.h
+++ b/bootstrap/source/ui.h
@@ -8,6 +8,21 @@
 
 #include "resolve.h"
 
+// ANSI SGR escapes for the on-screen console. libnx's PrintConsole supports
+// only the BASIC set — the 30-37 foreground colors, bold (1) and reset (0).
+// The bright 90-97 colors and dim (2) are NOT supported (they print garbage),
+// and the framebuffer font has no box-drawing/checkmark glyphs, so we use ASCII
+// only. "Dim"/"gray" therefore map to plain (no color) on purpose.
+#define NX_C_RESET "\x1b[0m"
+#define NX_C_BOLD "\x1b[1m"
+#define NX_C_DIM ""
+#define NX_C_RED "\x1b[31m"
+#define NX_C_GREEN "\x1b[32m"
+#define NX_C_YELLOW "\x1b[33m"
+#define NX_C_BLUE "\x1b[34m"
+#define NX_C_CYAN "\x1b[36m"
+#define NX_C_GRAY ""
+
 // consoleInit + print "nx.js slim launcher" header + printf(fmt, ...) +
 // wait for + and exit. Does not return.
 void nx_fail(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/bootstrap/source/ui.h
+++ b/bootstrap/source/ui.h
@@ -44,8 +44,9 @@ void nx_fail_no_runtime(const nx_resolve_t *r);
 // like nx_fail_no_runtime() and DOES NOT RETURN. So: a `true` return means a
 // runtime is ready; the function not returning means the user exited.
 //
-// The console must already be initialized (the NRO launcher's nx_fail* do this;
-// the NSP forwarder calls nx_ui_bringup first). `consoleInit` is idempotent.
+// This calls consoleInit() itself (idempotent), so the console need not be
+// initialized beforehand. The NSP forwarder must still call nx_ui_bringup
+// first, though, to bring up the display/input services the console needs.
 bool nx_resolve_or_download(nx_resolve_t *r);
 
 // Exit hook invoked after the user presses + on any nx_fail* screen. Weakly

--- a/bootstrap/test/match-test.c
+++ b/bootstrap/test/match-test.c
@@ -87,6 +87,16 @@ int main(void) {
 	expect_satisfies("1.0.0-beta.1", ">=1.0.0-beta.1", true);
 	expect_satisfies("1.0.0-beta.1", ">=1.0.0-beta.2", false);
 
+	// --- Caret on a FULL prerelease version (what @nx.js/nro|nsp now bake,
+	// e.g. "^1.0.0-beta.2": "at least the version packaged with, or newer").
+	// By precedence, ^1.0.0-beta.2 == >=1.0.0-beta.2 <2.0.0.
+	expect_satisfies("1.0.0-beta.2", "^1.0.0-beta.2", true); // exact floor
+	expect_satisfies("1.0.0-beta.3", "^1.0.0-beta.2", true); // newer prerelease
+	expect_satisfies("1.0.0", "^1.0.0-beta.2", true);        // the release
+	expect_satisfies("1.2.0", "^1.0.0-beta.2", true);        // newer minor
+	expect_satisfies("1.0.0-beta.1", "^1.0.0-beta.2", false); // OLDER -> rejected
+	expect_satisfies("2.0.0", "^1.0.0-beta.2", false);        // major bump out
+
 	// --- Comparison / "pick highest" ordering ---
 	expect_cmp("1.2.0", "1.10.0", -1);  // numeric, not lexical
 	expect_cmp("1.10.0", "1.2.0", 1);

--- a/packages/nro/src/main.ts
+++ b/packages/nro/src/main.ts
@@ -164,8 +164,12 @@ if (slim) {
 		const selfPkg = JSON.parse(
 			readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
 		);
-		const major = String(selfPkg.version).replace(/[.-].*/, '');
-		const runtimeReq = `^${major}`;
+		// Caret on the FULL version this builder (== the runtime version, since
+		// the packages are version-locked) was published as — i.e. "at least
+		// the runtime this app was packaged with, or any newer compatible
+		// release". A caret-on-major (^1) would wrongly accept an OLDER runtime
+		// missing features the app expects.
+		const runtimeReq = `^${selfPkg.version}`;
 		// Prepend a [runtime] section, preserving any existing ini content.
 		const merged =
 			`[runtime]\n; nx.js shared runtime version requirement (semver).\nversion = ${runtimeReq}\n` +

--- a/packages/nsp/src/main.ts
+++ b/packages/nsp/src/main.ts
@@ -247,13 +247,18 @@ try {
 			const selfPkg = JSON.parse(
 				readFileSync(new URL('package.json', root), 'utf8'),
 			);
-			const major = String(selfPkg.version).replace(/[.-].*/, '');
+			// Caret on the FULL version this builder (== the runtime version,
+			// since the packages are version-locked) was published as — "at
+			// least the runtime this app was packaged with, or any newer
+			// compatible release". A caret-on-major (^1) would wrongly accept an
+			// OLDER runtime missing features the app expects.
+			const runtimeReq = `^${selfPkg.version}`;
 			const merged =
-				`[runtime]\n; nx.js shared runtime version requirement (semver).\nversion = ^${major}\n` +
+				`[runtime]\n; nx.js shared runtime version requirement (semver).\nversion = ${runtimeReq}\n` +
 				(existingIniText ? `\n${existingIniText}` : '');
 			romfsEntry['nxjs.ini'] = new Blob([merged]);
 			console.log(
-				`  ${chalk.cyan('nxjs.ini')} (generated; [runtime] version = ^${major})`,
+				`  ${chalk.cyan('nxjs.ini')} (generated; [runtime] version = ${runtimeReq})`,
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

Finishes the slim-app bootstrapping story with two changes.

### 1. Bake `^<full version>` instead of `^<major>`
Slim apps baked `[runtime] version = ^1` (caret-on-major), which would accept an *older* shared runtime that predates features the app was built against. Now `@nx.js/nro`, `@nx.js/nsp`, and the launcher's compiled-in default bake `^<full version>` (e.g. `^1.0.0-beta.2`) = "at least the runtime this app was packaged with, or any newer compatible release". Source of truth is the packaging tool's own version (== the runtime version via the version-lock).

Also fixes a matcher bug this exposed: the vendored semver's caret/tilde/range checks compare only `MAJOR.MINOR.PATCH` and ignore the prerelease, so `^1.0.0-beta.2` wrongly accepted `1.0.0-beta.1`. Added a prerelease-floor guard in `nx_version_satisfies` (+ host tests).

### 2. Auto-download the runtime when missing
When a slim app (NRO or NSP) finds no shared runtime satisfying its requirement under `sdmc:/nx.js/`, the launcher now **downloads** a compatible one instead of only showing a manual-install screen:
- Queries the GitHub releases API over HTTPS (via the Switch `ssl` service — TLS + cert verify + SNI; no curl/mbedtls), scrapes `tag_name`s, and reuses the semver matcher to pick the **highest release satisfying the requirement**.
- Downloads `.../releases/download/v<ver>/nxjs.nro` (following GitHub's CDN redirect) with an on-screen progress indicator.
- Saves it as `sdmc:/nx.js/nxjs-v<ver>.nro` (via a `.part` temp + rename) and continues launching automatically.
- Falls back to the manual-install screen if the download can't proceed (no network / no satisfying release).

New `bootstrap/source/download.{c,h}` (shared by both launchers). Wired into `launcher-nro` (envSetNextLoad path) and `launcher-nsp` (the forwarder brings up the display for progress, then restores the exact pre-`loadNro` service state — sm closed, plain applet teardown — before jumping into the runtime).

## Verification (on-device, online, no runtime installed)
- **Slim NRO**: auto-downloads v1.0.0-beta.2, saves it, chainloads → hello-world runs. ✅
- **Slim NSP**: same, end-to-end. ✅ (Required a lean socket config for the forwarder's 16 MiB heap, and restoring the happy-path service state post-download — both fixed.)
- The HTTPS client correctly follows `github.com` → `release-assets.githubusercontent.com`, and the version selection picks the satisfying release.

## Notes
- Fixed an `ssl` integration bug found on-device: must use the libnx `socketSslConnectionSetSocketDescriptor` wrapper (registers the BSD fd with the ssl service), not the raw `sslConnectionSetSocketDescriptor` IPC cmd (fails `0xe87b`).