### PR TITLE
feat: hardware-backed Gamepad.id + gamepadconnected/disconnected events

### DIFF
--- a/.changeset/gamepad-id.md
+++ b/.changeset/gamepad-id.md
@@ -1,5 +1,7 @@
 ---
-"@nx.js/runtime": patch
+"@nx.js/runtime": minor
 ---
 
-fix: `Gamepad.id` is now unique per controller (e.g. `"switch-gamepad-0"`) instead of an empty string for every pad. Previously all controllers shared an empty `id`, so the standard Web Gamepad pattern of keying per-controller state/config/slot-assignment by `gamepad.id` collapsed every connected pad onto a single entry. The id is derived from the controller's libnx `HidNpadIdType` index (the stable per-pad discriminator).
+feat: `Gamepad.id` now reports the controller's real hardware identity. On firmware 5.0.0+ it is the device name plus the controller's serial number (e.g. `"Nintendo Switch Pro Controller (XAW10012345678)"`), queried from the `hid:sys` service. The serial is resolved lazily and cached — it is never read on the input-polling hot path, and is invalidated only when a controller connects or disconnects. When the serial is unavailable (older firmware, no serial, or a system error) `id` falls back to the previous unique-per-slot `"switch-gamepad-<index>"` string.
+
+Additionally, the global `gamepadconnected` and `gamepaddisconnected` events now fire when controllers are connected to or disconnected from the system (previously the `GamepadEvent` type existed but was never dispatched).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,35 +629,72 @@ fixtures and compare them to Chrome. It needs the CI toolchain (clang-19/lld-19
 ssh natecube "docker exec nxdbg bash -lc 'cd /work && <cmd>'"
 ```
 
+**You do NOT need natecube hardware access beyond `ssh natecube` + the running
+`nxdbg` container** — this is the canonical way to run the conformance suite
+when you don't have `/opt/host` locally (macOS dev machines won't). The recipe
+below is verified end-to-end; run each step as
+`ssh natecube "docker exec nxdbg bash -lc 'cd /work && <cmd>'"`.
+
+**IMPORTANT — leave `/work` as you found it.** `/work` is a real working tree the
+user may have checked out to another branch with uncommitted changes. Before
+touching it: `git stash list` + `git status`. If dirty, `git stash push -u -m
+<note>` first; **restore at the end** (`git checkout <orig-branch>`, `git stash
+pop`, delete any temp branch you made, `rm -rf .pnpm-store`).
+
+End-to-end recipe (each line is a separate `docker exec … bash -lc 'cd /work &&
+…'`; always append `< /dev/null` to pnpm/node so they can't hang on a prompt):
+
+```bash
+# 0. git dubious-ownership guard (once per fresh container)
+git config --global --add safe.directory /work
+# 1. Get your branch into /work (origin remote-tracking refs may be absent —
+#    fetch straight into a local branch ref, don't rely on origin/<branch>):
+git fetch origin <branch>:<branch> && git checkout <branch>
+# 2. node + pnpm are NOT baked in (Debian 12 / x86_64). Install the x64 build:
+cd /tmp && curl -fsSL https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz \
+  -o node.tar.xz && tar -xf node.tar.xz && cp -r node-v22.14.0-linux-x64/* /usr/local/
+corepack enable && corepack prepare pnpm@8.15.9 --activate     # match packageManager
+# 3. Deps + a FRESH runtime.js bundled from your branch (the harness runs it):
+pnpm install --frozen-lockfile < /dev/null
+pnpm --filter @nx.js/runtime bundle < /dev/null                # -> packages/runtime/runtime.js
+# 4. Build the host binary (clang-19/lld-19 + /opt/host V8/Skia/ada):
+cd packages/runtime/test && cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 && \
+    cmake --build build -j"$(nproc)"                           # -> build/nxjs-test
+# 5a. Run ONE fixture directly (NO Chrome) — absolute paths; stdbuf because the
+#     binary idles until the fixture calls Switch.exit():
+node packages/runtime/test/build-fixtures.mjs                  # fixtures/*.ts -> fixtures/build/*.js
+stdbuf -oL ./packages/runtime/test/build/nxjs-test \
+    "$(pwd)/packages/runtime/runtime.js" \
+    "$(pwd)/packages/runtime/test/fixtures/build/<name>.js"
+# 5b. Conformance vs Chrome for SPECIFIC fixtures (avoids the flaky full run).
+#     Needs Playwright Chromium + its apt libs (libnspr4 etc.):
+pnpm --filter @nx.js/runtime exec playwright install chromium < /dev/null
+apt-get update -qq && pnpm --filter @nx.js/runtime exec playwright install-deps chromium < /dev/null
+#     Filter by vitest test name "<fixture>: nxjs-test vs Chrome" (run from the
+#     runtime package dir; -t is a substring match so be specific):
+cd /work/packages/runtime && npx vitest run --config test/vitest.config.ts \
+    -t "<fixture>: nxjs-test vs Chrome" < /dev/null
+```
+
 Notes / gotchas learned:
