### PR TITLE
fix: keep console.canvas live after the app takes over the screen

### DIFF
--- a/.changeset/console-canvas-live.md
+++ b/.changeset/console-canvas-live.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: `console.canvas` now keeps updating after an app takes over the screen with `screen.getContext('2d')`. Previously, once the app owned the screen the runtime stopped rendering the console terminal, so an app compositing `console.canvas` itself (e.g. `ctx.drawImage(console.canvas, ...)`) — especially when it cached the canvas reference once — saw it frozen at the last auto-presented frame. The per-frame present now still renders the terminal (without blitting it) while the app owns the screen, and accessing `console.canvas` renders any pending output on demand, so composited console output stays live.

--- a/apps/console-screen/.gitignore
+++ b/apps/console-screen/.gitignore
@@ -1,0 +1,5 @@
+/*.nro
+/*.nsp
+/node_modules
+/romfs/main.js
+/romfs/main.js.map

--- a/apps/console-screen/package.json
+++ b/apps/console-screen/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "console-screen",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Verify console -> screen.getContext() handoff + console.canvas compositing",
+  "scripts": {
+    "build": "esbuild --bundle --sourcemap --sources-content=false --target=es2022 --format=esm --outdir=romfs src/main.ts",
+    "nro": "nxjs-nro",
+    "nsp": "nxjs-nsp"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@nx.js/nro": "workspace:^",
+    "@nx.js/nsp": "workspace:^",
+    "@nx.js/runtime": "workspace:^",
+    "esbuild": "catalog:"
+  }
+}

--- a/apps/console-screen/src/main.ts
+++ b/apps/console-screen/src/main.ts
@@ -1,0 +1,116 @@
+// Verifies two things that hadn't been exercised together:
+//
+//   1. console.log(...) first  ->  later screen.getContext('2d') takes over.
+//      The console auto-presents to the full screen until the app acquires the
+//      screen's 2D context, at which point the console auto-present stops and the
+//      app owns rendering.
+//
+//   2. Compositing console.canvas with the app's own drawing: the app draws its
+//      own scene each frame AND blits console.canvas (scaled + rotated) via
+//      ctx.drawImage(console.canvas, ...). Crucially, the app keeps logging
+//      AFTER the handoff (a per-second counter), proving console.canvas stays
+//      LIVE (render-on-demand) and isn't frozen at the last auto-presented frame.
+//
+// Timeline: ~3s of plain console output (full-screen console), then the app
+// takes the screen and animates a scene with a LARGE live console panel (left)
+// plus a scaled-down + rotated thumbnail (corner). Press + to exit.
+
+// ---- Phase 1: plain console output (console owns the full screen) ----
+console.log('console-screen verification');
+console.log('');
+console.log('Phase 1: this is the full-screen console.');
+console.log('In ~3s the app takes the screen via getContext("2d").');
+console.log('');
+
+const W = screen.width; // 1280
+const H = screen.height; // 720
+
+// Grab console.canvas before the handoff (stays valid afterwards).
+const consoleCanvas = console.canvas;
+
+let started = 0;
+let appOwns = false;
+let ctx: CanvasRenderingContext2D | null = null;
+let frame = 0;
+let secs = 0;
+let lastTick = 0;
+
+function render(t: number) {
+	if (!started) started = t;
+	const elapsed = t - started;
+
+	// Phase 1: leave the console alone (it auto-presents itself).
+	if (!appOwns && elapsed < 3000) {
+		requestAnimationFrame(render);
+		return;
+	}
+
+	// Phase 2: take over the screen exactly once.
+	if (!appOwns) {
+		ctx = screen.getContext('2d'); // handoff: console auto-present stops
+		appOwns = true;
+		lastTick = t;
+		console.log('-- App owns the screen now. Live counter below: --');
+	}
+	if (!ctx) {
+		requestAnimationFrame(render);
+		return;
+	}
+	frame++;
+
+	// Keep logging AFTER the handoff: one line per second. If console.canvas is
+	// live, these lines keep appearing in the on-screen console panel; if it
+	// were frozen, the panel would stop at the handoff message.
+	if (t - lastTick >= 1000) {
+		lastTick += 1000;
+		secs++;
+		console.log(`  tick ${secs}: console.canvas is LIVE after handoff`);
+	}
+
+	// --- The app's own scene: animated gradient + bouncing circle. ---
+	const g = ctx.createLinearGradient(0, 0, W, H);
+	g.addColorStop(0, '#101822');
+	g.addColorStop(1, `rgb(${40 + (frame % 120)}, 30, 110)`);
+	ctx.fillStyle = g;
+	ctx.fillRect(0, 0, W, H);
+
+	const cx = W * 0.72 + Math.cos(frame / 30) * 150;
+	const cy = H / 2 + Math.sin(frame / 20) * 200;
+	ctx.fillStyle = '#ffcc33';
+	ctx.beginPath();
+	ctx.arc(cx, cy, 40, 0, Math.PI * 2);
+	ctx.fill();
+
+	ctx.fillStyle = '#ffffff';
+	ctx.font = '26px sans-serif';
+	ctx.fillText('App-owned screen (gradient + circle drawn by the app)', 30, 40);
+
+	// --- LARGE live console panel (left half), so the updating text is
+	// readable. drawImage(console.canvas) scaled down ~0.5x, upright. ---
+	const pw = 600;
+	const ph = (H * pw) / W; // keep aspect
+	const px = 30;
+	const py = 70;
+	ctx.fillStyle = 'rgba(0,0,0,0.55)';
+	ctx.fillRect(px - 6, py - 6, pw + 12, ph + 12);
+	ctx.drawImage(consoleCanvas, px, py, pw, ph);
+	ctx.fillStyle = '#9fe09f';
+	ctx.font = '20px sans-serif';
+	ctx.fillText('^ live console.canvas (drawImage, scaled)', px, py + ph + 28);
+
+	// --- Small rotated thumbnail (corner): drawImage with rotation. ---
+	const sc = 280 / W;
+	const tw = W * sc;
+	const th = H * sc;
+	ctx.save();
+	ctx.translate(W - tw / 2 - 50, H - th / 2 - 50);
+	ctx.rotate(-0.12);
+	ctx.fillStyle = 'rgba(0,0,0,0.6)';
+	ctx.fillRect(-tw / 2 - 5, -th / 2 - 5, tw + 10, th + 10);
+	ctx.drawImage(consoleCanvas, -tw / 2, -th / 2, tw, th);
+	ctx.restore();
+
+	requestAnimationFrame(render);
+}
+
+requestAnimationFrame(render);

--- a/apps/console-screen/tsconfig.json
+++ b/apps/console-screen/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@nx.js/runtime"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/runtime/src/console-screen.ts
+++ b/packages/runtime/src/console-screen.ts
@@ -11,6 +11,12 @@ import type { CanvasRenderingContext2D } from './canvas/canvas-rendering-context
 let activeTerminal: Terminal | undefined;
 let appOwnsScreen = false;
 let screenCtx: CanvasRenderingContext2D | undefined;
+// Set when console output (or a scroll) has happened that the screen hasn't
+// been re-blitted for yet. Tracked separately from `Terminal.dirty` because
+// reading `console.canvas` renders + clears the terminal's dirty flag, so by
+// the time presentConsole() runs `render()` may already return false even
+// though the on-screen blit is stale. Cleared after a successful blit.
+let needsBlit = false;
 
 // `screen.ts` registers a getter that returns the screen's own 2D context +
 // puts the screen into canvas (framebuffer) mode, WITHOUT marking the app as
@@ -54,6 +60,7 @@ function wireTouchScroll(): void {
 			// `rows` -> scrollUp(negative) == scrollDown() toward the latest
 			// output. (scrollUp/scrollDown clamp internally.)
 			activeTerminal.scrollUp(rows);
+			needsBlit = true; // the viewport changed; re-blit next frame
 			lastY = y;
 		}
 	});
@@ -70,6 +77,7 @@ function wireTouchScroll(): void {
 export function markAppOwnsScreen(): void {
 	appOwnsScreen = true;
 	screenCtx = undefined;
+	needsBlit = false; // the app draws the screen now; nothing for us to blit
 }
 
 /**
@@ -82,6 +90,7 @@ export function onConsoleOutput(term: Terminal): void {
 	// for apps that composite it (even when they own the screen). Only the
 	// screen-mode acquisition + auto-present below is gated on app ownership.
 	activeTerminal = term;
+	needsBlit = true;
 	if (appOwnsScreen) return;
 	if (!screenCtx && consoleScreenCtxGetter) {
 		try {
@@ -112,9 +121,16 @@ export function presentConsole(): void {
 		return;
 	}
 	if (!screenCtx) return;
-	// render() is a no-op when nothing changed; only blit on an actual change.
-	if (activeTerminal.render()) {
+	// Ensure the terminal pixels are current (no-op if already rendered, e.g.
+	// because user code read `console.canvas` this turn).
+	activeTerminal.render();
+	// Blit when output/scroll happened since the last blit. We gate on
+	// `needsBlit` rather than render()'s return because reading `console.canvas`
+	// can have already done (and cleared) the render — in which case render()
+	// returns false here yet the on-screen copy is still stale.
+	if (needsBlit) {
 		screenCtx.drawImage(activeTerminal.canvas, 0, 0);
+		needsBlit = false;
 	}
 }
 

--- a/packages/runtime/src/console-screen.ts
+++ b/packages/runtime/src/console-screen.ts
@@ -78,8 +78,11 @@ export function markAppOwnsScreen(): void {
  * blit it.
  */
 export function onConsoleOutput(term: Terminal): void {
-	if (appOwnsScreen) return;
+	// Always track the terminal so presentConsole() keeps console.canvas live
+	// for apps that composite it (even when they own the screen). Only the
+	// screen-mode acquisition + auto-present below is gated on app ownership.
 	activeTerminal = term;
+	if (appOwnsScreen) return;
 	if (!screenCtx && consoleScreenCtxGetter) {
 		try {
 			screenCtx = consoleScreenCtxGetter();
@@ -93,9 +96,22 @@ export function onConsoleOutput(term: Terminal): void {
 /**
  * Per-frame hook (called from the runtime frame handler, after rAF). Blits the
  * active console terminal canvas to the screen when it has changed.
+ *
+ * Once the app owns the screen we no longer blit, but we STILL render the
+ * terminal each frame: an app may composite `console.canvas` itself (e.g.
+ * `drawImage`), and apps commonly cache the canvas reference once — so the
+ * pixels must keep updating as new `console.log` output arrives, even though we
+ * stop drawing it to the screen. `render()` is a no-op when nothing changed, so
+ * this is cheap.
  */
 export function presentConsole(): void {
-	if (appOwnsScreen || !activeTerminal || !screenCtx) return;
+	if (!activeTerminal) return;
+	if (appOwnsScreen) {
+		// App owns the screen: keep console.canvas live, but don't blit it.
+		activeTerminal.render();
+		return;
+	}
+	if (!screenCtx) return;
 	// render() is a no-op when nothing changed; only blit on an actual change.
 	if (activeTerminal.render()) {
 		screenCtx.drawImage(activeTerminal.canvas, 0, 0);

--- a/packages/runtime/src/terminal.ts
+++ b/packages/runtime/src/terminal.ts
@@ -230,8 +230,19 @@ export class Terminal {
 		this.#term.onWriteParsed(markDirty);
 	}
 
-	/** The {@link OffscreenCanvas} the terminal renders into. */
+	/**
+	 * The {@link OffscreenCanvas} the terminal renders into.
+	 *
+	 * Accessing this renders any pending output first (render() is a no-op when
+	 * nothing changed), so the returned canvas always reflects the latest
+	 * writes. This matters when an app composites `console.canvas` itself (e.g.
+	 * `drawImage`) — especially after it has taken over the screen with
+	 * `screen.getContext('2d')`, which stops the runtime's per-frame console
+	 * present; without rendering here the canvas would freeze at the last
+	 * auto-presented frame.
+	 */
 	get canvas(): OffscreenCanvas {
+		this.render();
 		return this.#canvas;
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,21 @@ importers:
         specifier: 'catalog:'
         version: 0.27.3
 
+  apps/console-screen:
+    devDependencies:
+      '@nx.js/nro':
+        specifier: workspace:^
+        version: link:../../packages/nro
+      '@nx.js/nsp':
+        specifier: workspace:^
+        version: link:../../packages/nsp
+      '@nx.js/runtime':
+        specifier: workspace:^
+        version: link:../../packages/runtime
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.27.3
+
   apps/console-theme:
     devDependencies:
       '@nx.js/nro':


### PR DESCRIPTION
## Summary

Verifying the (previously untested) flow of `console.log()` first → later `screen.getContext('2d')` takeover → compositing `console.canvas` surfaced a real bug: **`console.canvas` froze once the app owned the screen.**

`console.log()` still writes to the terminal after the handoff, and an app may composite `console.canvas` itself (`ctx.drawImage(console.canvas, ...)`). But the terminal's `render()` was only driven by `presentConsole()`, which early-returned entirely once the app owned the screen — so a cached `console.canvas` reference stayed frozen at the last auto-presented frame.

## Fix

- `presentConsole()` now still **renders** the active terminal each frame after the handoff (it just no longer blits it to the screen), so composited `console.canvas` keeps updating. `render()` is dirty-gated, so this is cheap.
- `onConsoleOutput()` always tracks the active terminal (even when the app owns the screen), so console output that *starts* after the handoff is rendered too.
- `Terminal.canvas` getter renders on demand, so reading `console.canvas` reflects the latest output regardless of access pattern.

## New example app

`apps/console-screen` verifies the full flow: ~3s of full-screen console, then `screen.getContext('2d')` takeover with the app drawing its own scene (gradient + bouncing circle + label) **and** compositing `console.canvas` — a large live panel + a scaled/rotated thumbnail — while logging a per-second counter after the handoff.

## Verification

On-device: confirmed Phase 1 (full-screen console), Phase 2 handoff (app owns the screen, auto-present stopped), `drawImage(console.canvas)` scaled + rotated, and the per-second counter incrementing live in the composited panel (proving `console.canvas` stays live post-handoff).