### PR TITLE
fix: give each Gamepad a unique id (was empty for all pads)

### DIFF
--- a/.changeset/gamepad-id.md
+++ b/.changeset/gamepad-id.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: `Gamepad.id` is now unique per controller (e.g. `"switch-gamepad-0"`) instead of an empty string for every pad. Previously all controllers shared an empty `id`, so the standard Web Gamepad pattern of keying per-controller state/config/slot-assignment by `gamepad.id` collapsed every connected pad onto a single entry. The id is derived from the controller's libnx `HidNpadIdType` index (the stable per-pad discriminator).

--- a/source/gamepad.cc
+++ b/source/gamepad.cc
@@ -1,7 +1,7 @@
 #include "error.h"
 #include "types.h"
 #include "wrap.h"
-#include <cstdio>
+#include <stdio.h>
 
 using namespace v8;
 

--- a/source/gamepad.cc
+++ b/source/gamepad.cc
@@ -1,6 +1,7 @@
 #include "error.h"
 #include "types.h"
 #include "wrap.h"
+#include <cstdio>
 
 using namespace v8;
 
@@ -73,7 +74,17 @@ void nx_gamepad_get_axes(const FunctionCallbackInfo<Value> &info) {
 }
 
 void nx_gamepad_get_id(const FunctionCallbackInfo<Value> &info) {
-	info.GetReturnValue().Set(nx_str(info.GetIsolate(), ""));
+	// Return an id UNIQUE per controller index. Previously this returned ""
+	// for every pad, so all 8 controllers were indistinguishable — code that
+	// keys state/config/slot-assignment by `gamepad.id` (the standard Web
+	// Gamepad pattern) collapsed all pads onto one entry. The Web spec says
+	// `id` should identify the controller; index is the stable discriminator
+	// libnx gives us (HidNpadIdType 0..7).
+	Isolate *iso = info.GetIsolate();
+	nx_gamepad_t *gamepad = nx::Unwrap<nx_gamepad_t>(info.This());
+	char buf[32];
+	snprintf(buf, sizeof(buf), "switch-gamepad-%u", (unsigned)gamepad->id);
+	info.GetReturnValue().Set(nx_str(iso, buf));
 }
 
 void nx_gamepad_get_raw_buttons(const FunctionCallbackInfo<Value> &info) {


### PR DESCRIPTION
## Summary

`Gamepad.id` returned an empty string `""` for **every** controller, so all 8 pads were indistinguishable. The standard Web Gamepad pattern of keying per-controller state / config / slot-assignment by `gamepad.id` therefore collapsed every connected pad onto a single entry.

## Fix

Return a per-controller id, `"switch-gamepad-<index>"`, derived from the controller's libnx `HidNpadIdType` (0..7) — the stable per-pad discriminator the platform provides. Per the Web Gamepad spec, `id` identifies the controller.

## Verification

Device build is warning-free.