-- The container is **x86_64**; install host node as the x64 build if missing.
-- `git` needs `git config --global --add safe.directory /work` (dubious
-  ownership) after a fresh container.
-- node/pnpm are NOT baked into the image — CI installs them per-run
-  (`actions/setup-node` + `pnpm/action-setup`). Install on demand if needed.
+- **AppleDouble `._*` files**: if `/work` was ever rsync'd from macOS, stray
+  `._<fixture>.js` sidecars can litter `fixtures/build/`. The conformance
+  fixture-discovery globs `*.js` and tries to execute them; `nxjs-test` chokes
+  and the test **hangs 30s then fails as `._<fixture>: …`**. This is NOT a real
+  failure — `find packages/runtime/test/fixtures/build -name '._*' -delete`,
+  then re-run. (A real fixture's result line has no `._` prefix.)
+- **Don't run the full `pnpm test`** unattended — some fixtures hit flaky public
+  endpoints (`echo.websocket.org`) and can stall for many minutes. Use the `-t`
+  filter for the fixtures your change touches.
 - Some apt dev headers (e.g. `libturbojpeg0-dev libjpeg62-turbo-dev`) may be
   missing in a fresh container and are needed to compile `image.cc`; CI installs
   them via apt.
 - To **symbolize a published crash**, check out the published tag/commit in
   `/work`, rebuild `nxjs.nro` there (same `switch-v8` as CI), and addr2line.
-- Build + run the host harness:
-  ```bash
-  cd packages/runtime/test
-  cmake -B build -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19
-  cmake --build build -j8                       # -> build/nxjs-test
-  # Full conformance (needs Playwright Chromium):
-  pnpm --filter @nx.js/runtime test
-  # Run ONE fixture directly (no Chrome) — use ABSOLUTE paths; line-buffer
-  # stdout because the binary idles until the fixture calls Switch.exit():
-  node packages/runtime/test/build-fixtures.mjs        # build fixtures/*.ts -> fixtures/build/*.js
-  stdbuf -oL ./packages/runtime/test/build/nxjs-test \
-      "$(pwd)/packages/runtime/runtime.js" \
-      "$(pwd)/packages/runtime/test/fixtures/build/<name>.js"
-  ```
-  A fixture that exits non-zero / segfaults: the harness loses block-buffered
+- A fixture that exits non-zero / segfaults: the harness loses block-buffered
   stdout, so a real failure can masquerade as "empty output, all fixtures fail".
-  Run it directly with `stdbuf -oL` to see the actual TAP + exit code.
+  Run it directly with `stdbuf -oL` (step 5a) to see the actual TAP + exit code.
 - The CI `pacman-packages` image SHA is pinned in `.github/workflows/ci.yml`
   (both the Build and Test jobs). When the V8/Skia portlib is rebuilt, the user
   provides a new image digest; bump both references and (optionally) re-create

--- a/docs/content/runtime/concepts/controllers.mdx
+++ b/docs/content/runtime/concepts/controllers.mdx
@@ -39,6 +39,36 @@ update();
 > It is optional, but recommended to use the [`Button`](/constants/api/enumerations/Button)
 > enum from the `@nx.js/constants` package to refer to the button indices, as shown in the example above.
 
+## Identifying controllers
+
+Each [`Gamepad`](/runtime/api/classes/Gamepad) has an `id` property that identifies the
+controller. On Switch firmware 5.0.0 and later, this is the controller's device name plus
+its hardware serial number, for example:
+
+```
+Nintendo Switch Pro Controller (XAW10012345678)
+```
+
+This makes `id` stable and unique per _physical_ controller, which is useful for keying
+per-player state or settings. The serial number is read once and cached, so reading `id`
+in your update loop is cheap. On older firmware (or if the serial is otherwise
+unavailable) `id` falls back to a per-slot string of the form `switch-gamepad-<index>`.
+
+## Connect and disconnect events
+
+The global `gamepadconnected` and `gamepaddisconnected` events fire when a controller is
+connected to or disconnected from the system:
+
+```typescript
+addEventListener('gamepadconnected', (event) => {
+  console.log(`Controller connected: ${event.gamepad.id}`);
+});
+
+addEventListener('gamepaddisconnected', (event) => {
+  console.log(`Controller disconnected at index ${event.gamepad.index}`);
+});
+```
+
 ## Plus button behavior
 
 By default, pressing the <Icon></Icon> button on the first controller __will exit the application__.

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -377,6 +377,16 @@ export interface Init {
 	gamepadButtonInit(c: ClassOf<GamepadButton>): void;
 	gamepadButtonNew(gamepad: Gamepad, index: number): void;
 
+	// hidsys.c
+	/**
+	 * Non-blocking check of the OS controller connect/disconnect event.
+	 * Returns `true` when a controller was connected or disconnected since the
+	 * last call (and invalidates the cached `Gamepad.id` values), `false`
+	 * otherwise. Called once per frame to drive `gamepadconnected` /
+	 * `gamepaddisconnected` dispatch.
+	 */
+	gamepadConnectionChanged(): boolean;
+
 	// image.c
 	imageInit(c: ClassOf<Image | ImageBitmap>): void;
 	imageNew(width?: number, height?: number): Image | ImageBitmap;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -246,6 +246,7 @@ export type {
 
 import { dispatchKeyboardEvents } from './keyboard';
 import { dispatchTouchEvents } from './touchscreen';
+import { sweepGamepadConnections } from './navigator/gamepad';
 
 $.onError((e) => {
 	const ev = new ErrorEvent('error', {
@@ -287,6 +288,10 @@ $.onFrame((plusDown) => {
 	callRafCallbacks();
 	dispatchTouchEvents(screen);
 	dispatchKeyboardEvents(globalThis);
+	// Emit `gamepadconnected` / `gamepaddisconnected` on controller hotplug.
+	for (const e of sweepGamepadConnections()) {
+		globalThis.dispatchEvent(e);
+	}
 	// Blit the default console's terminal canvas onto the screen if it changed
 	// (no-op once the app owns screen rendering). After rAF so an app that
 	// draws to the screen each frame isn't overwritten on the same frame.

--- a/packages/runtime/src/navigator/gamepad.ts
+++ b/packages/runtime/src/navigator/gamepad.ts
@@ -1,5 +1,6 @@
 import { $ } from '../$';
 import { assertInternalConstructor, def, proto } from '../utils';
+import { GamepadEvent } from '../polyfills/event';
 import type {
 	GamepadHapticActuatorType,
 	GamepadMappingType,
@@ -16,6 +17,18 @@ export class Gamepad implements globalThis.Gamepad {
 	readonly axes!: readonly number[];
 	readonly buttons!: readonly GamepadButton[];
 	readonly connected!: boolean;
+	/**
+	 * A string identifying the controller. When available (firmware 5.0.0+),
+	 * this is the controller's device name plus its hardware serial number,
+	 * e.g. `"Nintendo Switch Pro Controller (XAW10012345678)"`, making it
+	 * stable and unique per physical controller.
+	 *
+	 * The serial is read from the `hid:sys` service and cached — it is only
+	 * re-queried when a controller is connected or disconnected, never on the
+	 * input-polling hot path. When the serial can't be obtained (older
+	 * firmware, no serial, or a system error) `id` falls back to a
+	 * unique-per-slot string of the form `"switch-gamepad-<index>"`.
+	 */
 	readonly id!: string;
 	readonly index!: number;
 	readonly mapping!: GamepadMappingType;
@@ -100,3 +113,35 @@ export function gamepadNew(index: number) {
 export const gamepads: Gamepad[] = Array(8)
 	.fill(0)
 	.map((_, i) => gamepadNew(i));
+
+// Tracks the last-seen connection state of each slot so we can diff and emit
+// `gamepadconnected` / `gamepaddisconnected` only on an actual transition.
+const connectedState: boolean[] = Array(8).fill(false);
+
+/**
+ * Detects controller connect/disconnect transitions and returns the
+ * `GamepadEvent`s that should be dispatched (in order). Cheap on the common
+ * path: it only diffs the 8 slots when the OS connection event has fired (the
+ * native `$.gamepadConnectionChanged()` is a non-blocking event check, and is
+ * also what invalidates the cached `Gamepad.id` values). Returns an empty
+ * array when nothing changed.
+ *
+ * @ignore
+ */
+export function sweepGamepadConnections(): GamepadEvent[] {
+	if (!$.gamepadConnectionChanged()) return [];
+	const events: GamepadEvent[] = [];
+	for (let i = 0; i < 8; i++) {
+		const g = gamepads[i];
+		const connected = g.connected;
+		if (connected === connectedState[i]) continue;
+		connectedState[i] = connected;
+		events.push(
+			new GamepadEvent(
+				connected ? 'gamepadconnected' : 'gamepaddisconnected',
+				{ gamepad: g },
+			),
+		);
+	}
+	return events;
+}

--- a/packages/runtime/src/navigator/gamepad.ts
+++ b/packages/runtime/src/navigator/gamepad.ts
@@ -120,20 +120,27 @@ const connectedState: boolean[] = Array(8).fill(false);
 
 /**
  * Detects controller connect/disconnect transitions and returns the
- * `GamepadEvent`s that should be dispatched (in order). Cheap on the common
- * path: it only diffs the 8 slots when the OS connection event has fired (the
- * native `$.gamepadConnectionChanged()` is a non-blocking event check, and is
- * also what invalidates the cached `Gamepad.id` values). Returns an empty
- * array when nothing changed.
+ * `GamepadEvent`s that should be dispatched (in order). Returns an empty array
+ * when nothing changed (the common path: 8 cheap boolean reads).
+ *
+ * `$.gamepadConnectionChanged()` is consulted purely to invalidate the cached
+ * `Gamepad.id` values when the OS connection event fires — the transition diff
+ * itself is always run off `Gamepad.connected`, so the events still dispatch
+ * even when `hid:sys` is unavailable (e.g. firmware < 5.0.0) and that native
+ * check always reports `false`.
  *
  * @ignore
  */
 export function sweepGamepadConnections(): GamepadEvent[] {
-	if (!$.gamepadConnectionChanged()) return [];
+	// Drain the native connect/disconnect event so the C side can invalidate
+	// the id cache for re-resolution. The return value does NOT gate the diff.
+	$.gamepadConnectionChanged();
 	const events: GamepadEvent[] = [];
 	for (let i = 0; i < 8; i++) {
 		const g = gamepads[i];
-		const connected = g.connected;
+		// Coerce to a real boolean: the host test stub leaves `connected`
+		// undefined, which would otherwise look like a transition every frame.
+		const connected = !!g.connected;
 		if (connected === connectedState[i]) continue;
 		connectedState[i] = connected;
 		events.push(

--- a/packages/runtime/test/fixtures/gamepad-event.ts
+++ b/packages/runtime/test/fixtures/gamepad-event.ts
@@ -6,6 +6,13 @@ import { test } from '../src/tap';
 // both environments. The real serial-backed `Gamepad.id` and hotplug
 // detection are device-only (verified on-device), so they are not asserted
 // here.
+//
+// `{ gamepad: null }` is used because a real `Gamepad` can't be constructed in
+// either environment (nx.js uses an internal constructor; headless Chrome has
+// no controllers). Although the W3C IDL declares `GamepadEventInit.gamepad` as
+// `required Gamepad`, Chrome accepts `null` (and even an absent init dict) —
+// verified empirically — so both engines agree, which is what the conformance
+// comparison checks.
 
 test('GamepadEvent type and gamepad property', (t) => {
 	const ev = new GamepadEvent('gamepadconnected', { gamepad: null });

--- a/packages/runtime/test/fixtures/gamepad-event.ts
+++ b/packages/runtime/test/fixtures/gamepad-event.ts
@@ -1,0 +1,35 @@
+import { test } from '../src/tap';
+
+// `GamepadEvent` is a standard Web API (present in Chrome and nx.js). These
+// assertions exercise the event shape + dispatch path that drives nx.js's
+// `gamepadconnected` / `gamepaddisconnected` events, and run identically in
+// both environments. The real serial-backed `Gamepad.id` and hotplug
+// detection are device-only (verified on-device), so they are not asserted
+// here.
+
+test('GamepadEvent type and gamepad property', (t) => {
+	const ev = new GamepadEvent('gamepadconnected', { gamepad: null });
+	t.equal(ev.type, 'gamepadconnected', 'type is set');
+	t.equal(ev.gamepad, null, 'gamepad property is exposed');
+});
+
+test('GamepadEvent dispatches on an EventTarget', (t) => {
+	const target = new EventTarget();
+	let received: GamepadEvent | null = null;
+	target.addEventListener('gamepaddisconnected', ((e: GamepadEvent) => {
+		received = e;
+	}) as EventListener);
+	const ev = new GamepadEvent('gamepaddisconnected', { gamepad: null });
+	target.dispatchEvent(ev);
+	t.ok(received, 'listener received the GamepadEvent');
+	t.equal(
+		(received as unknown as GamepadEvent | null)?.type,
+		'gamepaddisconnected',
+		'received event has correct type',
+	);
+});
+
+test('GamepadEvent is an instance of Event', (t) => {
+	const ev = new GamepadEvent('gamepadconnected', { gamepad: null });
+	t.ok(ev instanceof Event, 'GamepadEvent extends Event');
+});

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -54,7 +54,8 @@ using namespace v8;
 NX_MOD(account); NX_MOD(album); NX_MOD(applet); NX_MOD(audio); NX_MOD(battery);
 NX_MOD(canvas); NX_MOD(compression); NX_MOD(crypto); NX_MOD(dns);
 NX_MOD(dommatrix); NX_MOD(error); NX_MOD(font); NX_MOD(fs); NX_MOD(fsdev);
-NX_MOD(gamepad); NX_MOD(image); NX_MOD(irs); NX_MOD(memory); NX_MOD(nifm);
+NX_MOD(gamepad); NX_MOD(hidsys); NX_MOD(image); NX_MOD(irs); NX_MOD(memory);
+NX_MOD(nifm);
 NX_MOD(ns); NX_MOD(path2d); NX_MOD(service); NX_MOD(swkbd); NX_MOD(tcp);
 NX_MOD(tls); NX_MOD(udp); NX_MOD(url); NX_MOD(web); NX_MOD(window);
 #undef NX_MOD
@@ -312,6 +313,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	nx_init_fs(iso, init_obj);
 	nx_init_fsdev(iso, init_obj);
 	nx_init_gamepad(iso, init_obj);
+	nx_init_hidsys(iso, init_obj);
 	nx_init_image(iso, init_obj);
 	nx_init_irs(iso, init_obj);
 	nx_init_memory(iso, init_obj);

--- a/packages/runtime/test/src/stubs.cc
+++ b/packages/runtime/test/src/stubs.cc
@@ -29,6 +29,12 @@ static void nx_stub_new(const FunctionCallbackInfo<Value> &info) {
 	info.GetReturnValue().Set(Object::New(iso));
 }
 
+// Boolean no-op: returns `false`. Used for predicate-shaped bindings whose
+// callers branch on the result (e.g. gamepadConnectionChanged).
+static void nx_stub_false(const FunctionCallbackInfo<Value> &info) {
+	info.GetReturnValue().Set(v8::Boolean::New(info.GetIsolate(), false));
+}
+
 // Register a list of names on init_obj, all bound to `fn`.
 static void nx_stub_register(Isolate *iso, Local<Object> init_obj,
                              const char *const *names, size_t count,
@@ -88,6 +94,14 @@ NX_STUB_FN(fsdev) {
 NX_STUB_FN(gamepad) {
 	NX_STUB_NAMES("gamepadInit", "gamepadNew", "gamepadButtonInit",
 	              "gamepadButtonNew")
+}
+
+// `hid:sys` (gamepad serial id resolution + connect/disconnect event) is
+// libnx-only, so it is stubbed host-side. gamepadConnectionChanged must return
+// a boolean (false) — the JS connection sweep branches on it.
+NX_STUB_FN(hidsys) {
+	static const char *const names[] = {"gamepadConnectionChanged"};
+	nx_stub_register(iso, init_obj, names, countof(names), nx_stub_false);
 }
 
 NX_STUB_FN(irs) {

--- a/source/gamepad.cc
+++ b/source/gamepad.cc
@@ -1,4 +1,5 @@
 #include "error.h"
+#include "hidsys.h"
 #include "types.h"
 #include "wrap.h"
 #include <stdio.h>
@@ -74,16 +75,20 @@ void nx_gamepad_get_axes(const FunctionCallbackInfo<Value> &info) {
 }
 
 void nx_gamepad_get_id(const FunctionCallbackInfo<Value> &info) {
-	// Return an id UNIQUE per controller index. Previously this returned ""
-	// for every pad, so all 8 controllers were indistinguishable — code that
-	// keys state/config/slot-assignment by `gamepad.id` (the standard Web
-	// Gamepad pattern) collapsed all pads onto one entry. The Web spec says
-	// `id` should identify the controller; index is the stable discriminator
-	// libnx gives us (HidNpadIdType 0..7).
+	// Resolve a descriptive, hardware-backed id — the controller's device name
+	// plus its serial number, e.g. "Nintendo Switch Pro Controller (XAW...)".
+	// The serial comes from the `hid:sys` service (FW 5.0.0+); that IPC is
+	// expensive, so `nx_gamepad_resolve_id` caches the result per Npad index
+	// and only re-queries after a connect/disconnect — it is NEVER hit on the
+	// hot input-polling path. When the serial can't be obtained (old firmware,
+	// no paired controller, IPC failure) it falls back to the prior
+	// "switch-gamepad-<index>" string, so `id` is always a non-empty value
+	// that is unique per controller slot (the standard Web Gamepad pattern of
+	// keying state/config by `gamepad.id`).
 	Isolate *iso = info.GetIsolate();
 	nx_gamepad_t *gamepad = nx::Unwrap<nx_gamepad_t>(info.This());
-	char buf[32];
-	snprintf(buf, sizeof(buf), "switch-gamepad-%u", (unsigned)gamepad->id);
+	char buf[96];
+	nx_gamepad_resolve_id(iso, (unsigned)gamepad->id, buf, sizeof(buf));
 	info.GetReturnValue().Set(nx_str(iso, buf));
 }
 

--- a/source/gamepad.h
+++ b/source/gamepad.h
@@ -1,16 +1,4 @@
 #pragma once
 #include "types.h"
 
-typedef struct {
-	HidNpadIdType id;
-	PadState *pad;
-} nx_gamepad_t;
-
-typedef struct {
-	nx_gamepad_t *gamepad;
-	u64 mask;
-} nx_gamepad_button_t;
-
-nx_gamepad_t *nx_get_gamepad(JSContext *ctx, JSValueConst obj);
-
-void nx_init_gamepad(JSContext *ctx, JSValueConst init_obj);
+void nx_init_gamepad(v8::Isolate *iso, v8::Local<v8::Object> init_obj);

--- a/source/hidsys.cc
+++ b/source/hidsys.cc
@@ -72,17 +72,23 @@ void nx_gamepad_connection_changed(const FunctionCallbackInfo<Value> &info) {
 
 } // namespace
 
-// Read one unique pad's serial number into `out` (NUL-terminated, trimmed).
-// Returns true only when a non-empty serial was obtained.
+// Read one unique pad's serial number into `out` (NUL-terminated, with any
+// trailing whitespace / control-byte padding trimmed). Returns true only when
+// a non-empty serial was obtained.
 bool read_serial(HidsysUniquePadId pad, char *out, size_t out_len) {
 	HidsysUniquePadSerialNumber serial;
 	memset(&serial, 0, sizeof(serial));
 	if (R_FAILED(hidsysGetUniquePadSerialNumber(pad, &serial)))
 		return false;
-	// serial_number is a 0x10 byte field, not guaranteed NUL-terminated.
+	// serial_number is a fixed 0x10-byte field, not guaranteed NUL-terminated
+	// and often padded with spaces / zero bytes.
 	char ser[sizeof(serial.serial_number) + 1];
 	memcpy(ser, serial.serial_number, sizeof(serial.serial_number));
 	ser[sizeof(serial.serial_number)] = '\0';
+	// Trim trailing padding (spaces and any control bytes <= 0x20).
+	size_t len = strlen(ser);
+	while (len > 0 && (unsigned char)ser[len - 1] <= ' ')
+		ser[--len] = '\0';
 	if (ser[0] == '\0')
 		return false;
 	snprintf(out, out_len, "%s", ser);

--- a/source/hidsys.cc
+++ b/source/hidsys.cc
@@ -1,0 +1,202 @@
+#include "hidsys.h"
+#include "types.h"
+#include <stdio.h>
+#include <string.h>
+
+using namespace v8;
+
+namespace {
+
+// Map the HidDeviceTypeBits bitfield (from hidGetNpadDeviceType) to a
+// human-readable controller name, mirroring the desktop-browser convention of
+// a descriptive `Gamepad.id`. Only the lowest set meaningful bit is used; a
+// dual Joy-Con reports both HandheldLeft/Right or JoyLeft/Right, in which case
+// we report the pair generically.
+const char *device_type_name(u32 bits) {
+	if (bits & HidDeviceTypeBits_FullKey)
+		return "Nintendo Switch Pro Controller";
+	if ((bits & HidDeviceTypeBits_JoyLeft) && (bits & HidDeviceTypeBits_JoyRight))
+		return "Joy-Con (L/R)";
+	if (bits & HidDeviceTypeBits_JoyLeft)
+		return "Joy-Con (L)";
+	if (bits & HidDeviceTypeBits_JoyRight)
+		return "Joy-Con (R)";
+	if ((bits & HidDeviceTypeBits_HandheldLeft) ||
+	    (bits & HidDeviceTypeBits_HandheldRight))
+		return "Nintendo Switch Handheld";
+	if (bits & HidDeviceTypeBits_Palma)
+		return "Poke Ball Plus";
+	if ((bits & HidDeviceTypeBits_LarkHvcLeft) ||
+	    (bits & HidDeviceTypeBits_LarkHvcRight) ||
+	    (bits & HidDeviceTypeBits_HandheldLarkHvcLeft) ||
+	    (bits & HidDeviceTypeBits_HandheldLarkHvcRight))
+		return "Famicom Controller";
+	if ((bits & HidDeviceTypeBits_LarkNesLeft) ||
+	    (bits & HidDeviceTypeBits_LarkNesRight) ||
+	    (bits & HidDeviceTypeBits_HandheldLarkNesLeft) ||
+	    (bits & HidDeviceTypeBits_HandheldLarkNesRight))
+		return "NES Controller";
+	if (bits & HidDeviceTypeBits_Lucia)
+		return "SNES Controller";
+	if (bits & HidDeviceTypeBits_Lagon)
+		return "Nintendo 64 Controller";
+	if (bits & HidDeviceTypeBits_Lager)
+		return "Sega Genesis Controller";
+	return "Nintendo Switch Controller";
+}
+
+void nx_gamepad_connection_changed(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_context_t *ctx = nx_ctx(iso);
+	bool changed = false;
+	if (ctx->hidsys_available) {
+		// Non-blocking: returns immediately whether or not the event fired.
+		if (R_SUCCEEDED(eventWait(&ctx->hidsys_conn_event, 0))) {
+			eventClear(&ctx->hidsys_conn_event);
+			// A controller connected or disconnected. Only invalidate the
+			// cache for slots that are CURRENTLY connected — those may now host
+			// a different controller and must re-resolve. Disconnected slots
+			// deliberately KEEP their last-known id so the `gamepaddisconnected`
+			// event (dispatched this same sweep) reports the real controller
+			// that left, rather than the "switch-gamepad-N" fallback you'd get
+			// from querying a pad that is no longer present.
+			for (int i = 0; i < 8; i++) {
+				if (padIsConnected(&ctx->pads[i]))
+					ctx->gamepad_id_cached[i] = false;
+			}
+			changed = true;
+		}
+	}
+	info.GetReturnValue().Set(Boolean::New(iso, changed));
+}
+
+} // namespace
+
+// Read one unique pad's serial number into `out` (NUL-terminated, trimmed).
+// Returns true only when a non-empty serial was obtained.
+bool read_serial(HidsysUniquePadId pad, char *out, size_t out_len) {
+	HidsysUniquePadSerialNumber serial;
+	memset(&serial, 0, sizeof(serial));
+	if (R_FAILED(hidsysGetUniquePadSerialNumber(pad, &serial)))
+		return false;
+	// serial_number is a 0x10 byte field, not guaranteed NUL-terminated.
+	char ser[sizeof(serial.serial_number) + 1];
+	memcpy(ser, serial.serial_number, sizeof(serial.serial_number));
+	ser[sizeof(serial.serial_number)] = '\0';
+	if (ser[0] == '\0')
+		return false;
+	snprintf(out, out_len, "%s", ser);
+	return true;
+}
+
+// Aggregate the serials of EVERY unique pad mapped to Npad `npad` into `out`,
+// joined with '+'. A single controller yields one serial; a dual Joy-Con pair
+// (handheld or detached dual mode) yields both (e.g. "XAW... + XCW..."), so the
+// combined console-as-one-controller has a single stable identifier. Returns
+// the number of serials written (0 if none / on failure).
+int aggregate_serials(HidNpadIdType npad, char *out, size_t out_len) {
+	HidsysUniquePadId pads[2];
+	s32 total = 0;
+	if (R_FAILED(hidsysGetUniquePadsFromNpad(npad, pads, countof(pads), &total)))
+		return 0;
+	int written = 0;
+	size_t off = 0;
+	out[0] = '\0';
+	for (s32 i = 0; i < total && i < (s32)countof(pads); i++) {
+		char ser[sizeof(HidsysUniquePadSerialNumber) + 1];
+		if (!read_serial(pads[i], ser, sizeof(ser)))
+			continue;
+		int n = snprintf(out + off, out_len - off, "%s%s",
+		                 written ? " + " : "", ser);
+		if (n < 0 || (size_t)n >= out_len - off)
+			break;
+		off += n;
+		written++;
+	}
+	return written;
+}
+
+void nx_gamepad_resolve_id(Isolate *iso, unsigned index, char *out,
+                           size_t out_len) {
+	nx_context_t *ctx = nx_ctx(iso);
+
+	if (index < 8 && ctx->gamepad_id_cached[index]) {
+		snprintf(out, out_len, "%s", ctx->gamepad_id_cache[index]);
+		return;
+	}
+
+	// Fallback used whenever the real serial can't be obtained (hidsys
+	// unavailable, firmware < 5.0.0, no paired unique pad, IPC failure). This
+	// preserves a non-empty, unique-per-slot id (the prior behavior).
+	char resolved[96];
+	snprintf(resolved, sizeof(resolved), "switch-gamepad-%u", index);
+	bool real = false;
+
+	if (ctx->hidsys_available) {
+		// Slot 0 doubles as the handheld controller. In handheld mode the
+		// active controller lives under HidNpadIdType_Handheld (0x20), not
+		// No1 (0), so prefer whichever is currently connected for that slot.
+		HidNpadIdType npad = (HidNpadIdType)index;
+		if (index == 0) {
+			u32 style = hidGetNpadStyleSet(HidNpadIdType_Handheld);
+			if (style & HidNpadStyleTag_NpadHandheld)
+				npad = HidNpadIdType_Handheld;
+		}
+
+		char serials[48];
+		int n = aggregate_serials(npad, serials, sizeof(serials));
+		// Fall back to the regular Npad if the handheld query came up empty
+		// (e.g. a controller connected to slot 0 in non-handheld mode).
+		if (n == 0 && npad != (HidNpadIdType)index)
+			n = aggregate_serials((HidNpadIdType)index, serials,
+			                      sizeof(serials));
+		if (n > 0) {
+			const char *name = device_type_name(hidGetNpadDeviceType(npad));
+			snprintf(resolved, sizeof(resolved), "%s (%s)", name, serials);
+			real = true;
+		}
+	}
+
+	// Only cache a successfully-resolved real serial. The serial DB can lag a
+	// frame or two behind a freshly-connected controller, so caching the
+	// fallback here would "stick" it until the next connect/disconnect event.
+	// Leaving the slot uncached lets the next `id` read retry — cheap, since
+	// retries only happen for an as-yet-unresolved connected slot.
+	if (real && index < 8) {
+		snprintf(ctx->gamepad_id_cache[index],
+		         sizeof(ctx->gamepad_id_cache[index]), "%s", resolved);
+		ctx->gamepad_id_cached[index] = true;
+	}
+	snprintf(out, out_len, "%s", resolved);
+}
+
+void nx_hidsys_init(Isolate *iso) {
+	nx_context_t *ctx = nx_ctx(iso);
+	ctx->hidsys_available = false;
+	memset(ctx->gamepad_id_cached, 0, sizeof(ctx->gamepad_id_cached));
+
+	Result rc = hidsysInitialize();
+	if (R_FAILED(rc))
+		return;
+
+	rc = hidsysAcquireUniquePadConnectionEventHandle(&ctx->hidsys_conn_event);
+	if (R_FAILED(rc)) {
+		hidsysExit();
+		return;
+	}
+
+	ctx->hidsys_available = true;
+}
+
+void nx_hidsys_exit(nx_context_t *ctx) {
+	if (!ctx->hidsys_available)
+		return;
+	eventClose(&ctx->hidsys_conn_event);
+	hidsysExit();
+	ctx->hidsys_available = false;
+}
+
+void nx_init_hidsys(Isolate *iso, Local<Object> init_obj) {
+	NX_SET_FUNC(init_obj, "gamepadConnectionChanged",
+	            nx_gamepad_connection_changed);
+}

--- a/source/hidsys.h
+++ b/source/hidsys.h
@@ -27,9 +27,11 @@ void nx_hidsys_exit(nx_context_t *ctx);
 void nx_gamepad_resolve_id(v8::Isolate *iso, unsigned index, char *out,
                            size_t out_len);
 
-// Non-blocking check of the OS unique-pad connection event. When it has
-// signaled (a controller connected/disconnected), clears the entire id cache
-// and returns true. Returns false (and does nothing) otherwise. Exposed to JS
-// as `$.gamepadConnectionChanged()` and called once per frame to drive the
-// `gamepadconnected` / `gamepaddisconnected` sweep.
+// Registers the `$.gamepadConnectionChanged()` binding: a non-blocking check of
+// the OS unique-pad connection event. When it has signaled (a controller
+// connected/disconnected), it invalidates the cached id of every CURRENTLY
+// CONNECTED slot (so a slot now hosting a different controller re-resolves)
+// while leaving disconnected slots' last-known ids intact (so the
+// `gamepaddisconnected` event reports the controller that left, not the
+// fallback), then returns true. Returns false (and does nothing) otherwise.
 void nx_init_hidsys(v8::Isolate *iso, v8::Local<v8::Object> init_obj);

--- a/source/hidsys.h
+++ b/source/hidsys.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "types.h"
+
+// `hid:sys` service integration used to resolve a real, hardware-backed
+// `Gamepad.id` (the controller's serial number + a human-readable device name)
+// and to drive `gamepadconnected` / `gamepaddisconnected` invalidation.
+//
+// All hidsys IPC is kept OUT of the per-frame input-polling hot path: id
+// strings are resolved lazily on first `Gamepad.id` access and cached per Npad
+// index on `nx_context_t`. The cache is invalidated only when the OS signals a
+// controller connect/disconnect (a single non-blocking event check per frame).
+
+// Open the `hid:sys` service and acquire the unique-pad connection event.
+// Tolerates failure (sets nx_ctx->hidsys_available = false) — `Gamepad.id`
+// then falls back to the index-based string. Call once during service init.
+void nx_hidsys_init(v8::Isolate *iso);
+
+// Close the connection event + the `hid:sys` service. Call during teardown.
+// Takes the context directly (not the isolate) because teardown runs it after
+// the isolate has been disposed.
+void nx_hidsys_exit(nx_context_t *ctx);
+
+// Resolve the id string for Npad `index` into `out` (size `out_len`), using the
+// per-index cache. On a cache miss it performs the hidsys IPC; on any failure
+// (hidsys unavailable, old firmware, no serial) it writes the index-based
+// fallback `"switch-gamepad-<index>"`. Always NUL-terminates `out`.
+void nx_gamepad_resolve_id(v8::Isolate *iso, unsigned index, char *out,
+                           size_t out_len);
+
+// Non-blocking check of the OS unique-pad connection event. When it has
+// signaled (a controller connected/disconnected), clears the entire id cache
+// and returns true. Returns false (and does nothing) otherwise. Exposed to JS
+// as `$.gamepadConnectionChanged()` and called once per frame to drive the
+// `gamepadconnected` / `gamepaddisconnected` sweep.
+void nx_init_hidsys(v8::Isolate *iso, v8::Local<v8::Object> init_obj);

--- a/source/main.cc
+++ b/source/main.cc
@@ -21,6 +21,7 @@
 #include FT_FREETYPE_H
 
 #include "error.h"
+#include "hidsys.h"
 #include "module.h"
 #include "skia_gpu.h"
 #include "types.h"
@@ -718,6 +719,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	nx_init_fs(iso, init_obj);
 	nx_init_fsdev(iso, init_obj);
 	nx_init_gamepad(iso, init_obj);
+	nx_init_hidsys(iso, init_obj);
 	nx_init_image(iso, init_obj);
 	nx_init_irs(iso, init_obj);
 	nx_init_memory(iso, init_obj);
@@ -1453,6 +1455,11 @@ int main(int argc, char *argv[]) {
 		              (HidNpadIdType)(HidNpadIdType_No1 + i));
 	}
 
+	// `hid:sys` for hardware-backed Gamepad.id (serial numbers) + the
+	// controller connect/disconnect event. Non-fatal: on failure, Gamepad.id
+	// falls back to the index-based string and connection events stop firing.
+	nx_hidsys_init(iso);
+
 	// The user entrypoint (user_code_path / user_code) was already resolved
 	// near the top of main() — before V8 init — so that `nxjs.ini` (which sits
 	// next to it) could be read in time to influence the V8 flag/heap/JIT
@@ -1690,6 +1697,7 @@ int main(int argc, char *argv[]) {
 	if (nx_ctx->spl_initialized) {
 		splExit();
 	}
+	nx_hidsys_exit(nx_ctx);
 	nx_config_free(&nx_ctx->config);
 	free(nx_ctx);
 

--- a/source/types.h
+++ b/source/types.h
@@ -159,6 +159,20 @@ typedef struct nx_context_s {
 
 	PadState pads[8];
 
+	// `hid:sys` service state for resolving real controller identifiers
+	// (serial numbers) behind `Gamepad.id`. The connection event signals on
+	// any controller connect/disconnect; the resolved id strings are cached
+	// per Npad index and invalidated (flag cleared) when it fires, so the
+	// expensive IPC happens at most once per connection and never in the hot
+	// input-polling loop. `hidsys_available` is false when hidsysInitialize()
+	// failed (id then falls back to the index-based string).
+	bool hidsys_available;
+	Event hidsys_conn_event;
+	bool gamepad_id_cached[8];
+	// Wide enough for "<device name> (<serialA> + <serialB>)" — a dual
+	// Joy-Con / handheld pair aggregates two 0x10-byte serials.
+	char gamepad_id_cache[8][96];
+
 	// mbedtls structures shared by all TLS connections
 	bool mbedtls_initialized;
 	mbedtls_entropy_context entropy;


### PR DESCRIPTION
## Summary

- `Gamepad.id` now reports the controller's **real hardware identity** — the device name plus serial number(s) from the `hid:sys` service, e.g. `"Nintendo Switch Pro Controller (XAW10012345678)"`. In **handheld / dual Joy-Con** mode both serials are aggregated into one stable id: `"Nintendo Switch Handheld (XBW... + XCW...)"`.
- Wires up the global **`gamepadconnected` / `gamepaddisconnected`** events — the `GamepadEvent` type existed but was never dispatched.
- Falls back to the prior unique-per-slot `"switch-gamepad-<index>"` string when no serial is available (firmware < 5.0.0, no serial, IPC failure).

## How it works (no hot-loop cost)

The serial `hid:sys` IPC is expensive, so it is kept entirely off the input-polling hot path:

- ids resolve **lazily** on first `Gamepad.id` access and are **cached** per Npad index on `nx_context_t`;
- the cache is invalidated **only** when the OS controller connect/disconnect event (`hidsysAcquireUniquePadConnectionEventHandle`) fires — checked once per frame as a non-blocking `eventWait(0)`;
- **disconnected** slots keep their last-known id (so `gamepaddisconnected` reports the controller that *left*, not the fallback);
- the fallback string is **never cached**, so a freshly-connected controller whose serial lags a frame or two still converges to its real id.

Handheld is special-cased: slot 0 doubles as the handheld controller (Npad `Handheld` 0x20, not `No1`), and every unique pad mapped to the Npad is aggregated, so a dual Joy-Con gets a single combined identifier.

## Changes

- **C:** new `source/hidsys.cc` + `hidsys.h` (service lifecycle, id resolver, connection-event poll); `source/gamepad.cc` `id` getter delegates to the cached resolver; `source/{main.cc,types.h}` wiring; de-staled `source/gamepad.h`.
- **TS:** `$.gamepadConnectionChanged()` binding (`$.ts`), per-frame `sweepGamepadConnections()` (`navigator/gamepad.ts`) dispatched from the frame loop (`index.ts`), updated `id` JSDoc.
- **Host test:** stubbed `hidsys` (`stubs.cc`, `main.cc`) + new `gamepad-event.ts` conformance fixture.
- **Docs/changeset:** `controllers.mdx` section on controller `id` + the new events; changeset bumped to `minor`. Also documents the natecube `nxdbg` conformance workflow end-to-end in `AGENTS.md`.

## Verification

- `pnpm build` from repo root passes all packages (incl. the `dist/index.d.ts` no-top-level-import guard).
- Device NRO builds against real libnx (`make`).
- **Host conformance** (natecube `nxdbg` container, clang-19 + `/opt/host`): `nxjs-test` builds clean; the new `gamepad-event` fixture passes **5/5** in `nxjs-test` and matches **Chrome** assertion-by-assertion; `event-target` (touched indirectly via event dispatch) still passes vs Chrome.
- **On-device (applet mode)**: verified across handheld, dual Joy-Con, single Joy-Con (L/R), and Pro Controller — connect/disconnect events report the correct real id, and handheld aggregates both serials.