### PR TITLE
Implement the Web Audio API

### DIFF
--- a/.changeset/web-audio-api.md
+++ b/.changeset/web-audio-api.md
@@ -1,0 +1,10 @@
+---
+"@nx.js/runtime": minor
+---
+
+feat: implement the Web Audio API (`AudioContext`, `OfflineAudioContext`, `AudioBuffer`, `AudioBufferSourceNode`, `GainNode`, `StereoPannerNode`, `AudioParam` automation, `decodeAudioData()`)
+
+Audio is now processed by a native graph engine on a dedicated real-time render
+thread (128-frame quanta, like browsers), streamed to the Switch `audren`
+service via double-buffered wavebufs. The `Audio` element is re-implemented on
+top of the new engine.

--- a/apps/web-audio/.gitignore
+++ b/apps/web-audio/.gitignore
@@ -1,0 +1,5 @@
+/*.nro
+/*.nsp
+/node_modules
+/romfs/main.js
+/romfs/main.js.map

--- a/apps/web-audio/package.json
+++ b/apps/web-audio/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "web-audio",
+  "version": "0.0.0",
+  "private": true,
+  "description": "nx.js example which generates and plays audio using the Web Audio API",
+  "scripts": {
+    "build": "esbuild --bundle --sourcemap --sources-content=false --target=es2022 --format=esm --outdir=romfs src/main.ts",
+    "nro": "nxjs-nro",
+    "nsp": "nxjs-nsp"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@nx.js/constants": "workspace:^",
+    "@nx.js/nro": "workspace:^",
+    "@nx.js/nsp": "workspace:^",
+    "@nx.js/runtime": "workspace:^",
+    "esbuild": "catalog:"
+  }
+}

--- a/apps/web-audio/src/main.ts
+++ b/apps/web-audio/src/main.ts
@@ -1,0 +1,218 @@
+// Web Audio API Demo - nx.js
+// All sounds are synthesized procedurally into AudioBuffers — no asset files.
+
+import { Button } from '@nx.js/constants';
+
+const ctx2d = screen.getContext('2d');
+const WIDTH = screen.width;
+const HEIGHT = screen.height;
+
+const audio = new AudioContext();
+
+// Master gain so the volume controls affect every sound.
+const master = audio.createGain();
+master.connect(audio.destination);
+
+let statusText = 'Press a button to play a sound';
+let volumeLevel = 1.0;
+let musicSource: AudioBufferSourceNode | null = null;
+
+// --- Procedural sound generation ------------------------------------------
+
+/** Create a mono AudioBuffer filled by `fn(t)` (t in seconds). */
+function generate(duration: number, fn: (t: number) => number): AudioBuffer {
+	const length = Math.floor(duration * audio.sampleRate);
+	const buffer = audio.createBuffer(1, length, audio.sampleRate);
+	const data = buffer.getChannelData(0);
+	for (let i = 0; i < length; i++) {
+		data[i] = fn(i / audio.sampleRate);
+	}
+	return buffer;
+}
+
+const square = (phase: number) => (Math.sin(phase) >= 0 ? 1 : -1);
+
+// "Coin" — square wave arpeggio (B5 → E6) with a quick decay.
+const coinBuffer = generate(0.45, (t) => {
+	const freq = t < 0.08 ? 987.77 : 1318.51;
+	const env = Math.exp(-t * 9);
+	return square(2 * Math.PI * freq * t) * env * 0.25;
+});
+
+// "Laser" — descending frequency sweep.
+const laserBuffer = generate(0.3, (t) => {
+	const freq = 1800 - 4500 * t;
+	const env = Math.exp(-t * 12);
+	return Math.sin(2 * Math.PI * freq * t) * env * 0.35;
+});
+
+// "Explosion" — white noise with a long decay.
+const explosionBuffer = generate(0.8, (t) => {
+	const env = Math.exp(-t * 5);
+	return (Math.random() * 2 - 1) * env * 0.5;
+});
+
+// "Blip" — short sine ping, used for the pan demo.
+const blipBuffer = generate(0.2, (t) => {
+	const env = Math.exp(-t * 20);
+	return Math.sin(2 * Math.PI * 880 * t) * env * 0.4;
+});
+
+// "Music" — a little looped bass arpeggio.
+const musicBuffer = generate(2.0, (t) => {
+	const notes = [110, 138.59, 164.81, 138.59]; // A2 C#3 E3 C#3
+	const step = Math.floor(t * 4) % notes.length;
+	const local = (t * 4) % 1;
+	const env = Math.min(1, local * 30) * Math.exp(-local * 4);
+	return (
+		(Math.sin(2 * Math.PI * notes[step] * t) +
+			0.5 * square(2 * Math.PI * notes[step] * 2 * t)) *
+		env *
+		0.2
+	);
+});
+
+// --- Playback helpers ------------------------------------------------------
+
+function playBuffer(buffer: AudioBuffer, pan = 0): AudioBufferSourceNode {
+	const source = audio.createBufferSource();
+	source.buffer = buffer;
+	if (pan !== 0) {
+		const panner = audio.createStereoPanner();
+		panner.pan.value = pan;
+		source.connect(panner);
+		panner.connect(master);
+	} else {
+		source.connect(master);
+	}
+	source.start();
+	return source;
+}
+
+// "Chord" — three detuned sources with a gain envelope driven by
+// AudioParam automation (setValueAtTime + ramps).
+function playChord() {
+	const now = audio.currentTime;
+	const env = audio.createGain();
+	env.gain.setValueAtTime(0, now);
+	env.gain.linearRampToValueAtTime(0.2, now + 0.05);
+	env.gain.exponentialRampToValueAtTime(0.001, now + 1.5);
+	env.connect(master);
+	for (const freq of [220, 277.18, 329.63]) {
+		const buffer = generate(1.5, (t) => Math.sin(2 * Math.PI * freq * t));
+		const source = audio.createBufferSource();
+		source.buffer = buffer;
+		source.connect(env);
+		source.start();
+	}
+}
+
+function toggleMusic() {
+	if (musicSource) {
+		musicSource.stop();
+		musicSource = null;
+		statusText = 'Music stopped';
+	} else {
+		musicSource = audio.createBufferSource();
+		musicSource.buffer = musicBuffer;
+		musicSource.loop = true;
+		musicSource.connect(master);
+		musicSource.start();
+		statusText = 'Music looping (Minus to stop)';
+	}
+}
+
+// --- UI / input ------------------------------------------------------------
+
+let prevButtons: boolean[] = [];
+
+function buttonPressed(gp: Gamepad, index: number): boolean {
+	const curr = gp.buttons[index]?.pressed ?? false;
+	const prev = prevButtons[index] ?? false;
+	return curr && !prev;
+}
+
+function handleInput() {
+	const gp = navigator.getGamepads()[0];
+	if (!gp) return;
+
+	if (buttonPressed(gp, Button.A)) {
+		playBuffer(coinBuffer);
+		statusText = 'Coin!';
+	}
+	if (buttonPressed(gp, Button.B)) {
+		playBuffer(laserBuffer);
+		statusText = 'Laser!';
+	}
+	if (buttonPressed(gp, Button.X)) {
+		playBuffer(explosionBuffer);
+		statusText = 'Explosion!';
+	}
+	if (buttonPressed(gp, Button.Y)) {
+		playChord();
+		statusText = 'Chord (gain automation)';
+	}
+	if (buttonPressed(gp, Button.L)) {
+		playBuffer(blipBuffer, -1);
+		statusText = 'Blip (left)';
+	}
+	if (buttonPressed(gp, Button.R)) {
+		playBuffer(blipBuffer, 1);
+		statusText = 'Blip (right)';
+	}
+	if (buttonPressed(gp, Button.Minus)) {
+		toggleMusic();
+	}
+	if (buttonPressed(gp, Button.Down)) {
+		volumeLevel = Math.max(0, +(volumeLevel - 0.1).toFixed(1));
+		master.gain.value = volumeLevel;
+	}
+	if (buttonPressed(gp, Button.Up)) {
+		volumeLevel = Math.min(1, +(volumeLevel + 0.1).toFixed(1));
+		master.gain.value = volumeLevel;
+	}
+
+	prevButtons = gp.buttons.map((b) => b.pressed);
+}
+
+function drawUI() {
+	ctx2d.fillStyle = '#1a1a2e';
+	ctx2d.fillRect(0, 0, WIDTH, HEIGHT);
+
+	ctx2d.fillStyle = '#e94560';
+	ctx2d.font = '48px system-ui';
+	ctx2d.textAlign = 'center';
+	ctx2d.fillText('Web Audio API Demo', WIDTH / 2, 90);
+
+	ctx2d.fillStyle = '#eee';
+	ctx2d.font = '28px system-ui';
+	ctx2d.textAlign = 'left';
+	const cx = 160;
+	const lines = [
+		'A = Coin       B = Laser',
+		'X = Explosion  Y = Chord (gain automation)',
+		'L = Blip left  R = Blip right (StereoPanner)',
+		'Minus = Toggle looped music',
+		'D-Pad Up/Down = Master volume',
+	];
+	lines.forEach((line, i) => {
+		ctx2d.fillText(line, cx, 180 + i * 50);
+	});
+
+	ctx2d.fillStyle = '#0f3460';
+	ctx2d.fillRect(80, 480, WIDTH - 160, 140);
+	ctx2d.fillStyle = '#eee';
+	ctx2d.fillText(`Status: ${statusText}`, 100, 530);
+	ctx2d.fillText(
+		`Volume: ${Math.round(volumeLevel * 100)}%   currentTime: ${audio.currentTime.toFixed(1)}s`,
+		100,
+		580,
+	);
+}
+
+function frame() {
+	handleInput();
+	drawUI();
+	requestAnimationFrame(frame);
+}
+requestAnimationFrame(frame);

--- a/apps/web-audio/tsconfig.json
+++ b/apps/web-audio/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@nx.js/runtime"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -48,6 +48,8 @@ type ClassOf<T> = {
 	new (...args: any[]): T;
 };
 
+export type AudioContextHandle = Opaque<'AudioContextHandle'>;
+export type AudioNodeHandle = Opaque<'AudioNodeHandle'>;
 type FileHandle = Opaque<'FileHandle'>;
 type CanvasGradientOpaque = Opaque<'CanvasGradientOpaque'>;
 type CompressHandle = Opaque<'CompressHandle'>;
@@ -549,37 +551,64 @@ export interface Init {
 	): URLSearchParamsIterator;
 	urlSearchIteratorNext(it: URLSearchParamsIterator): any;
 
-	// audio.c
-	audioInit(): void;
-	audioExit(): void;
-	audioDecode(
-		buffer: ArrayBuffer,
-		mimeType: string,
-	): Promise<{
-		pcmData: ArrayBuffer;
-		sampleRate: number;
-		channels: number;
-		samples: number;
-		byteLength: number;
-	}>;
-	audioPlay(
-		pcmData: ArrayBuffer,
-		voiceId: number,
-		volume: number,
-		loop: boolean,
-		sampleRate: number,
-		channels: number,
-		totalSamples: number,
+	// audio.cc — Web Audio API
+	audioContextNew(sampleRate: number, offline: boolean): AudioContextHandle;
+	audioContextClose(ctx: AudioContextHandle): void;
+	audioContextSuspend(ctx: AudioContextHandle): void;
+	audioContextResume(ctx: AudioContextHandle): void;
+	audioContextCurrentTime(ctx: AudioContextHandle): number;
+	audioContextDestination(ctx: AudioContextHandle): AudioNodeHandle;
+	audioNodeNew(ctx: AudioContextHandle, type: number): AudioNodeHandle;
+	audioNodeConnect(src: AudioNodeHandle, dst: AudioNodeHandle): void;
+	audioNodeDisconnect(src: AudioNodeHandle, dst?: AudioNodeHandle): void;
+	audioParamValue(node: AudioNodeHandle, index: number): number;
+	audioParamSetValue(node: AudioNodeHandle, index: number, value: number): void;
+	audioParamSchedule(
+		node: AudioNodeHandle,
+		index: number,
+		type: number,
+		time: number,
+		value: number,
+		timeConstant: number,
 	): void;
-	audioStop(voiceId: number): void;
-	audioPause(voiceId: number, paused: boolean): void;
-	audioSetVolume(voiceId: number, volume: number): void;
-	audioSetPitch(voiceId: number, pitch: number): void;
-	audioUpdate(): void;
-	audioGetPlayedSamples(voiceId: number): number;
-	audioAllocVoice(): number;
-	audioFreeVoice(voiceId: number): void;
-	audioIsPlaying(voiceId: number): boolean;
+	audioParamSetValueCurve(
+		node: AudioNodeHandle,
+		index: number,
+		curve: Float32Array,
+		startTime: number,
+		duration: number,
+	): void;
+	audioParamCancel(node: AudioNodeHandle, index: number, time: number): void;
+	audioSourceSetBuffer(
+		node: AudioNodeHandle,
+		channels: Float32Array[],
+		length: number,
+		sampleRate: number,
+	): void;
+	audioSourceStart(
+		node: AudioNodeHandle,
+		when: number,
+		offset: number,
+		duration: number,
+	): void;
+	audioSourceStop(node: AudioNodeHandle, when: number): void;
+	audioSourceSetLoop(
+		node: AudioNodeHandle,
+		loop: boolean,
+		loopStart: number,
+		loopEnd: number,
+	): void;
+	audioSourceState(node: AudioNodeHandle): number;
+	audioDecode(buffer: ArrayBuffer): Promise<{
+		channelData: ArrayBuffer[];
+		length: number;
+		sampleRate: number;
+	}>;
+	audioOfflineRender(
+		ctx: AudioContextHandle,
+		numberOfChannels: number,
+		length: number,
+	): Promise<ArrayBuffer[]>;
 
 	// (Uint8Array base64/hex methods are provided natively by V8 — no binding.)
 

--- a/packages/runtime/src/audio.ts
+++ b/packages/runtime/src/audio.ts
@@ -1,4 +1,8 @@
 import { $ } from './$';
+import { createAudioBuffer, type AudioBuffer } from './audio/audio-buffer';
+import type { AudioBufferSourceNode } from './audio/audio-buffer-source-node';
+import { AudioContext } from './audio/audio-context';
+import type { GainNode } from './audio/gain-node';
 import { DOMException } from './dom-exception';
 import { fetch } from './fetch/fetch';
 import { ErrorEvent, Event } from './polyfills/event';
@@ -13,54 +17,21 @@ const HAVE_CURRENT_DATA = 2;
 const HAVE_FUTURE_DATA = 3;
 const HAVE_ENOUGH_DATA = 4;
 
-interface DecodedAudio {
-	pcmData: ArrayBuffer;
-	sampleRate: number;
-	channels: number;
-	samples: number;
-	byteLength: number;
-}
-
-function mimeFromExtension(path: string): string {
-	const ext = path.split('.').pop()?.toLowerCase();
-	switch (ext) {
-		case 'mp3':
-			return 'audio/mpeg';
-		case 'wav':
-			return 'audio/wav';
-		case 'ogg':
-			return 'audio/ogg';
-		default:
-			return 'application/octet-stream';
+// All `Audio` elements share one (lazily-created) AudioContext.
+let sharedCtx: AudioContext | null = null;
+function getContext(): AudioContext {
+	if (!sharedCtx) {
+		sharedCtx = new AudioContext();
 	}
-}
-
-let audioInitialized = false;
-let updateInterval: ReturnType<typeof setInterval> | null = null;
-
-function ensureAudioInit() {
-	if (!audioInitialized) {
-		$.audioInit();
-		audioInitialized = true;
-		addEventListener('unload', () => {
-			$.audioExit();
-			audioInitialized = false;
-		});
-	}
-}
-
-function ensureUpdateLoop() {
-	if (!updateInterval) {
-		updateInterval = setInterval(() => {
-			$.audioUpdate();
-		}, 16); // ~60fps
-	}
+	return sharedCtx;
 }
 
 /**
  * The `Audio` class provides audio playback functionality similar to the
  * [`HTMLAudioElement`](https://developer.mozilla.org/docs/Web/API/HTMLAudioElement)
- * in web browsers.
+ * in web browsers. It is implemented on top of the Web Audio API
+ * ({@link AudioContext}) — for low-level / game audio use the Web Audio
+ * classes directly.
  *
  * ### Supported Audio Formats
  *
@@ -94,9 +65,11 @@ export class Audio extends EventTarget {
 	#ended = false;
 	#playbackRate = 1.0;
 	#readyState = HAVE_NOTHING;
-	#voiceId = -1;
-	#decoded: DecodedAudio | null = null;
-	#sampleOffset = 0;
+	#buffer: AudioBuffer | null = null;
+	#gain: GainNode | null = null;
+	#source: AudioBufferSourceNode | null = null;
+	#offset = 0; // playback position (seconds) at the last start/pause/rebase
+	#startCtxTime = 0; // context time at the last start/rebase
 	#timeupdateInterval: ReturnType<typeof setInterval> | null = null;
 
 	constructor(src?: string) {
@@ -132,8 +105,8 @@ export class Audio extends EventTarget {
 
 	set volume(val: number) {
 		this.#volume = Math.max(0, Math.min(1, val));
-		if (this.#voiceId >= 0) {
-			$.audioSetVolume(this.#voiceId, this.#volume);
+		if (this.#gain) {
+			this.#gain.gain.value = this.#volume;
 		}
 	}
 
@@ -143,6 +116,9 @@ export class Audio extends EventTarget {
 
 	set loop(val: boolean) {
 		this.#loop = val;
+		if (this.#source) {
+			this.#source.loop = val;
+		}
 	}
 
 	get paused(): boolean {
@@ -154,41 +130,35 @@ export class Audio extends EventTarget {
 	}
 
 	get currentTime(): number {
-		if (!this.#decoded) return 0;
-		if (this.#voiceId >= 0 && !this.#paused) {
-			const played = $.audioGetPlayedSamples(this.#voiceId) as number;
-			return (played + this.#sampleOffset) / this.#decoded.sampleRate;
+		if (!this.#buffer) return 0;
+		if (this.#paused || !this.#source) return this.#offset;
+		const ctx = getContext();
+		let pos =
+			this.#offset +
+			(ctx.currentTime - this.#startCtxTime) * this.#playbackRate;
+		const dur = this.#buffer.duration;
+		if (this.#loop) {
+			pos = dur > 0 ? pos % dur : 0;
+		} else if (pos > dur) {
+			pos = dur;
 		}
-		return this.#sampleOffset / (this.#decoded?.sampleRate ?? 48000);
+		return pos;
 	}
 
 	set currentTime(val: number) {
-		if (!this.#decoded) return;
-		this.#sampleOffset = Math.max(
-			0,
-			Math.min(
-				Math.floor(val * this.#decoded.sampleRate),
-				this.#decoded.samples,
-			),
-		);
-		// If currently playing, restart at new offset
-		if (!this.#paused && this.#voiceId >= 0) {
-			$.audioStop(this.#voiceId);
-			$.audioPlay(
-				this.#decoded.pcmData,
-				this.#voiceId,
-				this.#volume,
-				this.#loop,
-				this.#decoded.sampleRate,
-				this.#decoded.channels,
-				this.#decoded.samples,
-			);
+		if (!this.#buffer) return;
+		const offset = Math.max(0, Math.min(val, this.#buffer.duration));
+		this.#offset = offset;
+		if (!this.#paused) {
+			// Restart playback at the new position.
+			this.#stopSource();
+			this.#startSource();
 		}
 	}
 
 	get duration(): number {
-		if (!this.#decoded) return NaN;
-		return this.#decoded.samples / this.#decoded.sampleRate;
+		if (!this.#buffer) return NaN;
+		return this.#buffer.duration;
 	}
 
 	get playbackRate(): number {
@@ -196,10 +166,14 @@ export class Audio extends EventTarget {
 	}
 
 	set playbackRate(val: number) {
-		this.#playbackRate = val;
-		if (this.#voiceId >= 0) {
-			$.audioSetPitch(this.#voiceId, val);
+		if (!this.#paused && this.#source) {
+			// Rebase the position tracking at the old rate before switching.
+			const ctx = getContext();
+			this.#offset = this.currentTime;
+			this.#startCtxTime = ctx.currentTime;
+			this.#source.playbackRate.value = val;
 		}
+		this.#playbackRate = val;
 	}
 
 	get readyState(): number {
@@ -228,11 +202,10 @@ export class Audio extends EventTarget {
 		// Stop current playback
 		this.#stop();
 		this.#readyState = HAVE_NOTHING;
-		this.#decoded = null;
+		this.#buffer = null;
 
 		const url = new URL(this.#src, $.entrypoint);
 		this.#currentSrc = url.href;
-		const mime = mimeFromExtension(url.pathname);
 
 		fetch(url)
 			.then((res) => {
@@ -241,10 +214,13 @@ export class Audio extends EventTarget {
 				}
 				return res.arrayBuffer();
 			})
-			.then((buf) => $.audioDecode(buf, mime) as Promise<DecodedAudio>)
+			.then((buf) => $.audioDecode(buf))
 			.then(
-				(decoded) => {
-					this.#decoded = decoded;
+				({ channelData, sampleRate }) => {
+					this.#buffer = createAudioBuffer(
+						channelData.map((ab) => new Float32Array(ab)),
+						sampleRate,
+					);
 					this.#readyState = HAVE_METADATA;
 					this.dispatchEvent(new Event('loadedmetadata'));
 					this.#readyState = HAVE_ENOUGH_DATA;
@@ -257,74 +233,74 @@ export class Audio extends EventTarget {
 	}
 
 	async play(): Promise<void> {
-		if (!this.#decoded) {
+		if (!this.#buffer) {
 			throw new DOMException('No audio source loaded', 'InvalidStateError');
 		}
-
-		ensureAudioInit();
-		ensureUpdateLoop();
-
-		if (this.#voiceId < 0) {
-			this.#voiceId = $.audioAllocVoice() as number;
-		}
-
+		this.#stopSource();
 		this.#paused = false;
 		this.#ended = false;
-
-		$.audioPlay(
-			this.#decoded.pcmData,
-			this.#voiceId,
-			this.#volume,
-			this.#loop,
-			this.#decoded.sampleRate,
-			this.#decoded.channels,
-			this.#decoded.samples,
-		);
-
-		if (this.#playbackRate !== 1.0) {
-			$.audioSetPitch(this.#voiceId, this.#playbackRate);
-		}
-
+		this.#startSource();
 		this.dispatchEvent(new Event('play'));
-
-		// Set up timeupdate + ended checking
 		this.#startTimeupdateLoop();
 	}
 
 	pause(): void {
 		if (this.#paused) return;
+		this.#offset = this.currentTime;
+		this.#stopSource();
 		this.#paused = true;
-		if (this.#voiceId >= 0) {
-			$.audioPause(this.#voiceId, true);
-		}
 		this.#stopTimeupdateLoop();
 		this.dispatchEvent(new Event('pause'));
 	}
 
+	#startSource(): void {
+		const ctx = getContext();
+		if (!this.#gain) {
+			this.#gain = ctx.createGain();
+			this.#gain.gain.value = this.#volume;
+			this.#gain.connect(ctx.destination);
+		}
+		const source = ctx.createBufferSource();
+		source.buffer = this.#buffer;
+		source.loop = this.#loop;
+		source.playbackRate.value = this.#playbackRate;
+		source.connect(this.#gain);
+		source.onended = () => {
+			// Ignore stale sources (replaced by seek/pause/replay).
+			if (this.#source !== source || this.#paused) return;
+			this.#ended = true;
+			this.#paused = true;
+			this.#offset = this.#buffer?.duration ?? 0;
+			this.#source = null;
+			this.#stopTimeupdateLoop();
+			this.dispatchEvent(new Event('ended'));
+		};
+		this.#source = source;
+		this.#startCtxTime = ctx.currentTime;
+		source.start(0, this.#offset);
+	}
+
+	#stopSource(): void {
+		const source = this.#source;
+		if (source) {
+			this.#source = null;
+			source.stop();
+			source.disconnect();
+		}
+	}
+
 	#stop(): void {
 		this.#stopTimeupdateLoop();
-		if (this.#voiceId >= 0) {
-			$.audioStop(this.#voiceId);
-			$.audioFreeVoice(this.#voiceId);
-			this.#voiceId = -1;
-		}
+		this.#stopSource();
 		this.#paused = true;
-		this.#sampleOffset = 0;
+		this.#offset = 0;
 	}
 
 	#startTimeupdateLoop(): void {
 		this.#stopTimeupdateLoop();
 		this.#timeupdateInterval = setInterval(() => {
-			if (this.#voiceId >= 0 && !this.#paused) {
+			if (!this.#paused) {
 				this.dispatchEvent(new Event('timeupdate'));
-
-				// Check if playback ended
-				if (!this.#loop && !$.audioIsPlaying(this.#voiceId)) {
-					this.#ended = true;
-					this.#paused = true;
-					this.#stopTimeupdateLoop();
-					this.dispatchEvent(new Event('ended'));
-				}
 			}
 		}, 250);
 	}

--- a/packages/runtime/src/audio/audio-buffer-source-node.ts
+++ b/packages/runtime/src/audio/audio-buffer-source-node.ts
@@ -112,9 +112,11 @@ export class AudioBufferSourceNode
 			loopEnd: options.loopEnd ?? 0,
 			playbackRate: createAudioParam(this, handle, 0, {
 				defaultValue: 1,
+				automationRate: 'k-rate',
 			}),
 			detune: createAudioParam(this, handle, 1, {
 				defaultValue: 0,
+				automationRate: 'k-rate',
 			}),
 		});
 		const i = _(this);

--- a/packages/runtime/src/audio/audio-buffer-source-node.ts
+++ b/packages/runtime/src/audio/audio-buffer-source-node.ts
@@ -1,0 +1,258 @@
+import { $ } from '../$';
+import { DOMException } from '../dom-exception';
+import { INTERNAL_SYMBOL } from '../internal';
+import { createInternal, def } from '../utils';
+import type { AudioBuffer } from './audio-buffer';
+import { createAudioParam } from './audio-param';
+import {
+	AudioScheduledSourceNode,
+	trackActiveSource,
+} from './audio-scheduled-source-node';
+import {
+	bufferInternal,
+	ctxInternal,
+	NODE_TYPE_BUFFER_SOURCE,
+	nodeInternal,
+} from './internal';
+import type { AudioParam } from './audio-param';
+import type { BaseAudioContext } from './base-audio-context';
+
+export interface AudioBufferSourceOptions {
+	buffer?: AudioBuffer | null;
+	detune?: number;
+	loop?: boolean;
+	loopEnd?: number;
+	loopStart?: number;
+	playbackRate?: number;
+}
+
+interface AudioBufferSourceNodeInternal {
+	buffer: AudioBuffer | null;
+	started: boolean;
+	loop: boolean;
+	loopStart: number;
+	loopEnd: number;
+	playbackRate: AudioParam;
+	detune: AudioParam;
+}
+
+const _ = createInternal<AudioBufferSourceNode, AudioBufferSourceNodeInternal>();
+
+function checkScheduleArg(name: string, paramName: string, v: number) {
+	if (!Number.isFinite(v)) {
+		throw new TypeError(
+			`Failed to execute '${name}' on 'AudioBufferSourceNode': The provided ${paramName} is non-finite.`,
+		);
+	}
+	if (v < 0) {
+		throw new RangeError(
+			`Failed to execute '${name}' on 'AudioBufferSourceNode': The ${paramName} provided (${v}) cannot be negative.`,
+		);
+	}
+}
+
+function syncLoop(node: AudioBufferSourceNode) {
+	const i = _(node);
+	$.audioSourceSetLoop(
+		nodeInternal(node).handle,
+		i.loop,
+		i.loopStart,
+		i.loopEnd,
+	);
+}
+
+// Hand the buffer's channel data to the native node. The render thread reads
+// the Float32Arrays' backing stores directly (no copy).
+function syncBuffer(node: AudioBufferSourceNode) {
+	const i = _(node);
+	if (!i.buffer) return;
+	const b = bufferInternal(i.buffer);
+	$.audioSourceSetBuffer(
+		nodeInternal(node).handle,
+		b.channels,
+		b.length,
+		b.sampleRate,
+	);
+}
+
+/**
+ * An audio source consisting of in-memory audio data, stored in an
+ * {@link AudioBuffer}. This is the node to use when playing back one-shot or
+ * looping sounds (e.g. game sound effects and music).
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode
+ */
+export class AudioBufferSourceNode
+	extends AudioScheduledSourceNode
+	implements globalThis.AudioBufferSourceNode
+{
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/AudioBufferSourceNode
+	 */
+	constructor(context: BaseAudioContext, options: AudioBufferSourceOptions = {}) {
+		const handle = $.audioNodeNew(
+			ctxInternal(context).handle,
+			NODE_TYPE_BUFFER_SOURCE,
+		);
+		// @ts-expect-error internal constructor
+		super(INTERNAL_SYMBOL, {
+			context,
+			handle,
+			numberOfInputs: 0,
+			numberOfOutputs: 1,
+			channelCount: 2,
+			channelCountMode: 'max',
+			channelInterpretation: 'speakers',
+		});
+		_.set(this, {
+			buffer: null,
+			started: false,
+			loop: options.loop ?? false,
+			loopStart: options.loopStart ?? 0,
+			loopEnd: options.loopEnd ?? 0,
+			playbackRate: createAudioParam(this, handle, 0, {
+				defaultValue: 1,
+			}),
+			detune: createAudioParam(this, handle, 1, {
+				defaultValue: 0,
+			}),
+		});
+		const i = _(this);
+		if (typeof options.playbackRate === 'number') {
+			i.playbackRate.value = options.playbackRate;
+		}
+		if (typeof options.detune === 'number') {
+			i.detune.value = options.detune;
+		}
+		if (i.loop || i.loopStart || i.loopEnd) syncLoop(this);
+		if (options.buffer) this.buffer = options.buffer;
+	}
+
+	/**
+	 * The {@link AudioBuffer} providing the audio asset to play.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/buffer
+	 */
+	get buffer(): AudioBuffer | null {
+		return _(this).buffer;
+	}
+
+	set buffer(buffer: AudioBuffer | null) {
+		const i = _(this);
+		if (buffer && i.buffer) {
+			throw new DOMException(
+				"Failed to set the 'buffer' property on 'AudioBufferSourceNode': Cannot set buffer to non-null after it has been already been set to a non-null buffer",
+				'InvalidStateError',
+			);
+		}
+		i.buffer = buffer;
+		if (buffer && i.started) syncBuffer(this);
+	}
+
+	/**
+	 * Speed factor at which the audio asset will be played (`1` = normal).
+	 * Since no pitch correction is applied, this changes the pitch of the
+	 * sound as well.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/playbackRate
+	 */
+	get playbackRate(): AudioParam {
+		return _(this).playbackRate;
+	}
+
+	/**
+	 * Detuning of the playback, in cents.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/detune
+	 */
+	get detune(): AudioParam {
+		return _(this).detune;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/loop
+	 */
+	get loop(): boolean {
+		return _(this).loop;
+	}
+
+	set loop(v: boolean) {
+		_(this).loop = v;
+		syncLoop(this);
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/loopStart
+	 */
+	get loopStart(): number {
+		return _(this).loopStart;
+	}
+
+	set loopStart(v: number) {
+		_(this).loopStart = v;
+		syncLoop(this);
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/loopEnd
+	 */
+	get loopEnd(): number {
+		return _(this).loopEnd;
+	}
+
+	set loopEnd(v: number) {
+		_(this).loopEnd = v;
+		syncLoop(this);
+	}
+
+	/**
+	 * Schedules the buffer to begin playback.
+	 *
+	 * @param when Time (in context seconds) the playback should begin. Values in the past begin immediately.
+	 * @param offset Offset (in seconds) into the buffer where playback should begin.
+	 * @param duration Duration (in seconds) of buffer content to play.
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/start
+	 */
+	start(when = 0, offset = 0, duration?: number): void {
+		checkScheduleArg('start', 'start time', when);
+		checkScheduleArg('start', 'offset', offset);
+		if (typeof duration === 'number') {
+			checkScheduleArg('start', 'duration', duration);
+		}
+		const i = _(this);
+		if (i.started) {
+			throw new DOMException(
+				"Failed to execute 'start' on 'AudioBufferSourceNode': cannot call start more than once.",
+				'InvalidStateError',
+			);
+		}
+		i.started = true;
+		syncBuffer(this);
+		$.audioSourceStart(
+			nodeInternal(this).handle,
+			when,
+			offset,
+			typeof duration === 'number' ? duration : -1,
+		);
+		trackActiveSource(this);
+	}
+
+	/**
+	 * Schedules the playback to stop.
+	 *
+	 * @param when Time (in context seconds) the playback should stop. Values in the past stop immediately.
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode/stop
+	 */
+	stop(when = 0): void {
+		checkScheduleArg('stop', 'stop time', when);
+		const i = _(this);
+		if (!i.started) {
+			throw new DOMException(
+				"Failed to execute 'stop' on 'AudioBufferSourceNode': cannot call stop without calling start first.",
+				'InvalidStateError',
+			);
+		}
+		$.audioSourceStop(nodeInternal(this).handle, when);
+	}
+}
+def(AudioBufferSourceNode);

--- a/packages/runtime/src/audio/audio-buffer.ts
+++ b/packages/runtime/src/audio/audio-buffer.ts
@@ -1,0 +1,176 @@
+import { DOMException } from '../dom-exception';
+import { def } from '../utils';
+import { bufferInternal as _ } from './internal';
+
+export interface AudioBufferOptions {
+	/** The size of the buffer in sample-frames. */
+	length: number;
+	/** The number of channels for the buffer (defaults to `1`). */
+	numberOfChannels?: number;
+	/** The sample rate in Hz for the buffer. */
+	sampleRate: number;
+}
+
+/**
+ * Adopt already-allocated channel data (e.g. from `decodeAudioData()`)
+ * without copying.
+ *
+ * @internal
+ */
+export function createAudioBuffer(
+	channels: Float32Array[],
+	sampleRate: number,
+): AudioBuffer {
+	const buffer = Object.create(AudioBuffer.prototype) as AudioBuffer;
+	_.set(buffer, {
+		channels,
+		sampleRate,
+		length: channels[0]?.length ?? 0,
+	});
+	return buffer;
+}
+
+/**
+ * A short audio asset residing in memory, created from an audio file using
+ * {@link BaseAudioContext.decodeAudioData | `decodeAudioData()`}, or from raw
+ * data using {@link BaseAudioContext.createBuffer | `createBuffer()`}. Once
+ * put into an `AudioBuffer`, the audio can be played by being passed into an
+ * {@link AudioBufferSourceNode}.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer
+ */
+export class AudioBuffer implements globalThis.AudioBuffer {
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/AudioBuffer
+	 */
+	constructor(options: AudioBufferOptions) {
+		if (typeof options !== 'object' || options === null) {
+			throw new TypeError(
+				"Failed to construct 'AudioBuffer': 1 argument required",
+			);
+		}
+		const numberOfChannels = options.numberOfChannels ?? 1;
+		const { length, sampleRate } = options;
+		if (
+			!Number.isInteger(numberOfChannels) ||
+			numberOfChannels < 1 ||
+			numberOfChannels > 32
+		) {
+			throw new DOMException(
+				`The number of channels provided (${numberOfChannels}) is outside the range [1, 32]`,
+				'NotSupportedError',
+			);
+		}
+		if (!Number.isInteger(length) || length < 1) {
+			throw new DOMException(
+				`The number of frames provided (${length}) is less than the minimum bound (1)`,
+				'NotSupportedError',
+			);
+		}
+		if (!(sampleRate >= 8000 && sampleRate <= 192000)) {
+			throw new DOMException(
+				`The sample rate provided (${sampleRate}) is outside the range [8000, 192000]`,
+				'NotSupportedError',
+			);
+		}
+		const channels: Float32Array[] = [];
+		for (let i = 0; i < numberOfChannels; i++) {
+			channels.push(new Float32Array(length));
+		}
+		_.set(this, { channels, sampleRate, length });
+	}
+
+	/**
+	 * Duration of the PCM audio data stored in the buffer, in seconds.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/duration
+	 */
+	get duration(): number {
+		const i = _(this);
+		return i.length / i.sampleRate;
+	}
+
+	/**
+	 * Length of the PCM audio data stored in the buffer, in sample-frames.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/length
+	 */
+	get length(): number {
+		return _(this).length;
+	}
+
+	/**
+	 * The number of discrete audio channels stored in the buffer.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/numberOfChannels
+	 */
+	get numberOfChannels(): number {
+		return _(this).channels.length;
+	}
+
+	/**
+	 * The sample rate of the PCM audio data, in samples per second.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/sampleRate
+	 */
+	get sampleRate(): number {
+		return _(this).sampleRate;
+	}
+
+	/**
+	 * Returns the `Float32Array` containing the PCM data for the requested
+	 * channel.
+	 *
+	 * > [!NOTE]
+	 * > In nx.js, the returned array is a live view of the data the audio
+	 * > render thread reads — mutations are heard, even during playback.
+	 *
+	 * @param channel An index representing the channel to get data for (`0` is the first channel).
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/getChannelData
+	 */
+	getChannelData(channel: number): Float32Array {
+		const i = _(this);
+		if (channel < 0 || channel >= i.channels.length) {
+			throw new DOMException(
+				`The channel index provided (${channel}) is outside the range [0, ${
+					i.channels.length - 1
+				}]`,
+				'IndexSizeError',
+			);
+		}
+		return i.channels[channel];
+	}
+
+	/**
+	 * Copies the samples from the specified channel into the `destination` array.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/copyFromChannel
+	 */
+	copyFromChannel(
+		destination: Float32Array,
+		channelNumber: number,
+		bufferOffset = 0,
+	): void {
+		const data = this.getChannelData(channelNumber);
+		if (bufferOffset >= data.length) return;
+		const count = Math.min(data.length - bufferOffset, destination.length);
+		destination.set(data.subarray(bufferOffset, bufferOffset + count));
+	}
+
+	/**
+	 * Copies the samples from the `source` array into the specified channel.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioBuffer/copyToChannel
+	 */
+	copyToChannel(
+		source: Float32Array,
+		channelNumber: number,
+		bufferOffset = 0,
+	): void {
+		const data = this.getChannelData(channelNumber);
+		if (bufferOffset >= data.length) return;
+		const count = Math.min(data.length - bufferOffset, source.length);
+		data.set(source.subarray(0, count), bufferOffset);
+	}
+}
+def(AudioBuffer);

--- a/packages/runtime/src/audio/audio-context.ts
+++ b/packages/runtime/src/audio/audio-context.ts
@@ -1,0 +1,171 @@
+import { $ } from '../$';
+import { DOMException } from '../dom-exception';
+import { INTERNAL_SYMBOL } from '../internal';
+import { performance } from '../performance';
+import { def } from '../utils';
+import { BaseAudioContext, setContextState } from './base-audio-context';
+import { ctxInternal as _ } from './internal';
+
+export interface AudioContextOptions {
+	/**
+	 * Hint for the playback latency tradeoff. Accepted for API compatibility;
+	 * nx.js always uses its fixed double-buffered output latency.
+	 */
+	latencyHint?: AudioContextLatencyCategory | number;
+	/**
+	 * Sample rate for the audio graph (defaults to `48000`, the native rate
+	 * of the Switch audio renderer).
+	 */
+	sampleRate?: number;
+}
+
+/**
+ * An audio-processing graph built from audio modules ({@link AudioNode}s)
+ * linked together, rendered in real-time to the console's audio output.
+ *
+ * @example
+ *
+ * ```typescript
+ * const ctx = new AudioContext();
+ * const res = await fetch('romfs:/jump.ogg');
+ * const buffer = await ctx.decodeAudioData(await res.arrayBuffer());
+ *
+ * const source = ctx.createBufferSource();
+ * source.buffer = buffer;
+ * source.connect(ctx.destination);
+ * source.start();
+ * ```
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/AudioContext
+ */
+export class AudioContext
+	extends BaseAudioContext
+	implements globalThis.AudioContext
+{
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioContext/AudioContext
+	 */
+	constructor(options: AudioContextOptions = {}) {
+		const sampleRate = options.sampleRate ?? 48000;
+		const handle = $.audioContextNew(sampleRate, false);
+		// There is no autoplay policy on the console, so the context begins
+		// in the "running" state.
+		// @ts-expect-error internal constructor
+		super(INTERNAL_SYMBOL, {
+			handle,
+			state: 'running',
+			sampleRate,
+		});
+		// Deterministically release the audio output (and join the audio
+		// render thread) when the application exits.
+		addEventListener('unload', () => {
+			const i = _(this);
+			if (i.state !== 'closed') {
+				$.audioContextClose(i.handle);
+				i.state = 'closed';
+			}
+		});
+	}
+
+	/**
+	 * The number of seconds of processing latency incurred by the audio graph
+	 * itself (one render quantum).
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioContext/baseLatency
+	 */
+	get baseLatency(): number {
+		return 128 / this.sampleRate;
+	}
+
+	/**
+	 * Estimated output latency: the double-buffered (2 × 1024 frame) audio
+	 * output stream.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioContext/outputLatency
+	 */
+	get outputLatency(): number {
+		return 2048 / this.sampleRate;
+	}
+
+	/**
+	 * Returns a new `AudioTimestamp` containing two correlated context/
+	 * performance timestamp values.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioContext/getOutputTimestamp
+	 */
+	getOutputTimestamp(): AudioTimestamp {
+		return {
+			contextTime: this.currentTime,
+			performanceTime: performance.now(),
+		};
+	}
+
+	/**
+	 * Resumes the progression of time in an audio context that has previously
+	 * been suspended.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioContext/resume
+	 */
+	async resume(): Promise<void> {
+		const i = _(this);
+		if (i.state === 'closed') {
+			throw new DOMException(
+				"Failed to execute 'resume' on 'AudioContext': Cannot resume a closed AudioContext.",
+				'InvalidStateError',
+			);
+		}
+		$.audioContextResume(i.handle);
+		setContextState(this, 'running');
+	}
+
+	/**
+	 * Suspends the progression of time in the audio context, temporarily
+	 * halting audio rendering (and reducing CPU/battery usage).
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioContext/suspend
+	 */
+	async suspend(): Promise<void> {
+		const i = _(this);
+		if (i.state === 'closed') {
+			throw new DOMException(
+				"Failed to execute 'suspend' on 'AudioContext': Cannot suspend a closed AudioContext.",
+				'InvalidStateError',
+			);
+		}
+		$.audioContextSuspend(i.handle);
+		setContextState(this, 'suspended');
+	}
+
+	/**
+	 * Closes the audio context, releasing the audio output resources that it
+	 * uses.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioContext/close
+	 */
+	async close(): Promise<void> {
+		const i = _(this);
+		if (i.state === 'closed') {
+			throw new DOMException(
+				"Failed to execute 'close' on 'AudioContext': Cannot close a closed AudioContext.",
+				'InvalidStateError',
+			);
+		}
+		$.audioContextClose(i.handle);
+		setContextState(this, 'closed');
+	}
+
+	createMediaElementSource(
+		mediaElement: HTMLMediaElement,
+	): MediaElementAudioSourceNode {
+		throw new Error('Method not implemented.');
+	}
+	createMediaStreamDestination(): MediaStreamAudioDestinationNode {
+		throw new Error('Method not implemented.');
+	}
+	createMediaStreamSource(
+		mediaStream: MediaStream,
+	): MediaStreamAudioSourceNode {
+		throw new Error('Method not implemented.');
+	}
+}
+def(AudioContext);

--- a/packages/runtime/src/audio/audio-destination-node.ts
+++ b/packages/runtime/src/audio/audio-destination-node.ts
@@ -1,0 +1,33 @@
+import { assertInternalConstructor, def } from '../utils';
+import { AudioNode } from './audio-node';
+
+/**
+ * The end destination of an audio graph — the audio output device of the
+ * console. Obtained via {@link BaseAudioContext.destination | `ctx.destination`};
+ * not user-constructible.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/AudioDestinationNode
+ */
+export class AudioDestinationNode
+	extends AudioNode
+	implements globalThis.AudioDestinationNode
+{
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		assertInternalConstructor(arguments);
+		// @ts-expect-error internal constructor
+		super(...arguments);
+	}
+
+	/**
+	 * The maximum number of channels that the physical device can handle.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioDestinationNode/maxChannelCount
+	 */
+	get maxChannelCount(): number {
+		return 2;
+	}
+}
+def(AudioDestinationNode);

--- a/packages/runtime/src/audio/audio-node.ts
+++ b/packages/runtime/src/audio/audio-node.ts
@@ -1,0 +1,183 @@
+import { $ } from '../$';
+import { DOMException } from '../dom-exception';
+import { EventTarget } from '../polyfills/event-target';
+import { assertInternalConstructor, def } from '../utils';
+import { AudioParam } from './audio-param';
+import { nodeInternal as _, type AudioNodeInternal } from './internal';
+import type { BaseAudioContext } from './base-audio-context';
+
+export interface AudioNodeOptions {
+	channelCount?: number;
+	channelCountMode?: ChannelCountMode;
+	channelInterpretation?: ChannelInterpretation;
+}
+
+/**
+ * A generic interface for representing an audio processing module, the
+ * building block of an audio routing graph.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/AudioNode
+ */
+export class AudioNode extends EventTarget implements globalThis.AudioNode {
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		assertInternalConstructor(arguments);
+		super();
+		_.set(this, arguments[1] as AudioNodeInternal);
+	}
+
+	/**
+	 * The {@link BaseAudioContext} which the node participates in.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/context
+	 */
+	get context(): BaseAudioContext {
+		return _(this).context;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/numberOfInputs
+	 */
+	get numberOfInputs(): number {
+		return _(this).numberOfInputs;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/numberOfOutputs
+	 */
+	get numberOfOutputs(): number {
+		return _(this).numberOfOutputs;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/channelCount
+	 */
+	get channelCount(): number {
+		return _(this).channelCount;
+	}
+
+	set channelCount(v: number) {
+		if (!Number.isInteger(v) || v < 1 || v > 32) {
+			throw new DOMException(
+				`The channel count provided (${v}) is outside the range [1, 32]`,
+				'NotSupportedError',
+			);
+		}
+		_(this).channelCount = v;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/channelCountMode
+	 */
+	get channelCountMode(): ChannelCountMode {
+		return _(this).channelCountMode;
+	}
+
+	set channelCountMode(v: ChannelCountMode) {
+		_(this).channelCountMode = v;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/channelInterpretation
+	 */
+	get channelInterpretation(): ChannelInterpretation {
+		return _(this).channelInterpretation;
+	}
+
+	set channelInterpretation(v: ChannelInterpretation) {
+		_(this).channelInterpretation = v;
+	}
+
+	/**
+	 * Connects one of the node's outputs to a destination node, directing the
+	 * processed audio data to it.
+	 *
+	 * > [!NOTE]
+	 * > Connecting to an `AudioParam` is not currently supported in nx.js.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/connect
+	 */
+	connect(
+		destinationNode: AudioNode,
+		output?: number,
+		input?: number,
+	): AudioNode;
+	connect(destinationParam: AudioParam, output?: number): void;
+	connect(
+		destination: AudioNode | AudioParam,
+		output = 0,
+		input = 0,
+	): AudioNode | void {
+		const i = _(this);
+		if (destination instanceof AudioParam) {
+			throw new DOMException(
+				"Failed to execute 'connect' on 'AudioNode': AudioParam connections are not supported",
+				'InvalidAccessError',
+			);
+		}
+		if (!(destination instanceof AudioNode)) {
+			throw new TypeError(
+				"Failed to execute 'connect' on 'AudioNode': parameter 1 is not of type 'AudioNode'",
+			);
+		}
+		const d = _(destination);
+		if (d.context !== i.context) {
+			throw new DOMException(
+				"Failed to execute 'connect' on 'AudioNode': cannot connect to an AudioNode belonging to a different audio context",
+				'InvalidAccessError',
+			);
+		}
+		if (output < 0 || output >= i.numberOfOutputs) {
+			throw new DOMException(
+				`Failed to execute 'connect' on 'AudioNode': output index (${output}) exceeds number of outputs (${i.numberOfOutputs})`,
+				'IndexSizeError',
+			);
+		}
+		if (input < 0 || input >= d.numberOfInputs) {
+			throw new DOMException(
+				`Failed to execute 'connect' on 'AudioNode': input index (${input}) exceeds number of inputs (${d.numberOfInputs})`,
+				'IndexSizeError',
+			);
+		}
+		$.audioNodeConnect(i.handle, d.handle);
+		return destination;
+	}
+
+	/**
+	 * Disconnects one or more nodes from the node.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioNode/disconnect
+	 */
+	disconnect(): void;
+	disconnect(output: number): void;
+	disconnect(destinationNode: AudioNode): void;
+	disconnect(destinationNode: AudioNode, output: number): void;
+	disconnect(destinationNode: AudioNode, output: number, input: number): void;
+	disconnect(destinationParam: AudioParam): void;
+	disconnect(destinationParam: AudioParam, output: number): void;
+	disconnect(destination?: AudioNode | AudioParam | number): void {
+		const i = _(this);
+		if (destination instanceof AudioParam) {
+			throw new DOMException(
+				"Failed to execute 'disconnect' on 'AudioNode': AudioParam connections are not supported",
+				'InvalidAccessError',
+			);
+		}
+		if (destination instanceof AudioNode) {
+			$.audioNodeDisconnect(i.handle, _(destination).handle);
+		} else {
+			// No argument (or an output index — all of our nodes have a
+			// single output, so it addresses everything).
+			if (typeof destination === 'number' && destination !== 0) {
+				throw new DOMException(
+					`Failed to execute 'disconnect' on 'AudioNode': output index (${destination}) exceeds number of outputs (${i.numberOfOutputs})`,
+					'IndexSizeError',
+				);
+			}
+			$.audioNodeDisconnect(i.handle);
+		}
+	}
+}
+def(AudioNode);

--- a/packages/runtime/src/audio/audio-param.ts
+++ b/packages/runtime/src/audio/audio-param.ts
@@ -1,0 +1,270 @@
+import { $, type AudioNodeHandle } from '../$';
+import { DOMException } from '../dom-exception';
+import { assertInternalConstructor, def } from '../utils';
+import {
+	MOST_POSITIVE_SINGLE,
+	PARAM_EVENT_EXPONENTIAL_RAMP,
+	PARAM_EVENT_LINEAR_RAMP,
+	PARAM_EVENT_SET_TARGET,
+	PARAM_EVENT_SET_VALUE,
+	paramInternal as _,
+} from './internal';
+import type { AudioNode } from './audio-node';
+
+function checkFinite(name: string, paramName: string, v: number): number {
+	if (!Number.isFinite(v)) {
+		throw new TypeError(
+			`Failed to execute '${name}' on 'AudioParam': The provided ${paramName} is non-finite.`,
+		);
+	}
+	return v;
+}
+
+function checkTime(name: string, paramName: string, t: number): number {
+	checkFinite(name, paramName, t);
+	if (t < 0) {
+		throw new RangeError(
+			`Failed to execute '${name}' on 'AudioParam': The ${paramName} provided (${t}) cannot be negative.`,
+		);
+	}
+	return t;
+}
+
+/**
+ * Create an `AudioParam` bound to native param storage, addressed as
+ * (node handle, param index).
+ *
+ * @internal
+ */
+export function createAudioParam(
+	node: AudioNode,
+	handle: AudioNodeHandle,
+	index: number,
+	opts: { defaultValue: number; minValue?: number; maxValue?: number },
+): AudioParam {
+	const param = Object.create(AudioParam.prototype) as AudioParam;
+	_.set(param, {
+		node,
+		handle,
+		index,
+		defaultValue: opts.defaultValue,
+		minValue: opts.minValue ?? -MOST_POSITIVE_SINGLE,
+		maxValue: opts.maxValue ?? MOST_POSITIVE_SINGLE,
+		automationRate: 'a-rate',
+	});
+	return param;
+}
+
+/**
+ * An audio-related parameter of an {@link AudioNode}, which can be set to a
+ * specific value or scheduled to change over time with sample-accurate
+ * automation.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/AudioParam
+ */
+export class AudioParam implements globalThis.AudioParam {
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		assertInternalConstructor(arguments);
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/automationRate
+	 */
+	get automationRate(): AutomationRate {
+		return _(this).automationRate;
+	}
+
+	set automationRate(_v: AutomationRate) {
+		// All nx.js params process at their natural rate; the setting is
+		// accepted but has no effect.
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/defaultValue
+	 */
+	get defaultValue(): number {
+		return _(this).defaultValue;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/minValue
+	 */
+	get minValue(): number {
+		return _(this).minValue;
+	}
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/maxValue
+	 */
+	get maxValue(): number {
+		return _(this).maxValue;
+	}
+
+	/**
+	 * The current value of the parameter, taking any scheduled automation
+	 * into account.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/value
+	 */
+	get value(): number {
+		const i = _(this);
+		return $.audioParamValue(i.handle, i.index);
+	}
+
+	set value(v: number) {
+		const i = _(this);
+		$.audioParamSetValue(i.handle, i.index, v);
+	}
+
+	/**
+	 * Schedules an instant change of the parameter value at a precise time.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/setValueAtTime
+	 */
+	setValueAtTime(value: number, startTime: number): AudioParam {
+		checkFinite('setValueAtTime', 'value', value);
+		checkTime('setValueAtTime', 'startTime', startTime);
+		const i = _(this);
+		$.audioParamSchedule(
+			i.handle,
+			i.index,
+			PARAM_EVENT_SET_VALUE,
+			startTime,
+			value,
+			0,
+		);
+		return this;
+	}
+
+	/**
+	 * Schedules a gradual linear change of the parameter value, ramping from
+	 * the previous event to `value` at `endTime`.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/linearRampToValueAtTime
+	 */
+	linearRampToValueAtTime(value: number, endTime: number): AudioParam {
+		checkFinite('linearRampToValueAtTime', 'value', value);
+		checkTime('linearRampToValueAtTime', 'endTime', endTime);
+		const i = _(this);
+		$.audioParamSchedule(
+			i.handle,
+			i.index,
+			PARAM_EVENT_LINEAR_RAMP,
+			endTime,
+			value,
+			0,
+		);
+		return this;
+	}
+
+	/**
+	 * Schedules a gradual exponential change of the parameter value, ramping
+	 * from the previous event to `value` at `endTime`.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/exponentialRampToValueAtTime
+	 */
+	exponentialRampToValueAtTime(value: number, endTime: number): AudioParam {
+		checkFinite('exponentialRampToValueAtTime', 'value', value);
+		if (value === 0) {
+			throw new RangeError(
+				"Failed to execute 'exponentialRampToValueAtTime' on 'AudioParam': The float target value provided (0) should not be in the range (-1.40130e-45, 1.40130e-45).",
+			);
+		}
+		checkTime('exponentialRampToValueAtTime', 'endTime', endTime);
+		const i = _(this);
+		$.audioParamSchedule(
+			i.handle,
+			i.index,
+			PARAM_EVENT_EXPONENTIAL_RAMP,
+			endTime,
+			value,
+			0,
+		);
+		return this;
+	}
+
+	/**
+	 * Schedules the start of an exponential approach to the `target` value
+	 * starting at `startTime`, decaying with `timeConstant`.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/setTargetAtTime
+	 */
+	setTargetAtTime(
+		target: number,
+		startTime: number,
+		timeConstant: number,
+	): AudioParam {
+		checkFinite('setTargetAtTime', 'target', target);
+		checkTime('setTargetAtTime', 'startTime', startTime);
+		checkFinite('setTargetAtTime', 'timeConstant', timeConstant);
+		if (timeConstant < 0) {
+			throw new RangeError(
+				`Failed to execute 'setTargetAtTime' on 'AudioParam': The time constant provided (${timeConstant}) cannot be negative.`,
+			);
+		}
+		const i = _(this);
+		$.audioParamSchedule(
+			i.handle,
+			i.index,
+			PARAM_EVENT_SET_TARGET,
+			startTime,
+			target,
+			timeConstant,
+		);
+		return this;
+	}
+
+	/**
+	 * Schedules the parameter value to follow a curve of values, scaled to fit
+	 * into the interval `[startTime, startTime + duration]`.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/setValueCurveAtTime
+	 */
+	setValueCurveAtTime(
+		values: number[] | Float32Array | Iterable<number>,
+		startTime: number,
+		duration: number,
+	): AudioParam {
+		const curve =
+			values instanceof Float32Array
+				? values.slice()
+				: new Float32Array(values as Iterable<number>);
+		if (curve.length < 2) {
+			throw new DOMException(
+				`Failed to execute 'setValueCurveAtTime' on 'AudioParam': The curve length provided (${curve.length}) is less than the minimum bound (2).`,
+				'InvalidStateError',
+			);
+		}
+		checkTime('setValueCurveAtTime', 'startTime', startTime);
+		checkFinite('setValueCurveAtTime', 'duration', duration);
+		if (duration <= 0) {
+			throw new RangeError(
+				`Failed to execute 'setValueCurveAtTime' on 'AudioParam': The curve duration provided (${duration}) should be strictly positive.`,
+			);
+		}
+		const i = _(this);
+		$.audioParamSetValueCurve(i.handle, i.index, curve, startTime, duration);
+		return this;
+	}
+
+	/**
+	 * Cancels all scheduled future changes to the parameter at or after
+	 * `cancelTime`.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/AudioParam/cancelScheduledValues
+	 */
+	cancelScheduledValues(cancelTime: number): AudioParam {
+		checkTime('cancelScheduledValues', 'cancelTime', cancelTime);
+		const i = _(this);
+		$.audioParamCancel(i.handle, i.index, cancelTime);
+		return this;
+	}
+
+	cancelAndHoldAtTime(cancelTime: number): AudioParam {
+		throw new Error('Method not implemented.');
+	}
+}
+def(AudioParam);

--- a/packages/runtime/src/audio/audio-param.ts
+++ b/packages/runtime/src/audio/audio-param.ts
@@ -40,7 +40,12 @@ export function createAudioParam(
 	node: AudioNode,
 	handle: AudioNodeHandle,
 	index: number,
-	opts: { defaultValue: number; minValue?: number; maxValue?: number },
+	opts: {
+		defaultValue: number;
+		minValue?: number;
+		maxValue?: number;
+		automationRate?: AutomationRate;
+	},
 ): AudioParam {
 	const param = Object.create(AudioParam.prototype) as AudioParam;
 	_.set(param, {
@@ -50,7 +55,7 @@ export function createAudioParam(
 		defaultValue: opts.defaultValue,
 		minValue: opts.minValue ?? -MOST_POSITIVE_SINGLE,
 		maxValue: opts.maxValue ?? MOST_POSITIVE_SINGLE,
-		automationRate: 'a-rate',
+		automationRate: opts.automationRate ?? 'a-rate',
 	});
 	return param;
 }
@@ -77,9 +82,11 @@ export class AudioParam implements globalThis.AudioParam {
 		return _(this).automationRate;
 	}
 
-	set automationRate(_v: AutomationRate) {
-		// All nx.js params process at their natural rate; the setting is
-		// accepted but has no effect.
+	set automationRate(v: AutomationRate) {
+		// The assignment is reflected by the getter, but nx.js params always
+		// process at their natural rate (gain/pan a-rate; playbackRate/detune
+		// k-rate), so this does not change processing.
+		_(this).automationRate = v;
 	}
 
 	/**

--- a/packages/runtime/src/audio/audio-scheduled-source-node.ts
+++ b/packages/runtime/src/audio/audio-scheduled-source-node.ts
@@ -1,0 +1,77 @@
+import { $ } from '../$';
+import { Event } from '../polyfills/event';
+import { clearInterval, setInterval } from '../timers';
+import { assertInternalConstructor, def } from '../utils';
+import { AudioNode } from './audio-node';
+import { nodeInternal, SOURCE_STATE_FINISHED } from './internal';
+
+// Sources which have been start()ed but have not yet finished. The strong
+// references here implement the spec's "playing reference" GC protection (an
+// actively playing source must not be collected, so that `ended` can fire),
+// and the polling interval is how native playback completion is surfaced to
+// JS as the `ended` event.
+const active = new Set<AudioScheduledSourceNode>();
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+function poll() {
+	for (const node of active) {
+		const state = $.audioSourceState(nodeInternal(node).handle);
+		if (state === SOURCE_STATE_FINISHED) {
+			active.delete(node);
+			node.dispatchEvent(new Event('ended'));
+		}
+	}
+	if (active.size === 0 && pollTimer !== null) {
+		clearInterval(pollTimer);
+		pollTimer = null;
+	}
+}
+
+/**
+ * @internal
+ */
+export function trackActiveSource(node: AudioScheduledSourceNode) {
+	active.add(node);
+	if (pollTimer === null) {
+		pollTimer = setInterval(poll, 50);
+	}
+}
+
+/**
+ * Parent interface for several types of audio source node. Provides the
+ * `start()` / `stop()` scheduling methods and the `ended` event.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode
+ */
+export class AudioScheduledSourceNode
+	extends AudioNode
+	implements globalThis.AudioScheduledSourceNode
+{
+	onended: ((this: AudioScheduledSourceNode, ev: Event) => any) | null;
+
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		assertInternalConstructor(arguments);
+		// @ts-expect-error internal constructor
+		super(...arguments);
+		this.onended = null;
+	}
+
+	start(when?: number): void {
+		throw new Error('Method not implemented.');
+	}
+
+	stop(when?: number): void {
+		throw new Error('Method not implemented.');
+	}
+
+	dispatchEvent(event: Event): boolean {
+		if (event.type === 'ended') {
+			this.onended?.(event);
+		}
+		return super.dispatchEvent(event);
+	}
+}
+def(AudioScheduledSourceNode);

--- a/packages/runtime/src/audio/base-audio-context.ts
+++ b/packages/runtime/src/audio/base-audio-context.ts
@@ -1,0 +1,272 @@
+import { $ } from '../$';
+import { DOMException } from '../dom-exception';
+import { Event } from '../polyfills/event';
+import { EventTarget } from '../polyfills/event-target';
+import { assertInternalConstructor, def } from '../utils';
+import { AudioBuffer, createAudioBuffer } from './audio-buffer';
+import { AudioBufferSourceNode } from './audio-buffer-source-node';
+import { AudioDestinationNode } from './audio-destination-node';
+import { GainNode } from './gain-node';
+import { StereoPannerNode } from './stereo-panner-node';
+import { ctxInternal as _, type BaseAudioContextInternal } from './internal';
+import { INTERNAL_SYMBOL } from '../internal';
+
+/**
+ * Transition the context state and fire `statechange` if it changed.
+ *
+ * @internal
+ */
+export function setContextState(
+	ctx: BaseAudioContext,
+	state: AudioContextState,
+) {
+	const i = _(ctx);
+	if (i.state === state) return;
+	i.state = state;
+	ctx.dispatchEvent(new Event('statechange'));
+}
+
+/**
+ * Base interface for online and offline audio-processing graphs, as
+ * represented by {@link AudioContext} and {@link OfflineAudioContext}
+ * respectively.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext
+ */
+export class BaseAudioContext
+	extends EventTarget
+	implements globalThis.BaseAudioContext
+{
+	onstatechange: ((this: BaseAudioContext, ev: Event) => any) | null;
+
+	/**
+	 * @ignore
+	 */
+	constructor() {
+		assertInternalConstructor(arguments);
+		super();
+		this.onstatechange = null;
+		_.set(this, arguments[1] as BaseAudioContextInternal);
+	}
+
+	/**
+	 * The time, in seconds, of the sample frame currently being processed by
+	 * the audio graph. Starts at `0` and increases in real-time while the
+	 * context is running.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/currentTime
+	 */
+	get currentTime(): number {
+		return $.audioContextCurrentTime(_(this).handle);
+	}
+
+	/**
+	 * The final destination of the audio graph (the audio output device).
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/destination
+	 */
+	get destination(): AudioDestinationNode {
+		const i = _(this);
+		let d = i.destination;
+		if (!d) {
+			const handle = $.audioContextDestination(i.handle);
+			// @ts-expect-error internal constructor
+			d = i.destination = new AudioDestinationNode(INTERNAL_SYMBOL, {
+				context: this,
+				handle,
+				numberOfInputs: 1,
+				numberOfOutputs: 0,
+				channelCount: 2,
+				channelCountMode: 'explicit',
+				channelInterpretation: 'speakers',
+			});
+		}
+		return d;
+	}
+
+	/**
+	 * The sample rate (in samples per second) used by all nodes in this
+	 * context.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate
+	 */
+	get sampleRate(): number {
+		return _(this).sampleRate;
+	}
+
+	/**
+	 * The current state of the audio context: `"suspended"`, `"running"` or
+	 * `"closed"`.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/state
+	 */
+	get state(): AudioContextState {
+		return _(this).state;
+	}
+
+	get audioWorklet(): AudioWorklet {
+		throw new Error('Method not implemented.');
+	}
+
+	get listener(): AudioListener {
+		throw new Error('Method not implemented.');
+	}
+
+	/**
+	 * Creates a new, empty {@link AudioBuffer}, which can be filled with data
+	 * and played via an {@link AudioBufferSourceNode}.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBuffer
+	 */
+	createBuffer(
+		numberOfChannels: number,
+		length: number,
+		sampleRate: number,
+	): AudioBuffer {
+		return new AudioBuffer({ numberOfChannels, length, sampleRate });
+	}
+
+	/**
+	 * Creates an {@link AudioBufferSourceNode} for playing an
+	 * {@link AudioBuffer}.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createBufferSource
+	 */
+	createBufferSource(): AudioBufferSourceNode {
+		return new AudioBufferSourceNode(this);
+	}
+
+	/**
+	 * Creates a {@link GainNode} for controlling volume.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createGain
+	 */
+	createGain(): GainNode {
+		return new GainNode(this);
+	}
+
+	/**
+	 * Creates a {@link StereoPannerNode} for panning across the stereo field.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createStereoPanner
+	 */
+	createStereoPanner(): StereoPannerNode {
+		return new StereoPannerNode(this);
+	}
+
+	/**
+	 * Asynchronously decodes audio file data contained in an `ArrayBuffer`
+	 * into an {@link AudioBuffer}.
+	 *
+	 * ### Supported Audio Formats
+	 *
+	 * - `mp3` — MP3 audio using [dr_mp3](https://github.com/mackron/dr_libs)
+	 * - `wav` — WAV audio using [dr_wav](https://github.com/mackron/dr_libs)
+	 * - `ogg` — OGG Vorbis audio using [stb_vorbis](https://github.com/nothings/stb)
+	 *
+	 * > [!NOTE]
+	 * > Unlike browsers, nx.js does NOT resample the decoded data to the
+	 * > context's sample rate — the returned buffer keeps the file's native
+	 * > rate (resampling happens at playback time).
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/BaseAudioContext/decodeAudioData
+	 */
+	decodeAudioData(
+		audioData: ArrayBuffer,
+		successCallback?: DecodeSuccessCallback | null,
+		errorCallback?: DecodeErrorCallback | null,
+	): Promise<AudioBuffer> {
+		if (!(audioData instanceof ArrayBuffer)) {
+			throw new TypeError(
+				"Failed to execute 'decodeAudioData' on 'BaseAudioContext': parameter 1 is not of type 'ArrayBuffer'",
+			);
+		}
+		// Per spec, decodeAudioData() detaches the input ArrayBuffer.
+		const transfer = (audioData as any).transfer;
+		const data: ArrayBuffer =
+			typeof transfer === 'function' ? transfer.call(audioData) : audioData;
+		const promise = $.audioDecode(data).then(
+			({ channelData, sampleRate }) => {
+				const buffer = createAudioBuffer(
+					channelData.map((ab) => new Float32Array(ab)),
+					sampleRate,
+				);
+				successCallback?.(buffer);
+				return buffer;
+			},
+			(err: unknown) => {
+				const error = new DOMException(
+					err instanceof Error ? err.message : String(err),
+					'EncodingError',
+				);
+				errorCallback?.(error as unknown as globalThis.DOMException);
+				throw error;
+			},
+		);
+		// When a success callback is used, surface failures through the
+		// callback path only if an error callback was given.
+		return promise;
+	}
+
+	createAnalyser(): AnalyserNode {
+		throw new Error('Method not implemented.');
+	}
+	createBiquadFilter(): BiquadFilterNode {
+		throw new Error('Method not implemented.');
+	}
+	createChannelMerger(numberOfInputs?: number): ChannelMergerNode {
+		throw new Error('Method not implemented.');
+	}
+	createChannelSplitter(numberOfOutputs?: number): ChannelSplitterNode {
+		throw new Error('Method not implemented.');
+	}
+	createConstantSource(): ConstantSourceNode {
+		throw new Error('Method not implemented.');
+	}
+	createConvolver(): ConvolverNode {
+		throw new Error('Method not implemented.');
+	}
+	createDelay(maxDelayTime?: number): DelayNode {
+		throw new Error('Method not implemented.');
+	}
+	createDynamicsCompressor(): DynamicsCompressorNode {
+		throw new Error('Method not implemented.');
+	}
+	createIIRFilter(
+		feedforward: number[] | Iterable<number>,
+		feedback: number[] | Iterable<number>,
+	): IIRFilterNode {
+		throw new Error('Method not implemented.');
+	}
+	createOscillator(): OscillatorNode {
+		throw new Error('Method not implemented.');
+	}
+	createPanner(): PannerNode {
+		throw new Error('Method not implemented.');
+	}
+	createPeriodicWave(
+		real: number[] | Float32Array | Iterable<number>,
+		imag: number[] | Float32Array | Iterable<number>,
+		constraints?: PeriodicWaveConstraints,
+	): PeriodicWave {
+		throw new Error('Method not implemented.');
+	}
+	createScriptProcessor(
+		bufferSize?: number,
+		numberOfInputChannels?: number,
+		numberOfOutputChannels?: number,
+	): ScriptProcessorNode {
+		throw new Error('Method not implemented.');
+	}
+	createWaveShaper(): WaveShaperNode {
+		throw new Error('Method not implemented.');
+	}
+
+	dispatchEvent(event: Event): boolean {
+		if (event.type === 'statechange') {
+			this.onstatechange?.(event);
+		}
+		return super.dispatchEvent(event);
+	}
+}
+def(BaseAudioContext);

--- a/packages/runtime/src/audio/gain-node.ts
+++ b/packages/runtime/src/audio/gain-node.ts
@@ -1,0 +1,54 @@
+import { $ } from '../$';
+import { INTERNAL_SYMBOL } from '../internal';
+import { createInternal, def } from '../utils';
+import { AudioNode, type AudioNodeOptions } from './audio-node';
+import { createAudioParam } from './audio-param';
+import { ctxInternal, NODE_TYPE_GAIN } from './internal';
+import type { AudioParam } from './audio-param';
+import type { BaseAudioContext } from './base-audio-context';
+
+export interface GainOptions extends AudioNodeOptions {
+	gain?: number;
+}
+
+const _ = createInternal<GainNode, { gain: AudioParam }>();
+
+/**
+ * An {@link AudioNode} which applies a (possibly automated) gain to its
+ * input — e.g. volume control and fades.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/GainNode
+ */
+export class GainNode extends AudioNode implements globalThis.GainNode {
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/GainNode/GainNode
+	 */
+	constructor(context: BaseAudioContext, options: GainOptions = {}) {
+		const handle = $.audioNodeNew(ctxInternal(context).handle, NODE_TYPE_GAIN);
+		// @ts-expect-error internal constructor
+		super(INTERNAL_SYMBOL, {
+			context,
+			handle,
+			numberOfInputs: 1,
+			numberOfOutputs: 1,
+			channelCount: options.channelCount ?? 2,
+			channelCountMode: options.channelCountMode ?? 'max',
+			channelInterpretation: options.channelInterpretation ?? 'speakers',
+		});
+		const gain = createAudioParam(this, handle, 0, { defaultValue: 1 });
+		if (typeof options.gain === 'number') {
+			gain.value = options.gain;
+		}
+		_.set(this, { gain });
+	}
+
+	/**
+	 * The amount of gain to apply (an a-rate {@link AudioParam}).
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/GainNode/gain
+	 */
+	get gain(): AudioParam {
+		return _(this).gain;
+	}
+}
+def(GainNode);

--- a/packages/runtime/src/audio/internal.ts
+++ b/packages/runtime/src/audio/internal.ts
@@ -1,0 +1,79 @@
+// Shared internal state for the Web Audio classes. Lives in its own module so
+// that sibling modules (audio-node.ts, base-audio-context.ts, the node
+// subclasses) can access each other's internals without import cycles — all
+// cross-module imports of this file are value imports, while the class types
+// are imported `type`-only.
+import type { AudioContextHandle, AudioNodeHandle } from '../$';
+import { createInternal } from '../utils';
+import type { AudioBuffer } from './audio-buffer';
+import type { AudioDestinationNode } from './audio-destination-node';
+import type { AudioNode } from './audio-node';
+import type { AudioParam } from './audio-param';
+import type { BaseAudioContext } from './base-audio-context';
+
+export interface BaseAudioContextInternal {
+	handle: AudioContextHandle;
+	state: AudioContextState;
+	sampleRate: number;
+	destination?: AudioDestinationNode;
+}
+
+export const ctxInternal = createInternal<
+	BaseAudioContext,
+	BaseAudioContextInternal
+>();
+
+export interface AudioNodeInternal {
+	context: BaseAudioContext;
+	handle: AudioNodeHandle;
+	numberOfInputs: number;
+	numberOfOutputs: number;
+	channelCount: number;
+	channelCountMode: ChannelCountMode;
+	channelInterpretation: ChannelInterpretation;
+}
+
+export const nodeInternal = createInternal<AudioNode, AudioNodeInternal>();
+
+export interface AudioParamInternal {
+	/**
+	 * The owning node — retained so that a reachable `AudioParam` keeps the
+	 * native node (and therefore the param storage) alive.
+	 */
+	node: AudioNode;
+	handle: AudioNodeHandle;
+	index: number;
+	defaultValue: number;
+	minValue: number;
+	maxValue: number;
+	automationRate: AutomationRate;
+}
+
+export const paramInternal = createInternal<AudioParam, AudioParamInternal>();
+
+export interface AudioBufferInternal {
+	channels: Float32Array[];
+	sampleRate: number;
+	length: number;
+}
+
+export const bufferInternal = createInternal<AudioBuffer, AudioBufferInternal>();
+
+// Native node type discriminators — must match `nx_audio_node_type` in
+// `source/audio-graph.h`.
+export const NODE_TYPE_GAIN = 1;
+export const NODE_TYPE_STEREO_PANNER = 2;
+export const NODE_TYPE_BUFFER_SOURCE = 3;
+
+// AudioParam automation event types — must match `nx_audio_param_event_type`
+// in `source/audio-graph.h`.
+export const PARAM_EVENT_SET_VALUE = 0;
+export const PARAM_EVENT_LINEAR_RAMP = 1;
+export const PARAM_EVENT_EXPONENTIAL_RAMP = 2;
+export const PARAM_EVENT_SET_TARGET = 3;
+
+// `nx_audio_source_state` values from `source/audio-graph.h`.
+export const SOURCE_STATE_FINISHED = 2;
+
+/** Maximum value of a single-precision float (AudioParam default min/max). */
+export const MOST_POSITIVE_SINGLE = 3.4028234663852886e38;

--- a/packages/runtime/src/audio/offline-audio-completion-event.ts
+++ b/packages/runtime/src/audio/offline-audio-completion-event.ts
@@ -1,0 +1,26 @@
+import { Event } from '../polyfills/event';
+import { def } from '../utils';
+import type { AudioBuffer } from './audio-buffer';
+
+export interface OfflineAudioCompletionEventInit extends EventInit {
+	renderedBuffer: AudioBuffer;
+}
+
+/**
+ * The event dispatched on an {@link OfflineAudioContext} when rendering
+ * completes.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/OfflineAudioCompletionEvent
+ */
+export class OfflineAudioCompletionEvent extends Event {
+	/**
+	 * The rendered {@link AudioBuffer}.
+	 */
+	readonly renderedBuffer: AudioBuffer;
+
+	constructor(type: string, eventInitDict: OfflineAudioCompletionEventInit) {
+		super(type, eventInitDict);
+		this.renderedBuffer = eventInitDict.renderedBuffer;
+	}
+}
+def(OfflineAudioCompletionEvent);

--- a/packages/runtime/src/audio/offline-audio-context.ts
+++ b/packages/runtime/src/audio/offline-audio-context.ts
@@ -1,0 +1,168 @@
+import { $ } from '../$';
+import { DOMException } from '../dom-exception';
+import { INTERNAL_SYMBOL } from '../internal';
+import { createInternal, def } from '../utils';
+import { AudioBuffer, createAudioBuffer } from './audio-buffer';
+import { BaseAudioContext, setContextState } from './base-audio-context';
+import { ctxInternal } from './internal';
+import { OfflineAudioCompletionEvent } from './offline-audio-completion-event';
+import type { Event } from '../polyfills/event';
+
+export interface OfflineAudioContextOptions {
+	/** The number of channels for the offline rendering (1 or 2 in nx.js). */
+	numberOfChannels?: number;
+	/** The length of the rendering, in sample-frames. */
+	length: number;
+	/** The sample rate of the rendering, in Hz. */
+	sampleRate: number;
+}
+
+interface OfflineAudioContextInternal {
+	length: number;
+	numberOfChannels: number;
+	started: boolean;
+}
+
+const _ = createInternal<OfflineAudioContext, OfflineAudioContextInternal>();
+
+/**
+ * An {@link AudioContext} which doesn't render the audio graph to the audio
+ * output device, but instead generates it (as fast as possible) into an
+ * {@link AudioBuffer}.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/OfflineAudioContext
+ */
+export class OfflineAudioContext
+	extends BaseAudioContext
+	implements globalThis.OfflineAudioContext
+{
+	oncomplete:
+		| ((this: OfflineAudioContext, ev: OfflineAudioCompletionEvent) => any)
+		| null;
+
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/OfflineAudioContext
+	 */
+	constructor(contextOptions: OfflineAudioContextOptions);
+	constructor(numberOfChannels: number, length: number, sampleRate: number);
+	constructor(
+		arg0: OfflineAudioContextOptions | number,
+		lengthArg?: number,
+		sampleRateArg?: number,
+	) {
+		let numberOfChannels: number;
+		let length: number;
+		let sampleRate: number;
+		if (typeof arg0 === 'object' && arg0 !== null) {
+			numberOfChannels = arg0.numberOfChannels ?? 1;
+			length = arg0.length;
+			sampleRate = arg0.sampleRate;
+		} else {
+			numberOfChannels = arg0;
+			length = lengthArg!;
+			sampleRate = sampleRateArg!;
+		}
+		if (
+			!Number.isInteger(numberOfChannels) ||
+			numberOfChannels < 1 ||
+			numberOfChannels > 2
+		) {
+			throw new DOMException(
+				`The number of channels provided (${numberOfChannels}) is outside the range [1, 2]`,
+				'NotSupportedError',
+			);
+		}
+		if (!Number.isInteger(length) || length < 1) {
+			throw new DOMException(
+				`The number of frames provided (${length}) is less than the minimum bound (1)`,
+				'NotSupportedError',
+			);
+		}
+		if (!(sampleRate >= 8000 && sampleRate <= 192000)) {
+			throw new DOMException(
+				`The sample rate provided (${sampleRate}) is outside the range [8000, 192000]`,
+				'NotSupportedError',
+			);
+		}
+		const handle = $.audioContextNew(sampleRate, true);
+		// @ts-expect-error internal constructor
+		super(INTERNAL_SYMBOL, {
+			handle,
+			state: 'suspended',
+			sampleRate,
+		});
+		this.oncomplete = null;
+		_.set(this, { length, numberOfChannels, started: false });
+	}
+
+	/**
+	 * The length of the rendering, in sample-frames.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/length
+	 */
+	get length(): number {
+		return _(this).length;
+	}
+
+	/**
+	 * Starts rendering the audio graph, resolving with the rendered
+	 * {@link AudioBuffer} once complete.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/OfflineAudioContext/startRendering
+	 */
+	async startRendering(): Promise<AudioBuffer> {
+		const i = _(this);
+		if (i.started) {
+			throw new DOMException(
+				"Failed to execute 'startRendering' on 'OfflineAudioContext': cannot call startRendering more than once",
+				'InvalidStateError',
+			);
+		}
+		i.started = true;
+		setContextState(this, 'running');
+		const channelData = await $.audioOfflineRender(
+			ctxInternal(this).handle,
+			i.numberOfChannels,
+			i.length,
+		);
+		const buffer = createAudioBuffer(
+			channelData.map((ab) => new Float32Array(ab)),
+			this.sampleRate,
+		);
+		setContextState(this, 'closed');
+		this.dispatchEvent(
+			new OfflineAudioCompletionEvent('complete', {
+				renderedBuffer: buffer,
+			}),
+		);
+		return buffer;
+	}
+
+	/**
+	 * Not currently supported in nx.js.
+	 */
+	async suspend(suspendTime: number): Promise<void> {
+		throw new DOMException(
+			"'suspend' is not supported on 'OfflineAudioContext' in nx.js",
+			'NotSupportedError',
+		);
+	}
+
+	/**
+	 * Not currently supported in nx.js.
+	 */
+	async resume(): Promise<void> {
+		throw new DOMException(
+			"'resume' is not supported on 'OfflineAudioContext' in nx.js",
+			'NotSupportedError',
+		);
+	}
+
+	dispatchEvent(event: Event): boolean {
+		if (event.type === 'complete') {
+			this.oncomplete?.(event as OfflineAudioCompletionEvent);
+		}
+		return super.dispatchEvent(event);
+	}
+}
+def(OfflineAudioContext);

--- a/packages/runtime/src/audio/stereo-panner-node.ts
+++ b/packages/runtime/src/audio/stereo-panner-node.ts
@@ -1,0 +1,65 @@
+import { $ } from '../$';
+import { INTERNAL_SYMBOL } from '../internal';
+import { createInternal, def } from '../utils';
+import { AudioNode, type AudioNodeOptions } from './audio-node';
+import { createAudioParam } from './audio-param';
+import { ctxInternal, NODE_TYPE_STEREO_PANNER } from './internal';
+import type { AudioParam } from './audio-param';
+import type { BaseAudioContext } from './base-audio-context';
+
+export interface StereoPannerOptions extends AudioNodeOptions {
+	pan?: number;
+}
+
+const _ = createInternal<StereoPannerNode, { pan: AudioParam }>();
+
+/**
+ * An {@link AudioNode} which pans its input across the stereo field using
+ * the equal-power panning algorithm.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/StereoPannerNode
+ */
+export class StereoPannerNode
+	extends AudioNode
+	implements globalThis.StereoPannerNode
+{
+	/**
+	 * @see https://developer.mozilla.org/docs/Web/API/StereoPannerNode/StereoPannerNode
+	 */
+	constructor(context: BaseAudioContext, options: StereoPannerOptions = {}) {
+		const handle = $.audioNodeNew(
+			ctxInternal(context).handle,
+			NODE_TYPE_STEREO_PANNER,
+		);
+		// @ts-expect-error internal constructor
+		super(INTERNAL_SYMBOL, {
+			context,
+			handle,
+			numberOfInputs: 1,
+			numberOfOutputs: 1,
+			channelCount: options.channelCount ?? 2,
+			channelCountMode: options.channelCountMode ?? 'clamped-max',
+			channelInterpretation: options.channelInterpretation ?? 'speakers',
+		});
+		const pan = createAudioParam(this, handle, 0, {
+			defaultValue: 0,
+			minValue: -1,
+			maxValue: 1,
+		});
+		if (typeof options.pan === 'number') {
+			pan.value = options.pan;
+		}
+		_.set(this, { pan });
+	}
+
+	/**
+	 * The position of the input in the stereo field (an a-rate
+	 * {@link AudioParam}): `-1` = full left, `0` = center, `1` = full right.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/StereoPannerNode/pan
+	 */
+	get pan(): AudioParam {
+		return _(this).pan;
+	}
+}
+def(StereoPannerNode);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -182,6 +182,42 @@ export interface ImportMeta {
  */
 export declare function queueMicrotask(callback: () => void): void;
 
+import './audio/audio-buffer';
+export type * from './audio/audio-buffer';
+
+import './audio/audio-param';
+export type * from './audio/audio-param';
+
+import './audio/audio-node';
+export type * from './audio/audio-node';
+
+import './audio/audio-scheduled-source-node';
+export type * from './audio/audio-scheduled-source-node';
+
+import './audio/audio-buffer-source-node';
+export type * from './audio/audio-buffer-source-node';
+
+import './audio/gain-node';
+export type * from './audio/gain-node';
+
+import './audio/stereo-panner-node';
+export type * from './audio/stereo-panner-node';
+
+import './audio/audio-destination-node';
+export type * from './audio/audio-destination-node';
+
+import './audio/base-audio-context';
+export type * from './audio/base-audio-context';
+
+import './audio/audio-context';
+export type * from './audio/audio-context';
+
+import './audio/offline-audio-completion-event';
+export type * from './audio/offline-audio-completion-event';
+
+import './audio/offline-audio-context';
+export type * from './audio/offline-audio-context';
+
 import './audio';
 import './web-applet';
 

--- a/packages/runtime/test/CMakeLists.txt
+++ b/packages/runtime/test/CMakeLists.txt
@@ -41,6 +41,9 @@ set(NX_SOURCE_DIR "${CMAKE_SOURCE_DIR}/../../../source")
 set(TEST_SOURCES
   src/main.cc
   src/stubs.cc
+  # Host audio output sink (wall-clock paced consumer thread); the device
+  # equivalent is source/audio-sink-audren.cc.
+  src/audio-sink.cc
 )
 
 # Real nx.js source modules that are portable (compiled from source/*.cc, with
@@ -48,6 +51,8 @@ set(TEST_SOURCES
 # screen provider, which the host raster harness does not use.
 set(NX_SOURCES
   ${NX_SOURCE_DIR}/async.cc
+  ${NX_SOURCE_DIR}/audio.cc
+  ${NX_SOURCE_DIR}/audio-graph.cc
   ${NX_SOURCE_DIR}/canvas.cc
   ${NX_SOURCE_DIR}/canvas_path.cc
   ${NX_SOURCE_DIR}/compression.cc

--- a/packages/runtime/test/fixtures/webaudio.ts
+++ b/packages/runtime/test/fixtures/webaudio.ts
@@ -1,0 +1,669 @@
+import { test } from '../src/tap';
+
+// Web Audio API conformance tests. All rendering goes through
+// OfflineAudioContext so the output is deterministic and does not depend on
+// Chrome's autoplay policy (a real-time AudioContext would start "suspended"
+// in headless Chrome without a user gesture).
+
+const RATE = 48000;
+
+function throwsName(
+	t: any,
+	fn: () => unknown,
+	name: string,
+	msg: string,
+): void {
+	try {
+		fn();
+		t.fail(msg);
+	} catch (err: any) {
+		t.equal(err?.name, name, msg);
+	}
+}
+
+function closeTo(a: number, b: number, eps = 1e-4): boolean {
+	return Math.abs(a - b) <= eps;
+}
+
+function maxDiff(data: Float32Array, expected: (i: number) => number): number {
+	let max = 0;
+	for (let i = 0; i < data.length; i++) {
+		const d = Math.abs(data[i] - expected(i));
+		if (d > max) max = d;
+	}
+	return max;
+}
+
+// --- AudioBuffer ---
+
+test('AudioBuffer basics', (t) => {
+	const buf = new AudioBuffer({
+		numberOfChannels: 2,
+		length: 1000,
+		sampleRate: RATE,
+	});
+	t.equal(buf.numberOfChannels, 2, 'numberOfChannels is 2');
+	t.equal(buf.length, 1000, 'length is 1000');
+	t.equal(buf.sampleRate, RATE, 'sampleRate is 48000');
+	t.ok(closeTo(buf.duration, 1000 / RATE, 1e-9), 'duration is length/rate');
+
+	const ch0 = buf.getChannelData(0);
+	t.ok(ch0 instanceof Float32Array, 'getChannelData returns Float32Array');
+	t.equal(ch0.length, 1000, 'channel data length matches');
+	t.equal(ch0[0], 0, 'channel data is zero-initialized');
+	t.equal(buf.getChannelData(0), ch0, 'getChannelData returns same array');
+
+	ch0[0] = 0.5;
+	const dest = new Float32Array(4);
+	buf.copyFromChannel(dest, 0);
+	t.equal(dest[0], 0.5, 'copyFromChannel copies data');
+
+	const src = new Float32Array([1, 2, 3, 4]);
+	buf.copyToChannel(src, 1, 2);
+	t.equal(buf.getChannelData(1)[2], 1, 'copyToChannel honors bufferOffset');
+	t.equal(buf.getChannelData(1)[5], 4, 'copyToChannel copies all values');
+
+	throwsName(
+		t,
+		() => buf.getChannelData(2),
+		'IndexSizeError',
+		'getChannelData throws for invalid channel',
+	);
+	throwsName(
+		t,
+		() =>
+			new AudioBuffer({ numberOfChannels: 0, length: 10, sampleRate: RATE }),
+		'NotSupportedError',
+		'constructor throws for 0 channels',
+	);
+	throwsName(
+		t,
+		() =>
+			new AudioBuffer({ numberOfChannels: 1, length: 0, sampleRate: RATE }),
+		'NotSupportedError',
+		'constructor throws for 0 length',
+	);
+	throwsName(
+		t,
+		() =>
+			new AudioBuffer({ numberOfChannels: 1, length: 10, sampleRate: 1 }),
+		'NotSupportedError',
+		'constructor throws for bad sampleRate',
+	);
+});
+
+// --- OfflineAudioContext basics ---
+
+test('OfflineAudioContext basics', (t) => {
+	const ctx = new OfflineAudioContext(1, 1280, RATE);
+	t.equal(ctx.length, 1280, 'length is 1280');
+	t.equal(ctx.sampleRate, RATE, 'sampleRate is 48000');
+	t.equal(ctx.state, 'suspended', 'initial state is suspended');
+	t.equal(ctx.currentTime, 0, 'initial currentTime is 0');
+	t.ok(ctx.destination instanceof AudioDestinationNode, 'destination type');
+	t.equal(ctx.destination.numberOfInputs, 1, 'destination numberOfInputs');
+	t.equal(ctx.destination.numberOfOutputs, 0, 'destination numberOfOutputs');
+	t.equal(ctx.destination.context, ctx, 'destination context is ctx');
+});
+
+// --- Source playback through gain ---
+
+test('buffer source through gain', async (t) => {
+	const N = 1280;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	const data = buffer.getChannelData(0);
+	for (let i = 0; i < N; i++) data[i] = 1;
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	t.equal(gain.gain.value, 1, 'gain defaults to 1');
+	gain.gain.value = 0.25;
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+
+	const rendered = await ctx.startRendering();
+	t.equal(rendered.length, N, 'rendered buffer length');
+	t.equal(rendered.numberOfChannels, 1, 'rendered buffer channels');
+	t.equal(rendered.sampleRate, RATE, 'rendered buffer sampleRate');
+	const out = rendered.getChannelData(0);
+	t.ok(maxDiff(out, () => 0.25) < 1e-6, 'all samples scaled by gain');
+	t.equal(ctx.state, 'closed', 'state is closed after rendering');
+});
+
+// --- Sample-accurate playback (no processing) ---
+
+test('buffer source passthrough is sample-accurate', async (t) => {
+	const N = 512;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	const data = buffer.getChannelData(0);
+	for (let i = 0; i < N; i++) data[i] = Math.sin(i / 10);
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(
+		maxDiff(out, (i) => Math.sin(i / 10)) < 1e-6,
+		'output matches buffer exactly',
+	);
+});
+
+// --- start() offset and duration ---
+
+test('buffer source start offset and duration', async (t) => {
+	const N = 1024;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N * 2, RATE);
+	const data = buffer.getChannelData(0);
+	for (let i = 0; i < data.length; i++) data[i] = i / data.length;
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.connect(ctx.destination);
+	// Start 256 frames into the buffer, play 128 frames worth.
+	source.start(0, 256 / RATE, 128 / RATE);
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(closeTo(out[0], data[256], 1e-6), 'first sample honors offset');
+	t.ok(closeTo(out[127], data[256 + 127], 1e-6), 'last sample before cutoff');
+	t.equal(out[200], 0, 'silent after duration elapses');
+	t.equal(out[N - 1], 0, 'silent at end');
+});
+
+// --- Delayed start ---
+
+test('buffer source delayed start', async (t) => {
+	const N = 512;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	buffer.getChannelData(0).fill(1);
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.connect(ctx.destination);
+	source.start(256 / RATE);
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.equal(out[0], 0, 'silent before start time');
+	t.equal(out[255], 0, 'silent right before start time');
+	t.equal(out[256], 1, 'plays at start time');
+	t.equal(out[N - 1], 1, 'still playing at end');
+});
+
+// --- Looping ---
+
+test('buffer source looping', async (t) => {
+	const N = 1000;
+	const period = 100;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, period, RATE);
+	const data = buffer.getChannelData(0);
+	for (let i = 0; i < period; i++) data[i] = (i + 1) / period;
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.loop = true;
+	t.equal(source.loop, true, 'loop property set');
+	source.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(
+		closeTo(out[0], data[0], 1e-6) &&
+			closeTo(out[period], data[0], 1e-6) &&
+			closeTo(out[5 * period + 50], data[50], 1e-6),
+		'looped content repeats',
+	);
+	t.ok(closeTo(out[N - 1], data[(N - 1) % period], 1e-6), 'loops to the end');
+});
+
+// --- playbackRate ---
+
+test('buffer source playbackRate', async (t) => {
+	const N = 256;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N * 2, RATE);
+	const data = buffer.getChannelData(0);
+	for (let i = 0; i < data.length; i++) data[i] = i;
+
+	const source = ctx.createBufferSource();
+	t.equal(source.playbackRate.value, 1, 'playbackRate defaults to 1');
+	t.equal(source.detune.value, 0, 'detune defaults to 0');
+	source.buffer = buffer;
+	source.playbackRate.value = 2;
+	source.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(
+		maxDiff(out, (i) => 2 * i) < 1e-2,
+		'output advances at twice the rate',
+	);
+});
+
+// --- Gain automation: setValueAtTime + linearRamp ---
+
+test('gain linear ramp automation', async (t) => {
+	const N = 1280;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	buffer.getChannelData(0).fill(1);
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	gain.gain.setValueAtTime(0, 0);
+	gain.gain.linearRampToValueAtTime(1, N / RATE);
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(
+		maxDiff(out, (i) => i / N) < 1e-3,
+		'gain ramps linearly from 0 to 1',
+	);
+});
+
+// --- Gain automation: setValueAtTime steps ---
+
+test('gain setValueAtTime steps', async (t) => {
+	const N = 1024;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	buffer.getChannelData(0).fill(1);
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	gain.gain.setValueAtTime(0.25, 0);
+	gain.gain.setValueAtTime(0.75, 512 / RATE);
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(closeTo(out[0], 0.25, 1e-6), 'first step value');
+	t.ok(closeTo(out[511], 0.25, 1e-6), 'holds until second step');
+	t.ok(closeTo(out[512], 0.75, 1e-6), 'second step value');
+	t.ok(closeTo(out[N - 1], 0.75, 1e-6), 'holds to the end');
+});
+
+// --- Exponential ramp ---
+
+test('gain exponential ramp automation', async (t) => {
+	const N = 1280;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	buffer.getChannelData(0).fill(1);
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	gain.gain.setValueAtTime(0.01, 0);
+	gain.gain.exponentialRampToValueAtTime(1, N / RATE);
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(
+		maxDiff(out, (i) => 0.01 * Math.pow(100, i / N)) < 1e-3,
+		'gain ramps exponentially',
+	);
+});
+
+// --- setTargetAtTime ---
+
+test('gain setTargetAtTime automation', async (t) => {
+	const N = 1280;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	buffer.getChannelData(0).fill(1);
+
+	const tc = 0.005;
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	gain.gain.setValueAtTime(1, 0);
+	gain.gain.setTargetAtTime(0, 0, tc);
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(
+		maxDiff(out, (i) => Math.exp(-(i / RATE) / tc)) < 1e-3,
+		'gain decays toward target',
+	);
+});
+
+// --- setValueCurveAtTime ---
+
+test('gain setValueCurveAtTime automation', async (t) => {
+	const N = 1024;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	buffer.getChannelData(0).fill(1);
+
+	const curve = new Float32Array([0, 1, 0.5]);
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	gain.gain.setValueCurveAtTime(curve, 0, 512 / RATE);
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(closeTo(out[0], 0, 1e-5), 'curve start value');
+	t.ok(closeTo(out[128], 0.5, 2e-3), 'curve interpolates first segment');
+	t.ok(closeTo(out[256], 1, 2e-3), 'curve midpoint value');
+	t.ok(closeTo(out[384], 0.75, 2e-3), 'curve interpolates second segment');
+	t.ok(closeTo(out[600], 0.5, 1e-5), 'holds final curve value');
+});
+
+// --- cancelScheduledValues ---
+
+test('cancelScheduledValues removes future events', async (t) => {
+	const N = 1024;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, N, RATE);
+	buffer.getChannelData(0).fill(1);
+
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const gain = ctx.createGain();
+	gain.gain.setValueAtTime(0.5, 0);
+	gain.gain.setValueAtTime(0.9, 512 / RATE);
+	gain.gain.cancelScheduledValues(256 / RATE);
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(closeTo(out[0], 0.5, 1e-6), 'kept event applies');
+	t.ok(closeTo(out[N - 1], 0.5, 1e-6), 'canceled event does not apply');
+});
+
+// --- StereoPannerNode ---
+
+test('stereo panner mono input', async (t) => {
+	const N = 384;
+	const SQRT1_2 = Math.SQRT1_2;
+	for (const [pan, gl, gr, name] of [
+		[0, SQRT1_2, SQRT1_2, 'center'],
+		[-1, 1, 0, 'left'],
+		[1, 0, 1, 'right'],
+	] as [number, number, number, string][]) {
+		const ctx = new OfflineAudioContext(2, N, RATE);
+		const buffer = ctx.createBuffer(1, N, RATE);
+		buffer.getChannelData(0).fill(1);
+		const source = ctx.createBufferSource();
+		source.buffer = buffer;
+		const panner = ctx.createStereoPanner();
+		panner.pan.value = pan;
+		source.connect(panner);
+		panner.connect(ctx.destination);
+		source.start();
+		const rendered = await ctx.startRendering();
+		const l = rendered.getChannelData(0);
+		const r = rendered.getChannelData(1);
+		t.ok(closeTo(l[100], gl, 1e-5), `pan ${name}: left gain`);
+		t.ok(closeTo(r[100], gr, 1e-5), `pan ${name}: right gain`);
+	}
+});
+
+test('stereo panner stereo input', async (t) => {
+	const N = 384;
+	const ctx = new OfflineAudioContext(2, N, RATE);
+	const buffer = ctx.createBuffer(2, N, RATE);
+	buffer.getChannelData(0).fill(0.5);
+	buffer.getChannelData(1).fill(0.25);
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	const panner = ctx.createStereoPanner();
+	t.equal(panner.pan.value, 0, 'pan defaults to 0');
+	source.connect(panner);
+	panner.connect(ctx.destination);
+	source.start();
+	const rendered = await ctx.startRendering();
+	t.ok(
+		closeTo(rendered.getChannelData(0)[100], 0.5, 1e-5),
+		'pan 0 stereo passthrough left',
+	);
+	t.ok(
+		closeTo(rendered.getChannelData(1)[100], 0.25, 1e-5),
+		'pan 0 stereo passthrough right',
+	);
+});
+
+// --- Stereo downmix to mono destination ---
+
+test('stereo source downmix to mono destination', async (t) => {
+	const N = 384;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(2, N, RATE);
+	buffer.getChannelData(0).fill(0.8);
+	buffer.getChannelData(1).fill(0.4);
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.connect(ctx.destination);
+	source.start();
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(closeTo(out[100], 0.6, 1e-5), 'mono downmix is 0.5*(L+R)');
+});
+
+// --- Fan-in summing ---
+
+test('multiple sources sum at destination', async (t) => {
+	const N = 384;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	for (const value of [0.25, 0.5]) {
+		const buffer = ctx.createBuffer(1, N, RATE);
+		buffer.getChannelData(0).fill(value);
+		const source = ctx.createBufferSource();
+		source.buffer = buffer;
+		source.connect(ctx.destination);
+		source.start();
+	}
+	const out = (await ctx.startRendering()).getChannelData(0);
+	t.ok(closeTo(out[100], 0.75, 1e-5), 'inputs are summed');
+});
+
+// --- ended event ---
+
+test('source ended event fires', async (t) => {
+	const N = 2048;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const buffer = ctx.createBuffer(1, 256, RATE);
+	buffer.getChannelData(0).fill(1);
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.connect(ctx.destination);
+	const ended = new Promise<boolean>((resolve) => {
+		const timo = setTimeout(() => resolve(false), 3000);
+		source.onended = () => {
+			clearTimeout(timo);
+			resolve(true);
+		};
+	});
+	source.start();
+	await ctx.startRendering();
+	t.ok(await ended, 'ended event fired');
+});
+
+// --- oncomplete event ---
+
+test('OfflineAudioContext complete event', async (t) => {
+	const N = 384;
+	const ctx = new OfflineAudioContext(1, N, RATE);
+	const complete = new Promise<any>((resolve) => {
+		const timo = setTimeout(() => resolve(null), 3000);
+		ctx.oncomplete = (ev) => {
+			clearTimeout(timo);
+			resolve(ev);
+		};
+	});
+	const rendered = await ctx.startRendering();
+	const ev = await complete;
+	t.ok(ev !== null, 'complete event fired');
+	t.equal(ev?.renderedBuffer?.length, N, 'event has renderedBuffer');
+	t.equal(rendered.length, N, 'startRendering resolves with buffer');
+});
+
+// --- decodeAudioData (WAV built in JS) ---
+
+function buildWav(samples: Float32Array, sampleRate: number): ArrayBuffer {
+	const dataSize = samples.length * 2;
+	const ab = new ArrayBuffer(44 + dataSize);
+	const view = new DataView(ab);
+	const writeStr = (off: number, s: string) => {
+		for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i));
+	};
+	writeStr(0, 'RIFF');
+	view.setUint32(4, 36 + dataSize, true);
+	writeStr(8, 'WAVE');
+	writeStr(12, 'fmt ');
+	view.setUint32(16, 16, true); // fmt chunk size
+	view.setUint16(20, 1, true); // PCM
+	view.setUint16(22, 1, true); // mono
+	view.setUint32(24, sampleRate, true);
+	view.setUint32(28, sampleRate * 2, true); // byte rate
+	view.setUint16(32, 2, true); // block align
+	view.setUint16(34, 16, true); // bits per sample
+	writeStr(36, 'data');
+	view.setUint32(40, dataSize, true);
+	for (let i = 0; i < samples.length; i++) {
+		const s = Math.max(-1, Math.min(1, samples[i]));
+		view.setInt16(44 + i * 2, Math.round(s * 32767), true);
+	}
+	return ab;
+}
+
+test('decodeAudioData decodes WAV', async (t) => {
+	const N = 4800;
+	const samples = new Float32Array(N);
+	for (let i = 0; i < N; i++) samples[i] = Math.sin((i / RATE) * 2 * Math.PI * 440) * 0.5;
+	const wav = buildWav(samples, RATE);
+
+	const ctx = new OfflineAudioContext(1, 384, RATE);
+	const buffer = await ctx.decodeAudioData(wav);
+	t.equal(buffer.numberOfChannels, 1, 'decoded channel count');
+	t.equal(buffer.sampleRate, RATE, 'decoded sample rate');
+	t.equal(buffer.length, N, 'decoded length');
+	const data = buffer.getChannelData(0);
+	t.ok(
+		maxDiff(data, (i) => samples[i]) < 1e-3,
+		'decoded samples match (within s16 quantization)',
+	);
+	t.equal(wav.byteLength, 0, 'input ArrayBuffer is detached');
+});
+
+test('decodeAudioData rejects garbage', async (t) => {
+	const ctx = new OfflineAudioContext(1, 384, RATE);
+	const garbage = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+	try {
+		await ctx.decodeAudioData(garbage);
+		t.fail('should have rejected');
+	} catch (err: any) {
+		t.equal(err.name, 'EncodingError', 'rejects with EncodingError');
+	}
+});
+
+// --- API errors ---
+
+test('Web Audio API errors', async (t) => {
+	const ctx = new OfflineAudioContext(1, 384, RATE);
+	const source = ctx.createBufferSource();
+	const buffer = ctx.createBuffer(1, 100, RATE);
+
+	throwsName(t, () => source.stop(), 'InvalidStateError', 'stop before start throws');
+
+	source.buffer = buffer;
+	throwsName(
+		t,
+		() => {
+			source.buffer = buffer;
+		},
+		'InvalidStateError',
+		'setting buffer twice throws',
+	);
+	source.buffer = null;
+	t.ok(source.buffer === null, 'buffer can be cleared');
+
+	source.start();
+	throwsName(t, () => source.start(), 'InvalidStateError', 'start twice throws');
+
+	const gain = ctx.createGain();
+	throwsName(
+		t,
+		() => gain.gain.setValueAtTime(1, -1),
+		'RangeError',
+		'negative time throws',
+	);
+	throwsName(
+		t,
+		() => gain.gain.exponentialRampToValueAtTime(0, 1),
+		'RangeError',
+		'exponential ramp to 0 throws',
+	);
+	throwsName(
+		t,
+		() => gain.gain.setTargetAtTime(1, 0, -1),
+		'RangeError',
+		'negative timeConstant throws',
+	);
+	throwsName(
+		t,
+		() => gain.gain.setValueCurveAtTime(new Float32Array([1]), 0, 0.1),
+		'InvalidStateError',
+		'short curve throws',
+	);
+
+	const ctx2 = new OfflineAudioContext(1, 384, RATE);
+	const gain2 = ctx2.createGain();
+	throwsName(
+		t,
+		() => gain.connect(gain2),
+		'InvalidAccessError',
+		'cross-context connect throws',
+	);
+
+	throwsName(
+		t,
+		() => new OfflineAudioContext(0, 384, RATE),
+		'NotSupportedError',
+		'OfflineAudioContext with 0 channels throws',
+	);
+});
+
+// --- Node properties ---
+
+test('AudioNode properties', (t) => {
+	const ctx = new OfflineAudioContext(1, 384, RATE);
+	const source = ctx.createBufferSource();
+	t.equal(source.numberOfInputs, 0, 'source numberOfInputs');
+	t.equal(source.numberOfOutputs, 1, 'source numberOfOutputs');
+	const gain = ctx.createGain();
+	t.equal(gain.numberOfInputs, 1, 'gain numberOfInputs');
+	t.equal(gain.numberOfOutputs, 1, 'gain numberOfOutputs');
+	t.equal(gain.context, ctx, 'gain context');
+	t.equal(gain.connect(ctx.destination), ctx.destination, 'connect returns destination');
+	gain.disconnect();
+	t.ok(source instanceof AudioScheduledSourceNode, 'source instanceof AudioScheduledSourceNode');
+	t.ok(source instanceof AudioNode, 'source instanceof AudioNode');
+	t.ok(gain instanceof AudioNode, 'gain instanceof AudioNode');
+	t.ok(gain.gain instanceof AudioParam, 'gain.gain instanceof AudioParam');
+	t.equal(gain.gain.defaultValue, 1, 'gain defaultValue');
+	const panner = ctx.createStereoPanner();
+	t.equal(panner.pan.minValue, -1, 'pan minValue');
+	t.equal(panner.pan.maxValue, 1, 'pan maxValue');
+	t.ok(ctx instanceof BaseAudioContext, 'ctx instanceof BaseAudioContext');
+});

--- a/packages/runtime/test/src/audio-sink.cc
+++ b/packages/runtime/test/src/audio-sink.cc
@@ -1,0 +1,59 @@
+// Host (nxjs-test) audio output sink — a wall-clock-paced consumer thread.
+//
+// There is no audible output on the host; the sink exists so that an online
+// AudioContext behaves like the device: currentTime advances in real time,
+// scheduled sources progress/finish, and the graph render code (the exact
+// same audio-graph.cc the device runs) is exercised under threading.
+#include "audio-sink.h"
+#include "audio-graph.h"
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+struct nx_audio_sink {
+	nx_audio_graph *graph;
+	std::thread thread;
+	std::atomic<bool> stop{false};
+};
+
+namespace {
+
+constexpr uint32_t CHUNK_FRAMES = 1024; // multiple of the render quantum
+
+void sink_thread(nx_audio_sink *s) {
+	using clock = std::chrono::steady_clock;
+	int16_t scratch[CHUNK_FRAMES * 2];
+	const double rate = s->graph->sample_rate; // immutable after create
+	const auto start = clock::now();
+	uint64_t consumed = 0;
+	while (!s->stop.load(std::memory_order_relaxed)) {
+		double elapsed =
+		    std::chrono::duration<double>(clock::now() - start).count();
+		uint64_t target = (uint64_t)(elapsed * rate);
+		while (consumed + CHUNK_FRAMES <= target &&
+		       !s->stop.load(std::memory_order_relaxed)) {
+			nx_audio_graph_render_s16(s->graph, scratch, CHUNK_FRAMES);
+			consumed += CHUNK_FRAMES;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(5));
+	}
+}
+
+} // namespace
+
+nx_audio_sink_t *nx_audio_sink_attach(nx_audio_graph *graph,
+                                      const char **err) {
+	(void)err;
+	nx_audio_sink *sink = new nx_audio_sink();
+	sink->graph = graph;
+	nx_audio_graph_ref(graph);
+	sink->thread = std::thread(sink_thread, sink);
+	return sink;
+}
+
+void nx_audio_sink_detach(nx_audio_sink_t *sink) {
+	sink->stop.store(true, std::memory_order_relaxed);
+	sink->thread.join();
+	nx_audio_graph_unref(sink->graph);
+	delete sink;
+}

--- a/packages/runtime/test/src/compat/switch.h
+++ b/packages/runtime/test/src/compat/switch.h
@@ -807,14 +807,6 @@ static inline void diagAbortWithResult(Result rc) {
 }
 
 // ============================================================================
-// Audio types (stubs for types.h / audio.c — module is stubbed)
-// ============================================================================
-
-typedef struct {
-	int _unused;
-} AudioDriver;
-
-// ============================================================================
 // NACP types (used by ns.h nx_app_t struct — module is stubbed)
 // ============================================================================
 

--- a/packages/runtime/test/src/stubs.cc
+++ b/packages/runtime/test/src/stubs.cc
@@ -9,10 +9,12 @@
  * factory functions return an empty object so callers that read properties
  * off the result do not crash.
  *
- * The portable modules (canvas, crypto, dns, compression, url, web, fs, image,
- * font, tcp, tls, udp, wasm, window, dommatrix, error, util, async) are
- * compiled from source/*.cc against the libnx stubs in compat/. memory.cc is
- * Switch-specific (svc memory introspection), so it is stubbed here too.
+ * The portable modules (audio, canvas, crypto, dns, compression, url, web,
+ * fs, image, font, tcp, tls, udp, wasm, window, dommatrix, error, util,
+ * async) are compiled from source/*.cc against the libnx stubs in compat/.
+ * memory.cc is Switch-specific (svc memory introspection), so it is stubbed
+ * here too. (audio.cc is portable because the platform output lives behind
+ * audio-sink.h — the host sink is src/audio-sink.cc.)
  */
 #include "types.h"
 #include <v8.h>
@@ -71,13 +73,6 @@ NX_STUB_FN(album) {
 NX_STUB_FN(applet) {
 	NX_STUB_NAMES("appletIlluminance", "appletGetAppletType",
 	              "appletGetOperationMode", "appletSetMediaPlaybackState")
-}
-
-NX_STUB_FN(audio) {
-	NX_STUB_NAMES("audioInit", "audioExit", "audioDecode", "audioPlay",
-	              "audioStop", "audioPause", "audioSetVolume", "audioSetPitch",
-	              "audioUpdate", "audioGetPlayedSamples", "audioAllocVoice",
-	              "audioFreeVoice", "audioIsPlaying")
 }
 
 NX_STUB_FN(battery) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,24 @@ importers:
         specifier: 'catalog:'
         version: 0.27.3
 
+  apps/web-audio:
+    devDependencies:
+      '@nx.js/constants':
+        specifier: workspace:^
+        version: link:../../packages/constants
+      '@nx.js/nro':
+        specifier: workspace:^
+        version: link:../../packages/nro
+      '@nx.js/nsp':
+        specifier: workspace:^
+        version: link:../../packages/nsp
+      '@nx.js/runtime':
+        specifier: workspace:^
+        version: link:../../packages/runtime
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.27.3
+
   apps/websocket-server:
     devDependencies:
       '@nx.js/nro':

--- a/source/audio-graph.cc
+++ b/source/audio-graph.cc
@@ -82,9 +82,11 @@ float param_value_at(const nx_audio_param *p, double t) {
 		}
 		case NX_AUDIO_PARAM_SET_TARGET: {
 			// In effect until the next event (or `t`, whichever is sooner).
+			// An event at exactly `t` takes over (events apply at their
+			// start time, inclusive), so the comparison is `<=`.
 			double tstop = t;
 			bool next_applies =
-			    i + 1 < evs.size() && evs[i + 1].time < t;
+			    i + 1 < evs.size() && evs[i + 1].time <= t;
 			if (next_applies)
 				tstop = evs[i + 1].time;
 			double val;

--- a/source/audio-graph.cc
+++ b/source/audio-graph.cc
@@ -1,0 +1,638 @@
+// Portable Web Audio graph engine implementation. See audio-graph.h for the
+// architecture overview. No V8 / libnx / libuv — compiled into both the device
+// runtime and the host nxjs-test binary.
+#include "audio-graph.h"
+#include <algorithm>
+#include <string.h>
+
+namespace {
+
+constexpr int Q = NX_AUDIO_RENDER_QUANTUM;
+
+float clampf(float v, float lo, float hi) {
+	return v < lo ? lo : (v > hi ? hi : v);
+}
+
+// ---------------------------------------------------------------------------
+// AudioParam timeline evaluation
+// ---------------------------------------------------------------------------
+
+// Computes the parameter value at time `t` by walking the (time-sorted) event
+// list. This is a pragmatic implementation of the Web Audio "computedValue"
+// algorithm covering the common shapes: set, linear/exponential ramps,
+// setTarget decay, and value curves. Ramps anchor at the previous event's
+// (time, value); a setTarget remains in effect until the next event.
+float param_value_at(const nx_audio_param *p, double t) {
+	const auto &evs = p->events;
+	double v_prev = p->value;
+	double t_prev = 0;
+	for (size_t i = 0; i < evs.size(); i++) {
+		const nx_audio_param_event &e = evs[i];
+		if (e.time > t) {
+			// `t` falls before this event takes effect. Ramps interpolate
+			// from the previous anchor toward this (future) event.
+			if (e.type == NX_AUDIO_PARAM_LINEAR_RAMP) {
+				if (e.time <= t_prev)
+					return clampf((float)e.value, p->min_value, p->max_value);
+				double f = (t - t_prev) / (e.time - t_prev);
+				if (f < 0)
+					f = 0;
+				return clampf((float)(v_prev + (e.value - v_prev) * f),
+				              p->min_value, p->max_value);
+			}
+			if (e.type == NX_AUDIO_PARAM_EXPONENTIAL_RAMP) {
+				if (v_prev == 0 || (v_prev < 0) != (e.value < 0) ||
+				    e.time <= t_prev)
+					return clampf((float)v_prev, p->min_value, p->max_value);
+				double f = (t - t_prev) / (e.time - t_prev);
+				if (f < 0)
+					f = 0;
+				return clampf((float)(v_prev * pow(e.value / v_prev, f)),
+				              p->min_value, p->max_value);
+			}
+			// Other event types have no effect before their start time.
+			return clampf((float)v_prev, p->min_value, p->max_value);
+		}
+		// Event time <= t: apply it and move the anchor forward.
+		switch (e.type) {
+		case NX_AUDIO_PARAM_SET_VALUE:
+		case NX_AUDIO_PARAM_LINEAR_RAMP:
+		case NX_AUDIO_PARAM_EXPONENTIAL_RAMP:
+			v_prev = e.value;
+			t_prev = e.time;
+			break;
+		case NX_AUDIO_PARAM_SET_VALUE_CURVE: {
+			size_t n = e.curve.size();
+			if (n == 0)
+				break;
+			double tend = e.time + e.duration;
+			if (t < tend && e.duration > 0) {
+				double f = (t - e.time) / e.duration * (double)(n - 1);
+				size_t k = (size_t)f;
+				if (k >= n - 1)
+					return clampf(e.curve[n - 1], p->min_value, p->max_value);
+				double frac = f - (double)k;
+				return clampf(
+				    (float)(e.curve[k] + (e.curve[k + 1] - e.curve[k]) * frac),
+				    p->min_value, p->max_value);
+			}
+			v_prev = e.curve[n - 1];
+			t_prev = tend;
+			break;
+		}
+		case NX_AUDIO_PARAM_SET_TARGET: {
+			// In effect until the next event (or `t`, whichever is sooner).
+			double tstop = t;
+			bool next_applies =
+			    i + 1 < evs.size() && evs[i + 1].time < t;
+			if (next_applies)
+				tstop = evs[i + 1].time;
+			double val;
+			if (e.time_constant <= 0) {
+				val = e.value;
+			} else {
+				val = e.value + (v_prev - e.value) *
+				                    exp(-(tstop - e.time) / e.time_constant);
+			}
+			if (!next_applies)
+				return clampf((float)val, p->min_value, p->max_value);
+			v_prev = val;
+			t_prev = tstop;
+			break;
+		}
+		}
+	}
+	return clampf((float)v_prev, p->min_value, p->max_value);
+}
+
+// Fill `out[0..n)` with a-rate values for frame times t0, t0+1/sr, ...
+void param_fill(const nx_audio_param *p, double t0, double inv_sr, float *out,
+                int n) {
+	if (p->events.empty()) {
+		float v = clampf(p->value, p->min_value, p->max_value);
+		for (int i = 0; i < n; i++)
+			out[i] = v;
+		return;
+	}
+	for (int i = 0; i < n; i++)
+		out[i] = param_value_at(p, t0 + i * inv_sr);
+}
+
+// Insert an event keeping the list time-sorted (stable for equal times). A
+// SET_VALUE at the exact time of an existing SET_VALUE replaces it.
+void param_insert_event(nx_audio_param *p, nx_audio_param_event &&e) {
+	if (e.type == NX_AUDIO_PARAM_SET_VALUE) {
+		for (auto &existing : p->events) {
+			if (existing.time == e.time &&
+			    existing.type == NX_AUDIO_PARAM_SET_VALUE) {
+				existing = std::move(e);
+				return;
+			}
+		}
+	}
+	auto it = std::upper_bound(
+	    p->events.begin(), p->events.end(), e.time,
+	    [](double t, const nx_audio_param_event &ev) { return t < ev.time; });
+	p->events.insert(it, std::move(e));
+}
+
+// ---------------------------------------------------------------------------
+// Node processing
+// ---------------------------------------------------------------------------
+
+void zero_bus(nx_audio_node *n) {
+	memset(n->bus, 0, sizeof(n->bus));
+}
+
+void process_node(nx_audio_graph *g, nx_audio_node *n, double t0);
+
+// `out_channels` is set to the computed channel count of the summed input.
+void sum_inputs(nx_audio_graph *g, nx_audio_node *n, double t0,
+                float in[NX_AUDIO_CHANNELS][Q], int *out_channels) {
+	memset(in, 0, sizeof(float) * NX_AUDIO_CHANNELS * Q);
+	int ch = 1;
+	for (nx_audio_node *src : n->inputs) {
+		process_node(g, src, t0);
+		for (int c = 0; c < NX_AUDIO_CHANNELS; c++)
+			for (int i = 0; i < Q; i++)
+				in[c][i] += src->bus[c][i];
+		if (src->bus_ch == 2)
+			ch = 2;
+	}
+	*out_channels = ch;
+}
+
+void process_buffer_source(nx_audio_graph *g, nx_audio_node *n, double t0) {
+	zero_bus(n);
+	n->bus_ch = 1;
+	if (!n->started || n->playback_state == NX_AUDIO_SOURCE_FINISHED)
+		return;
+
+	bool has_buf = !n->buffer_channels.empty() && n->buffer_length > 0 &&
+	               n->buffer_sample_rate > 0;
+	if (has_buf && n->buffer_channels.size() > 1)
+		n->bus_ch = 2;
+
+	// k-rate playback rate, computed once per quantum.
+	double rate = param_value_at(&n->params[0], t0);
+	double detune = param_value_at(&n->params[1], t0);
+	double r = rate * exp2(detune / 1200.0);
+	if (has_buf)
+		r *= n->buffer_sample_rate / g->sample_rate;
+
+	double inv_sr = 1.0 / g->sample_rate;
+	double buf_len = has_buf ? (double)n->buffer_length : 0;
+
+	// Loop points, in buffer frames.
+	double loop_s = 0, loop_e = buf_len;
+	if (n->loop && has_buf) {
+		loop_s = n->loop_start * n->buffer_sample_rate;
+		loop_e = n->loop_end > 0 ? n->loop_end * n->buffer_sample_rate
+		                         : buf_len;
+		if (loop_s < 0)
+			loop_s = 0;
+		if (loop_e > buf_len)
+			loop_e = buf_len;
+		if (loop_e <= loop_s) {
+			loop_s = 0;
+			loop_e = buf_len;
+		}
+	}
+	double dur_frames =
+	    n->duration >= 0 && has_buf ? n->duration * n->buffer_sample_rate : -1;
+
+	const float *ch0 = has_buf ? n->buffer_channels[0] : nullptr;
+	const float *ch1 = has_buf && n->buffer_channels.size() > 1
+	                       ? n->buffer_channels[1]
+	                       : ch0;
+
+	bool finished = false;
+	for (int i = 0; i < Q; i++) {
+		double t = t0 + i * inv_sr;
+		if (n->stop_time >= 0 && t >= n->stop_time) {
+			finished = true;
+			break;
+		}
+		if (t < n->start_time)
+			continue; // bus is already zero
+		if (!n->playing) {
+			n->playing = true;
+			n->position = n->start_offset * n->buffer_sample_rate;
+			if (n->position < 0)
+				n->position = 0;
+			if (n->loop && n->position > loop_e)
+				n->position = loop_s;
+			n->played_frames = 0;
+		}
+		if (!has_buf)
+			continue; // null buffer: silence until stop()
+		if (dur_frames >= 0 && n->played_frames >= dur_frames) {
+			finished = true;
+			break;
+		}
+		if (!n->loop && (n->position >= buf_len || n->position < 0)) {
+			finished = true;
+			break;
+		}
+		uint32_t i0 = (uint32_t)n->position;
+		if (i0 >= n->buffer_length)
+			i0 = n->buffer_length - 1;
+		uint32_t i1 = i0 + 1 < n->buffer_length ? i0 + 1 : i0;
+		double frac = n->position - (double)i0;
+		n->bus[0][i] = (float)(ch0[i0] + (ch0[i1] - ch0[i0]) * frac);
+		n->bus[1][i] = (float)(ch1[i0] + (ch1[i1] - ch1[i0]) * frac);
+		n->position += r;
+		n->played_frames += fabs(r);
+		if (n->loop) {
+			double ll = loop_e - loop_s;
+			if (ll > 0) {
+				while (n->position >= loop_e)
+					n->position -= ll;
+				while (n->position < loop_s && r < 0)
+					n->position += ll;
+			}
+		}
+	}
+	if (finished) {
+		n->playback_state = NX_AUDIO_SOURCE_FINISHED;
+		n->playing = false;
+	}
+}
+
+void process_gain(nx_audio_graph *g, nx_audio_node *n, double t0) {
+	float in[NX_AUDIO_CHANNELS][Q];
+	int ch;
+	sum_inputs(g, n, t0, in, &ch);
+	n->bus_ch = ch;
+	float gain[Q];
+	param_fill(&n->params[0], t0, 1.0 / g->sample_rate, gain, Q);
+	for (int i = 0; i < Q; i++) {
+		n->bus[0][i] = in[0][i] * gain[i];
+		n->bus[1][i] = in[1][i] * gain[i];
+	}
+}
+
+void process_stereo_panner(nx_audio_graph *g, nx_audio_node *n, double t0) {
+	float in[NX_AUDIO_CHANNELS][Q];
+	int ch;
+	sum_inputs(g, n, t0, in, &ch);
+	n->bus_ch = 2; // panner output is always stereo
+	float pan[Q];
+	param_fill(&n->params[0], t0, 1.0 / g->sample_rate, pan, Q);
+	constexpr double HALF_PI = 1.57079632679489661923;
+	if (ch == 1) {
+		// Mono input (L==R): x = (pan + 1) / 2.
+		for (int i = 0; i < Q; i++) {
+			double x = (pan[i] + 1) / 2;
+			n->bus[0][i] = (float)(in[0][i] * cos(x * HALF_PI));
+			n->bus[1][i] = (float)(in[0][i] * sin(x * HALF_PI));
+		}
+	} else {
+		// Stereo input, per the spec's equal-power algorithm.
+		for (int i = 0; i < Q; i++) {
+			double p = pan[i];
+			double x = p <= 0 ? p + 1 : p;
+			float gl = (float)cos(x * HALF_PI);
+			float gr = (float)sin(x * HALF_PI);
+			if (p <= 0) {
+				n->bus[0][i] = in[0][i] + in[1][i] * gl;
+				n->bus[1][i] = in[1][i] * gr;
+			} else {
+				n->bus[0][i] = in[0][i] * gl;
+				n->bus[1][i] = in[1][i] + in[0][i] * gr;
+			}
+		}
+	}
+}
+
+void process_destination(nx_audio_graph *g, nx_audio_node *n, double t0) {
+	float in[NX_AUDIO_CHANNELS][Q];
+	int ch;
+	sum_inputs(g, n, t0, in, &ch);
+	n->bus_ch = ch;
+	memcpy(n->bus, in, sizeof(in));
+}
+
+void process_node(nx_audio_graph *g, nx_audio_node *n, double t0) {
+	if (n->processed_quantum == g->quantum_id)
+		return; // already rendered this quantum (fan-out memoization)
+	if (n->processing) {
+		// Cycle (not legal in Web Audio without a DelayNode, which we don't
+		// implement) — break it with silence.
+		zero_bus(n);
+		return;
+	}
+	n->processing = true;
+	switch (n->type) {
+	case NX_AUDIO_NODE_BUFFER_SOURCE:
+		process_buffer_source(g, n, t0);
+		break;
+	case NX_AUDIO_NODE_GAIN:
+		process_gain(g, n, t0);
+		break;
+	case NX_AUDIO_NODE_STEREO_PANNER:
+		process_stereo_panner(g, n, t0);
+		break;
+	case NX_AUDIO_NODE_DESTINATION:
+		process_destination(g, n, t0);
+		break;
+	}
+	n->processing = false;
+	n->processed_quantum = g->quantum_id;
+}
+
+// Renders one 128-frame quantum into the destination bus and advances time.
+// Caller holds the graph mutex.
+void render_quantum(nx_audio_graph *g) {
+	g->quantum_id++;
+	double t0 = (double)g->frames_rendered / g->sample_rate;
+	process_node(g, g->destination, t0);
+	// Sources not reachable from the destination still progress through their
+	// schedule (so `ended` fires even for unconnected/indirect sources).
+	for (nx_audio_node *n : g->nodes) {
+		if (n->type == NX_AUDIO_NODE_BUFFER_SOURCE &&
+		    n->processed_quantum != g->quantum_id)
+			process_node(g, n, t0);
+	}
+	g->frames_rendered += Q;
+}
+
+void graph_destroy(nx_audio_graph *g) {
+	for (nx_audio_node *n : g->nodes)
+		delete n;
+	delete g;
+}
+
+nx_audio_node *node_new(nx_audio_graph *g, nx_audio_node_type type) {
+	nx_audio_node *n = new nx_audio_node();
+	n->graph = g;
+	n->type = type;
+	zero_bus(n);
+	switch (type) {
+	case NX_AUDIO_NODE_GAIN: {
+		nx_audio_param gain;
+		gain.value = 1.f;
+		n->params.push_back(gain);
+		break;
+	}
+	case NX_AUDIO_NODE_STEREO_PANNER: {
+		nx_audio_param pan;
+		pan.value = 0.f;
+		pan.min_value = -1.f;
+		pan.max_value = 1.f;
+		n->params.push_back(pan);
+		break;
+	}
+	case NX_AUDIO_NODE_BUFFER_SOURCE: {
+		nx_audio_param rate;
+		rate.value = 1.f;
+		n->params.push_back(rate);
+		nx_audio_param detune;
+		detune.value = 0.f;
+		n->params.push_back(detune);
+		break;
+	}
+	case NX_AUDIO_NODE_DESTINATION:
+		break;
+	}
+	g->nodes.push_back(n);
+	return n;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Public API (all functions lock the graph mutex)
+// ---------------------------------------------------------------------------
+
+nx_audio_graph *nx_audio_graph_create(double sample_rate) {
+	nx_audio_graph *g = new nx_audio_graph();
+	g->sample_rate = sample_rate;
+	g->destination = node_new(g, NX_AUDIO_NODE_DESTINATION);
+	return g;
+}
+
+void nx_audio_graph_ref(nx_audio_graph *g) { g->refs.fetch_add(1); }
+
+void nx_audio_graph_unref(nx_audio_graph *g) {
+	if (g->refs.fetch_sub(1) == 1)
+		graph_destroy(g);
+}
+
+double nx_audio_graph_current_time(nx_audio_graph *g) {
+	std::lock_guard<std::mutex> lock(g->mutex);
+	return (double)g->frames_rendered / g->sample_rate;
+}
+
+void nx_audio_graph_set_suspended(nx_audio_graph *g, bool suspended) {
+	std::lock_guard<std::mutex> lock(g->mutex);
+	g->suspended = suspended;
+}
+
+nx_audio_node *nx_audio_node_create(nx_audio_graph *g,
+                                    nx_audio_node_type type) {
+	nx_audio_graph_ref(g);
+	std::lock_guard<std::mutex> lock(g->mutex);
+	return node_new(g, type);
+}
+
+void nx_audio_node_release(nx_audio_node *n) {
+	nx_audio_graph *g = n->graph;
+	{
+		std::lock_guard<std::mutex> lock(g->mutex);
+		if (n->type != NX_AUDIO_NODE_DESTINATION) {
+			for (nx_audio_node *src : n->inputs)
+				src->outputs.erase(std::remove(src->outputs.begin(),
+				                               src->outputs.end(), n),
+				                   src->outputs.end());
+			for (nx_audio_node *dst : n->outputs)
+				dst->inputs.erase(
+				    std::remove(dst->inputs.begin(), dst->inputs.end(), n),
+				    dst->inputs.end());
+			g->nodes.erase(std::remove(g->nodes.begin(), g->nodes.end(), n),
+			               g->nodes.end());
+			delete n;
+		}
+		// The destination node is graph-owned; only the ref is dropped.
+	}
+	nx_audio_graph_unref(g);
+}
+
+void nx_audio_node_connect(nx_audio_node *src, nx_audio_node *dst) {
+	std::lock_guard<std::mutex> lock(src->graph->mutex);
+	// Idempotent: multiple connections between the same nodes collapse.
+	if (std::find(dst->inputs.begin(), dst->inputs.end(), src) !=
+	    dst->inputs.end())
+		return;
+	dst->inputs.push_back(src);
+	src->outputs.push_back(dst);
+}
+
+void nx_audio_node_disconnect(nx_audio_node *src, nx_audio_node *dst) {
+	std::lock_guard<std::mutex> lock(src->graph->mutex);
+	if (dst) {
+		dst->inputs.erase(
+		    std::remove(dst->inputs.begin(), dst->inputs.end(), src),
+		    dst->inputs.end());
+		src->outputs.erase(
+		    std::remove(src->outputs.begin(), src->outputs.end(), dst),
+		    src->outputs.end());
+	} else {
+		for (nx_audio_node *d : src->outputs)
+			d->inputs.erase(
+			    std::remove(d->inputs.begin(), d->inputs.end(), src),
+			    d->inputs.end());
+		src->outputs.clear();
+	}
+}
+
+nx_audio_param *nx_audio_node_param(nx_audio_node *n, int index) {
+	if (index < 0 || (size_t)index >= n->params.size())
+		return nullptr;
+	return &n->params[index];
+}
+
+float nx_audio_param_value(nx_audio_node *n, nx_audio_param *p) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	double t = (double)n->graph->frames_rendered / n->graph->sample_rate;
+	return param_value_at(p, t);
+}
+
+void nx_audio_param_set_value(nx_audio_node *n, nx_audio_param *p,
+                              float value) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	p->value = value;
+	if (!p->events.empty()) {
+		// Per spec, setting .value with scheduled automation behaves like
+		// setValueAtTime(value, currentTime).
+		double t = (double)n->graph->frames_rendered / n->graph->sample_rate;
+		nx_audio_param_event e = {};
+		e.type = NX_AUDIO_PARAM_SET_VALUE;
+		e.time = t;
+		e.value = value;
+		param_insert_event(p, std::move(e));
+	}
+}
+
+void nx_audio_param_schedule(nx_audio_node *n, nx_audio_param *p,
+                             nx_audio_param_event_type type, double time,
+                             float value, double time_constant) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	nx_audio_param_event e = {};
+	e.type = type;
+	e.time = time;
+	e.value = value;
+	e.time_constant = time_constant;
+	param_insert_event(p, std::move(e));
+}
+
+void nx_audio_param_set_value_curve(nx_audio_node *n, nx_audio_param *p,
+                                    const float *curve, size_t len,
+                                    double start_time, double duration) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	nx_audio_param_event e = {};
+	e.type = NX_AUDIO_PARAM_SET_VALUE_CURVE;
+	e.time = start_time;
+	e.duration = duration;
+	e.curve.assign(curve, curve + len);
+	param_insert_event(p, std::move(e));
+}
+
+void nx_audio_param_cancel(nx_audio_node *n, nx_audio_param *p, double time) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	p->events.erase(std::remove_if(p->events.begin(), p->events.end(),
+	                               [time](const nx_audio_param_event &e) {
+		                               return e.time >= time;
+	                               }),
+	                p->events.end());
+}
+
+void nx_audio_source_set_buffer(nx_audio_node *n, const float *const *channels,
+                                int num_channels, uint32_t length,
+                                double sample_rate,
+                                std::vector<std::shared_ptr<void>> holds) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	n->buffer_channels.assign(channels, channels + num_channels);
+	n->buffer_holds = std::move(holds);
+	n->buffer_length = length;
+	n->buffer_sample_rate = sample_rate;
+}
+
+void nx_audio_source_set_loop(nx_audio_node *n, bool loop, double loop_start,
+                              double loop_end) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	n->loop = loop;
+	n->loop_start = loop_start;
+	n->loop_end = loop_end;
+}
+
+void nx_audio_source_start(nx_audio_node *n, double when, double offset,
+                           double duration) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	if (n->started)
+		return; // JS throws InvalidStateError before reaching here
+	n->started = true;
+	n->playback_state = NX_AUDIO_SOURCE_SCHEDULED;
+	n->start_time = when;
+	n->start_offset = offset;
+	n->duration = duration;
+}
+
+void nx_audio_source_stop(nx_audio_node *n, double when) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	double t = (double)n->graph->frames_rendered / n->graph->sample_rate;
+	if (when < t)
+		when = t;
+	n->stop_time = when;
+}
+
+int nx_audio_source_playback_state(nx_audio_node *n) {
+	std::lock_guard<std::mutex> lock(n->graph->mutex);
+	return n->playback_state;
+}
+
+void nx_audio_graph_render_s16(nx_audio_graph *g, int16_t *out,
+                               uint32_t frames) {
+	std::lock_guard<std::mutex> lock(g->mutex);
+	if (g->suspended || g->closed) {
+		memset(out, 0, (size_t)frames * NX_AUDIO_CHANNELS * sizeof(int16_t));
+		return;
+	}
+	uint32_t done = 0;
+	while (done < frames) {
+		render_quantum(g);
+		uint32_t n = frames - done < Q ? frames - done : Q;
+		const float *l = g->destination->bus[0];
+		const float *r = g->destination->bus[1];
+		for (uint32_t i = 0; i < n; i++) {
+			float fl = clampf(l[i], -1.f, 1.f);
+			float fr = clampf(r[i], -1.f, 1.f);
+			out[(done + i) * 2] = (int16_t)lrintf(fl * 32767.f);
+			out[(done + i) * 2 + 1] = (int16_t)lrintf(fr * 32767.f);
+		}
+		done += n;
+	}
+}
+
+void nx_audio_graph_render_offline(nx_audio_graph *g, float *const *channels,
+                                   int num_channels, uint32_t length) {
+	std::lock_guard<std::mutex> lock(g->mutex);
+	uint32_t done = 0;
+	while (done < length) {
+		render_quantum(g);
+		uint32_t n = length - done < Q ? length - done : Q;
+		const float *l = g->destination->bus[0];
+		const float *r = g->destination->bus[1];
+		if (num_channels == 1) {
+			// Mono destination: speakers downmix = 0.5 * (L + R).
+			for (uint32_t i = 0; i < n; i++)
+				channels[0][done + i] = 0.5f * (l[i] + r[i]);
+		} else {
+			for (uint32_t i = 0; i < n; i++) {
+				channels[0][done + i] = l[i];
+				channels[1][done + i] = r[i];
+			}
+		}
+		done += n;
+	}
+}

--- a/source/audio-graph.h
+++ b/source/audio-graph.h
@@ -1,0 +1,176 @@
+#pragma once
+// Portable Web Audio graph engine — pure C++ (std only).
+//
+// This file is compiled into BOTH the device runtime and the host nxjs-test
+// binary, so it must not reference V8, libnx, or libuv. The V8 bindings live
+// in audio.cc; the platform output sinks live in audio-sink-audren.cc (device)
+// and packages/runtime/test/src/audio-sink.cc (host).
+//
+// Threading model: a "control thread" (the JS loop thread, via audio.cc) and a
+// "render thread" (the sink, or a libuv worker for OfflineAudioContext) both
+// touch the graph. Every public function in this header — and the render
+// entrypoints — locks the graph mutex internally. The internal bus format is
+// stereo float32, processed in 128-frame render quanta (like browsers).
+
+#include <atomic>
+#include <math.h>
+#include <memory>
+#include <mutex>
+#include <stddef.h>
+#include <stdint.h>
+#include <vector>
+
+#define NX_AUDIO_RENDER_QUANTUM 128
+#define NX_AUDIO_CHANNELS 2
+
+enum nx_audio_node_type {
+	NX_AUDIO_NODE_DESTINATION = 0,
+	NX_AUDIO_NODE_GAIN = 1,
+	NX_AUDIO_NODE_STEREO_PANNER = 2,
+	NX_AUDIO_NODE_BUFFER_SOURCE = 3,
+};
+
+// AudioParam automation event types (matches the JS side's wire protocol).
+enum nx_audio_param_event_type {
+	NX_AUDIO_PARAM_SET_VALUE = 0,
+	NX_AUDIO_PARAM_LINEAR_RAMP = 1,
+	NX_AUDIO_PARAM_EXPONENTIAL_RAMP = 2,
+	NX_AUDIO_PARAM_SET_TARGET = 3,
+	NX_AUDIO_PARAM_SET_VALUE_CURVE = 4,
+};
+
+// AudioBufferSourceNode playback states (polled by JS for `ended` events).
+enum nx_audio_source_state {
+	NX_AUDIO_SOURCE_UNSCHEDULED = 0,
+	NX_AUDIO_SOURCE_SCHEDULED = 1,
+	NX_AUDIO_SOURCE_FINISHED = 2,
+};
+
+struct nx_audio_param_event {
+	nx_audio_param_event_type type;
+	double time;          // event (start) time, in context seconds
+	float value;          // target value (SET_VALUE/RAMP/SET_TARGET)
+	double time_constant; // SET_TARGET only
+	double duration;      // SET_VALUE_CURVE only
+	std::vector<float> curve; // SET_VALUE_CURVE only
+};
+
+struct nx_audio_param {
+	float value = 0.f; // [[current value]] (base when no events apply)
+	float min_value = -3.402823466e+38f;
+	float max_value = 3.402823466e+38f;
+	std::vector<nx_audio_param_event> events; // sorted by time
+};
+
+struct nx_audio_graph;
+
+struct nx_audio_node {
+	nx_audio_graph *graph = nullptr;
+	nx_audio_node_type type;
+
+	// Graph topology. `inputs` are the nodes connected INTO this node;
+	// `outputs` is the reverse mapping (for cleanup on release). Duplicate
+	// connections are collapsed (per spec: multiple connect() calls between
+	// the same nodes are idempotent).
+	std::vector<nx_audio_node *> inputs;
+	std::vector<nx_audio_node *> outputs;
+
+	// Per-quantum processing state.
+	uint64_t processed_quantum = 0;
+	bool processing = false; // cycle guard
+	float bus[NX_AUDIO_CHANNELS][NX_AUDIO_RENDER_QUANTUM];
+	// Channel count of the bus content: 1 = mono (L==R), 2 = true stereo.
+	// Drives spec-correct mono vs stereo panning behavior.
+	int bus_ch = 1;
+
+	// AudioParams, addressed by index:
+	//   GAIN:          0 = gain
+	//   STEREO_PANNER: 0 = pan
+	//   BUFFER_SOURCE: 0 = playbackRate, 1 = detune
+	std::vector<nx_audio_param> params;
+
+	// ---- AudioBufferSourceNode state ----
+	// Channel data points into externally-owned memory (V8 BackingStores);
+	// `buffer_holds` keeps that memory alive for the render thread.
+	std::vector<const float *> buffer_channels;
+	std::vector<std::shared_ptr<void>> buffer_holds;
+	uint32_t buffer_length = 0;   // frames
+	double buffer_sample_rate = 0;
+	bool loop = false;
+	double loop_start = 0;
+	double loop_end = 0;
+	int playback_state = NX_AUDIO_SOURCE_UNSCHEDULED;
+	bool started = false;       // start() called
+	bool playing = false;       // playhead initialized (first audible quantum)
+	double start_time = 0;      // when (context seconds)
+	double start_offset = 0;    // offset into buffer (seconds)
+	double duration = -1;       // <0 = no duration limit (buffer seconds)
+	double stop_time = -1;      // <0 = no stop scheduled
+	double position = 0;        // playhead, fractional buffer frames
+	double played_frames = 0;   // cumulative buffer frames consumed
+};
+
+struct nx_audio_graph {
+	std::mutex mutex;
+	std::atomic<int> refs{1};
+	double sample_rate;
+	uint64_t frames_rendered = 0; // currentTime = frames_rendered / rate
+	uint64_t quantum_id = 0;
+	bool suspended = false;
+	bool closed = false;
+	nx_audio_node *destination = nullptr;
+	std::vector<nx_audio_node *> nodes; // all live nodes (owned), incl. dest
+};
+
+// ---- graph lifecycle ----
+nx_audio_graph *nx_audio_graph_create(double sample_rate);
+void nx_audio_graph_ref(nx_audio_graph *g);
+void nx_audio_graph_unref(nx_audio_graph *g); // frees at 0 (incl. all nodes)
+double nx_audio_graph_current_time(nx_audio_graph *g);
+void nx_audio_graph_set_suspended(nx_audio_graph *g, bool suspended);
+
+// ---- nodes ----
+// Creating a node adds a graph ref; releasing it removes the node from the
+// graph (disconnecting both directions) and drops that ref. Releasing the
+// destination node only drops the ref (the node itself is graph-owned).
+// Safe to call from a GC finalizer (locks the mutex; no JS API).
+nx_audio_node *nx_audio_node_create(nx_audio_graph *g, nx_audio_node_type type);
+void nx_audio_node_release(nx_audio_node *n);
+void nx_audio_node_connect(nx_audio_node *src, nx_audio_node *dst);
+// dst == NULL disconnects all outputs.
+void nx_audio_node_disconnect(nx_audio_node *src, nx_audio_node *dst);
+
+// ---- params ----
+// Returns NULL for an out-of-range index.
+nx_audio_param *nx_audio_node_param(nx_audio_node *n, int index);
+float nx_audio_param_value(nx_audio_node *n, nx_audio_param *p); // at currentTime
+void nx_audio_param_set_value(nx_audio_node *n, nx_audio_param *p, float value);
+void nx_audio_param_schedule(nx_audio_node *n, nx_audio_param *p,
+                             nx_audio_param_event_type type, double time,
+                             float value, double time_constant);
+void nx_audio_param_set_value_curve(nx_audio_node *n, nx_audio_param *p,
+                                    const float *curve, size_t len,
+                                    double start_time, double duration);
+void nx_audio_param_cancel(nx_audio_node *n, nx_audio_param *p, double time);
+
+// ---- buffer source ----
+void nx_audio_source_set_buffer(nx_audio_node *n, const float *const *channels,
+                                int num_channels, uint32_t length,
+                                double sample_rate,
+                                std::vector<std::shared_ptr<void>> holds);
+void nx_audio_source_set_loop(nx_audio_node *n, bool loop, double loop_start,
+                              double loop_end);
+void nx_audio_source_start(nx_audio_node *n, double when, double offset,
+                           double duration);
+void nx_audio_source_stop(nx_audio_node *n, double when);
+int nx_audio_source_playback_state(nx_audio_node *n);
+
+// ---- rendering (called from sink threads / libuv workers; locks mutex) ----
+// Renders `frames` of interleaved stereo s16. When the graph is suspended (or
+// closed), fills with silence WITHOUT advancing currentTime.
+void nx_audio_graph_render_s16(nx_audio_graph *g, int16_t *out,
+                               uint32_t frames);
+// OfflineAudioContext rendering: renders `length` frames into `num_channels`
+// planar float buffers (1 = mono downmix, 2 = stereo). Ignores `suspended`.
+void nx_audio_graph_render_offline(nx_audio_graph *g, float *const *channels,
+                                   int num_channels, uint32_t length);

--- a/source/audio-sink-audren.cc
+++ b/source/audio-sink-audren.cc
@@ -1,0 +1,236 @@
+// Nintendo Switch audio output sink — streams the Web Audio graph to the
+// audren service (via libnx's AudioDriver) using double-buffered wavebufs fed
+// from a dedicated render thread.
+//
+// Process-global model: ONE audren session + AudioDriver + render thread is
+// shared by all attached graphs (audrenInitialize can only be brought up once
+// per process); each attached graph gets its own voice on the final mix. The
+// render thread is the only code that touches the driver after init —
+// attach/detach coordinate with it through `g.mutex`.
+//
+// This file is device-only (libnx); the host nxjs-test binary compiles
+// packages/runtime/test/src/audio-sink.cc instead.
+#include "audio-sink.h"
+#include "audio-graph.h"
+#include <malloc.h>
+#include <string.h>
+#include <switch.h>
+#include <vector>
+
+#define SINK_SAMPLE_RATE 48000
+#define SINK_NUM_VOICES 24
+#define SINK_BUF_FRAMES 1024 // per wavebuf (multiple of the render quantum)
+#define SINK_NUM_BUFS 2
+#define SINK_ALIGN 0x1000
+#define ALIGN_UP(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
+
+struct nx_audio_sink {
+	nx_audio_graph *graph;
+	int voice_id;
+	void *mempool;
+	size_t mempool_size;
+	int mempool_id;
+	AudioDriverWaveBuf wavebufs[SINK_NUM_BUFS];
+};
+
+namespace {
+
+const AudioRendererConfig ar_config = {
+    .output_rate = AudioRendererOutputRate_48kHz,
+    .num_voices = SINK_NUM_VOICES,
+    .num_effects = 0,
+    .num_sinks = 1,
+    .num_mix_objs = 1,
+    .num_mix_buffers = 2,
+};
+
+struct {
+	Mutex mutex; // guards everything below + driver access from the thread
+	bool initialized;
+	AudioDriver drv;
+	std::vector<nx_audio_sink *> sinks;
+	bool voice_used[SINK_NUM_VOICES];
+	Thread thread;
+	bool thread_running;
+	bool stop;
+} g;
+
+void render_thread(void *arg) {
+	(void)arg;
+	while (true) {
+		mutexLock(&g.mutex);
+		if (g.stop) {
+			mutexUnlock(&g.mutex);
+			break;
+		}
+		for (nx_audio_sink *sink : g.sinks) {
+			for (int b = 0; b < SINK_NUM_BUFS; b++) {
+				AudioDriverWaveBuf *wb = &sink->wavebufs[b];
+				if (wb->state != AudioDriverWaveBufState_Free &&
+				    wb->state != AudioDriverWaveBufState_Done)
+					continue;
+				int16_t *pcm = (int16_t *)wb->data_raw;
+				nx_audio_graph_render_s16(sink->graph, pcm, SINK_BUF_FRAMES);
+				armDCacheFlush(pcm, SINK_BUF_FRAMES * 2 * sizeof(int16_t));
+				audrvVoiceAddWaveBuf(&g.drv, sink->voice_id, wb);
+			}
+			if (!audrvVoiceIsPlaying(&g.drv, sink->voice_id))
+				audrvVoiceStart(&g.drv, sink->voice_id);
+		}
+		audrvUpdate(&g.drv);
+		mutexUnlock(&g.mutex);
+		audrenWaitFrame();
+	}
+}
+
+// Bring up audren + the driver + the render thread. Caller holds g.mutex.
+const char *global_init(void) {
+	if (g.initialized)
+		return NULL;
+	Result rc = audrenInitialize(&ar_config);
+	if (R_FAILED(rc))
+		return "audrenInitialize() failed";
+	rc = audrvCreate(&g.drv, &ar_config, 2);
+	if (R_FAILED(rc)) {
+		audrenExit();
+		return "audrvCreate() failed";
+	}
+	static const u8 sink_channels[] = {0, 1};
+	audrvDeviceSinkAdd(&g.drv, AUDREN_DEFAULT_DEVICE_NAME, 2, sink_channels);
+	rc = audrenStartAudioRenderer();
+	if (R_FAILED(rc)) {
+		audrvClose(&g.drv);
+		audrenExit();
+		return "audrenStartAudioRenderer() failed";
+	}
+	audrvUpdate(&g.drv);
+	memset(g.voice_used, 0, sizeof(g.voice_used));
+	g.stop = false;
+	// Higher priority than the main thread (0x2C) so mixing keeps up; any
+	// core (-2). 64 KiB of stack is plenty for the graph render.
+	rc = threadCreate(&g.thread, render_thread, NULL, NULL, 0x10000, 0x20, -2);
+	if (R_FAILED(rc) || R_FAILED(threadStart(&g.thread))) {
+		audrvClose(&g.drv);
+		audrenExit();
+		return "failed to start audio render thread";
+	}
+	g.thread_running = true;
+	g.initialized = true;
+	return NULL;
+}
+
+// Tear down audren when the last sink detaches. Caller holds g.mutex; the
+// mutex is released while joining the thread.
+void global_exit(void) {
+	if (!g.initialized)
+		return;
+	g.stop = true;
+	mutexUnlock(&g.mutex);
+	threadWaitForExit(&g.thread);
+	threadClose(&g.thread);
+	mutexLock(&g.mutex);
+	g.thread_running = false;
+	audrvClose(&g.drv);
+	audrenExit();
+	g.initialized = false;
+}
+
+} // namespace
+
+nx_audio_sink_t *nx_audio_sink_attach(nx_audio_graph *graph,
+                                      const char **err) {
+	mutexLock(&g.mutex);
+	const char *init_err = global_init();
+	if (init_err) {
+		mutexUnlock(&g.mutex);
+		*err = init_err;
+		return NULL;
+	}
+	int voice_id = -1;
+	for (int i = 0; i < SINK_NUM_VOICES; i++) {
+		if (!g.voice_used[i]) {
+			voice_id = i;
+			break;
+		}
+	}
+	if (voice_id < 0) {
+		if (g.sinks.empty())
+			global_exit();
+		mutexUnlock(&g.mutex);
+		*err = "no free audio voices";
+		return NULL;
+	}
+
+	size_t mempool_size =
+	    ALIGN_UP(SINK_NUM_BUFS * SINK_BUF_FRAMES * 2 * sizeof(int16_t),
+	             SINK_ALIGN);
+	void *mempool = memalign(SINK_ALIGN, mempool_size);
+	if (!mempool) {
+		if (g.sinks.empty())
+			global_exit();
+		mutexUnlock(&g.mutex);
+		*err = "failed to allocate audio buffer";
+		return NULL;
+	}
+	memset(mempool, 0, mempool_size);
+	armDCacheFlush(mempool, mempool_size);
+
+	nx_audio_sink *sink = new nx_audio_sink();
+	sink->graph = graph;
+	nx_audio_graph_ref(graph);
+	sink->voice_id = voice_id;
+	g.voice_used[voice_id] = true;
+	sink->mempool = mempool;
+	sink->mempool_size = mempool_size;
+	sink->mempool_id = audrvMemPoolAdd(&g.drv, mempool, mempool_size);
+	audrvMemPoolAttach(&g.drv, sink->mempool_id);
+
+	// The voice plays at the graph's sample rate; audren resamples to 48 kHz.
+	int channels = 2;
+	audrvVoiceInit(&g.drv, voice_id, channels, PcmFormat_Int16,
+	               (int)sink->graph->sample_rate);
+	audrvVoiceSetDestinationMix(&g.drv, voice_id, AUDREN_FINAL_MIX_ID);
+	audrvVoiceSetMixFactor(&g.drv, voice_id, 1.0f, 0, 0);
+	audrvVoiceSetMixFactor(&g.drv, voice_id, 0.0f, 0, 1);
+	audrvVoiceSetMixFactor(&g.drv, voice_id, 0.0f, 1, 0);
+	audrvVoiceSetMixFactor(&g.drv, voice_id, 1.0f, 1, 1);
+
+	memset(sink->wavebufs, 0, sizeof(sink->wavebufs));
+	for (int b = 0; b < SINK_NUM_BUFS; b++) {
+		AudioDriverWaveBuf *wb = &sink->wavebufs[b];
+		wb->data_raw =
+		    (uint8_t *)mempool + b * SINK_BUF_FRAMES * 2 * sizeof(int16_t);
+		wb->size = SINK_BUF_FRAMES * 2 * sizeof(int16_t);
+		wb->start_sample_offset = 0;
+		wb->end_sample_offset = SINK_BUF_FRAMES;
+		wb->state = AudioDriverWaveBufState_Free;
+	}
+
+	g.sinks.push_back(sink);
+	mutexUnlock(&g.mutex);
+	return sink;
+}
+
+void nx_audio_sink_detach(nx_audio_sink_t *sink) {
+	mutexLock(&g.mutex);
+	for (auto it = g.sinks.begin(); it != g.sinks.end(); ++it) {
+		if (*it == sink) {
+			g.sinks.erase(it);
+			break;
+		}
+	}
+	if (g.initialized) {
+		audrvVoiceStop(&g.drv, sink->voice_id);
+		audrvVoiceDrop(&g.drv, sink->voice_id);
+		audrvUpdate(&g.drv);
+		audrvMemPoolDetach(&g.drv, sink->mempool_id);
+		audrvMemPoolRemove(&g.drv, sink->mempool_id);
+	}
+	g.voice_used[sink->voice_id] = false;
+	if (g.sinks.empty())
+		global_exit();
+	mutexUnlock(&g.mutex);
+	free(sink->mempool);
+	nx_audio_graph_unref(sink->graph);
+	delete sink;
+}

--- a/source/audio-sink.h
+++ b/source/audio-sink.h
@@ -1,0 +1,23 @@
+#pragma once
+// Platform audio output sink for online AudioContexts.
+//
+// The sink owns a real-time render thread that periodically pulls PCM from the
+// audio graph (nx_audio_graph_render_s16) and submits it to the platform audio
+// output. Two implementations exist:
+//   - source/audio-sink-audren.cc — Nintendo Switch (libnx audren streaming
+//     wavebufs). Compiled into the device runtime via the Makefile glob.
+//   - packages/runtime/test/src/audio-sink.cc — host nxjs-test (wall-clock
+//     paced consumer thread; output is discarded).
+#include <stddef.h>
+
+struct nx_audio_graph;
+typedef struct nx_audio_sink nx_audio_sink_t;
+
+// Attach `graph` to the platform audio output (takes a graph ref for the
+// lifetime of the sink). Returns NULL and sets `*err` to a static string on
+// failure.
+nx_audio_sink_t *nx_audio_sink_attach(nx_audio_graph *graph, const char **err);
+
+// Stop feeding the graph to the output and release the sink (drops the graph
+// ref). Idempotent per sink pointer is NOT required — call exactly once.
+void nx_audio_sink_detach(nx_audio_sink_t *sink);

--- a/source/audio.cc
+++ b/source/audio.cc
@@ -1,10 +1,25 @@
+// Web Audio API native bindings.
+//
+// This module is PORTABLE (compiled into both the device runtime and the host
+// nxjs-test binary): the graph processing lives in audio-graph.cc and the
+// platform output behind audio-sink.h (audren on device, a paced thread on
+// host). Decoding (decodeAudioData) uses the vendored dr_mp3 / dr_wav /
+// stb_vorbis single-header libraries on the libuv threadpool.
+//
+// JS object model: AudioContext/OfflineAudioContext wrap an nx_audio_ctx_t
+// (graph + optional sink); every AudioNode wraps an nx_audio_node* directly.
+// AudioParams are addressed as (node, param index) pairs — they have no native
+// wrapper (the JS AudioParam object retains its AudioNode, which keeps the
+// native node alive).
+#include "audio.h"
 #include "async.h"
+#include "audio-graph.h"
+#include "audio-sink.h"
 #include "error.h"
-#include "types.h"
 #include "util.h"
-#include <malloc.h>
+#include "wrap.h"
+#include <stdlib.h>
 #include <string.h>
-#include <switch.h>
 
 #define DR_MP3_IMPLEMENTATION
 #define DR_MP3_NO_STDIO
@@ -25,221 +40,541 @@ extern "C" {
 
 using namespace v8;
 
-#define AUDIO_SAMPLE_RATE 48000
-#define AUDIO_NUM_VOICES 24
-#define AUDIO_ALIGN 0x1000
-#define ALIGN_UP(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
+// Decoded channel cap — bounds memory for absurd channel counts. Web Audio
+// allows up to 32 channels; files beyond that are truncated.
+#define NX_AUDIO_DECODE_MAX_CHANNELS 32
 
 namespace {
 
-bool audio_initialized = false;
-AudioDriver audio_driver;
-bool voice_in_use[AUDIO_NUM_VOICES];
-void *audio_mempool_ptr = NULL;
-size_t audio_mempool_size = 0;
-int audio_mempool_id = -1;
-AudioDriverWaveBuf voice_wavebufs[AUDIO_NUM_VOICES];
+// An online or offline audio context: the graph plus (for online contexts)
+// the platform output sink.
+typedef struct {
+	nx_audio_graph *graph;
+	nx_audio_sink_t *sink; // NULL for offline contexts / after close()
+} nx_audio_ctx_t;
 
-const AudioRendererConfig arConfig = {
-    .output_rate = AudioRendererOutputRate_48kHz,
-    .num_voices = AUDIO_NUM_VOICES,
-    .num_effects = 0,
-    .num_sinks = 1,
-    .num_mix_objs = 1,
-    .num_mix_buffers = 2,
+void free_audio_ctx(nx_audio_ctx_t *ctx) {
+	if (ctx->sink) {
+		nx_audio_sink_detach(ctx->sink);
+		ctx->sink = NULL;
+	}
+	nx_audio_graph_unref(ctx->graph);
+	delete ctx;
+}
+
+nx_audio_ctx_t *get_ctx(Isolate *iso, Local<Value> v) {
+	nx_audio_ctx_t *ctx = nx::Unwrap<nx_audio_ctx_t>(v);
+	if (!ctx)
+		nx_throw(iso, "expected AudioContext handle");
+	return ctx;
+}
+
+nx_audio_node *get_node(Isolate *iso, Local<Value> v) {
+	nx_audio_node *n = nx::Unwrap<nx_audio_node>(v);
+	if (!n)
+		nx_throw(iso, "expected AudioNode handle");
+	return n;
+}
+
+double arg_f64(const FunctionCallbackInfo<Value> &info, int i) {
+	double v = 0;
+	if (!info[i]->NumberValue(info.GetIsolate()->GetCurrentContext()).To(&v))
+		v = 0;
+	return v;
+}
+
+int arg_i32(const FunctionCallbackInfo<Value> &info, int i) {
+	int32_t v = 0;
+	if (!info[i]->Int32Value(info.GetIsolate()->GetCurrentContext()).To(&v))
+		v = 0;
+	return v;
+}
+
+// ---------------------------------------------------------------------------
+// Context lifecycle
+// ---------------------------------------------------------------------------
+
+// audioContextNew(sampleRate, offline) -> handle
+void nx_audio_context_new(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	double sample_rate = arg_f64(info, 0);
+	bool offline = info[1]->BooleanValue(iso);
+	if (!(sample_rate >= 8000 && sample_rate <= 192000)) {
+		iso->ThrowException(Exception::RangeError(
+		    nx_str(iso, "sampleRate must be between 8000 and 192000")));
+		return;
+	}
+	nx_audio_graph *graph = nx_audio_graph_create(sample_rate);
+	nx_audio_sink_t *sink = NULL;
+	if (!offline) {
+		const char *err = NULL;
+		sink = nx_audio_sink_attach(graph, &err);
+		if (!sink) {
+			nx_audio_graph_unref(graph);
+			nx_throw(iso, err ? err : "failed to open audio output");
+			return;
+		}
+	}
+	nx_audio_ctx_t *ctx = new nx_audio_ctx_t{graph, sink};
+	Local<Object> obj = nx::NewWrapped(iso);
+	nx::Wrap<nx_audio_ctx_t>(iso, obj, ctx, free_audio_ctx);
+	info.GetReturnValue().Set(obj);
+}
+
+void nx_audio_context_close(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_ctx_t *ctx = get_ctx(iso, info[0]);
+	if (!ctx)
+		return;
+	if (ctx->sink) {
+		nx_audio_sink_detach(ctx->sink);
+		ctx->sink = NULL;
+	}
+	ctx->graph->closed = true;
+}
+
+void nx_audio_context_suspend(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_ctx_t *ctx = get_ctx(iso, info[0]);
+	if (!ctx)
+		return;
+	nx_audio_graph_set_suspended(ctx->graph, true);
+}
+
+void nx_audio_context_resume(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_ctx_t *ctx = get_ctx(iso, info[0]);
+	if (!ctx)
+		return;
+	nx_audio_graph_set_suspended(ctx->graph, false);
+}
+
+void nx_audio_context_current_time(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_ctx_t *ctx = get_ctx(iso, info[0]);
+	if (!ctx)
+		return;
+	info.GetReturnValue().Set(
+	    Number::New(iso, nx_audio_graph_current_time(ctx->graph)));
+}
+
+// ---------------------------------------------------------------------------
+// Nodes
+// ---------------------------------------------------------------------------
+
+void release_node(nx_audio_node *n) { nx_audio_node_release(n); }
+
+void nx_audio_context_destination(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_ctx_t *ctx = get_ctx(iso, info[0]);
+	if (!ctx)
+		return;
+	// The destination node is graph-owned; the wrapper still holds a graph
+	// ref (released via nx_audio_node_release, which special-cases it).
+	nx_audio_graph_ref(ctx->graph);
+	Local<Object> obj = nx::NewWrapped(iso);
+	nx::Wrap<nx_audio_node>(iso, obj, ctx->graph->destination, release_node);
+	info.GetReturnValue().Set(obj);
+}
+
+// audioNodeNew(ctx, type) -> handle
+void nx_audio_node_new(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_ctx_t *ctx = get_ctx(iso, info[0]);
+	if (!ctx)
+		return;
+	int type = arg_i32(info, 1);
+	if (type < NX_AUDIO_NODE_GAIN || type > NX_AUDIO_NODE_BUFFER_SOURCE) {
+		nx_throw(iso, "invalid AudioNode type");
+		return;
+	}
+	nx_audio_node *n =
+	    nx_audio_node_create(ctx->graph, (nx_audio_node_type)type);
+	Local<Object> obj = nx::NewWrapped(iso);
+	nx::Wrap<nx_audio_node>(iso, obj, n, release_node);
+	info.GetReturnValue().Set(obj);
+}
+
+void nx_audio_node_connect_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *src = get_node(iso, info[0]);
+	nx_audio_node *dst = src ? get_node(iso, info[1]) : NULL;
+	if (!src || !dst)
+		return;
+	if (src->graph != dst->graph) {
+		nx_throw(iso, "cannot connect nodes from different AudioContexts");
+		return;
+	}
+	nx_audio_node_connect(src, dst);
+}
+
+void nx_audio_node_disconnect_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *src = get_node(iso, info[0]);
+	if (!src)
+		return;
+	nx_audio_node *dst = NULL;
+	if (!info[1]->IsUndefined() && !info[1]->IsNull()) {
+		dst = get_node(iso, info[1]);
+		if (!dst)
+			return;
+	}
+	nx_audio_node_disconnect(src, dst);
+}
+
+// ---------------------------------------------------------------------------
+// Params — addressed as (node, index)
+// ---------------------------------------------------------------------------
+
+nx_audio_param *get_param(Isolate *iso,
+                          const FunctionCallbackInfo<Value> &info,
+                          nx_audio_node **node_out) {
+	nx_audio_node *n = get_node(iso, info[0]);
+	if (!n)
+		return NULL;
+	nx_audio_param *p = nx_audio_node_param(n, arg_i32(info, 1));
+	if (!p) {
+		nx_throw(iso, "invalid AudioParam index");
+		return NULL;
+	}
+	*node_out = n;
+	return p;
+}
+
+void nx_audio_param_value_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n;
+	nx_audio_param *p = get_param(iso, info, &n);
+	if (!p)
+		return;
+	info.GetReturnValue().Set(Number::New(iso, nx_audio_param_value(n, p)));
+}
+
+void nx_audio_param_set_value_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n;
+	nx_audio_param *p = get_param(iso, info, &n);
+	if (!p)
+		return;
+	nx_audio_param_set_value(n, p, (float)arg_f64(info, 2));
+}
+
+// audioParamSchedule(node, idx, type, time, value, timeConstant)
+void nx_audio_param_schedule_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n;
+	nx_audio_param *p = get_param(iso, info, &n);
+	if (!p)
+		return;
+	int type = arg_i32(info, 2);
+	if (type < NX_AUDIO_PARAM_SET_VALUE || type > NX_AUDIO_PARAM_SET_TARGET) {
+		nx_throw(iso, "invalid AudioParam event type");
+		return;
+	}
+	nx_audio_param_schedule(n, p, (nx_audio_param_event_type)type,
+	                        arg_f64(info, 3), (float)arg_f64(info, 4),
+	                        arg_f64(info, 5));
+}
+
+// audioParamSetValueCurve(node, idx, curve: Float32Array, startTime, duration)
+void nx_audio_param_set_value_curve_cb(
+    const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n;
+	nx_audio_param *p = get_param(iso, info, &n);
+	if (!p)
+		return;
+	size_t size = 0;
+	uint8_t *buf = NX_GetBufferSource(iso, &size, info[2]);
+	if (!buf) {
+		nx_throw(iso, "expected Float32Array curve");
+		return;
+	}
+	nx_audio_param_set_value_curve(n, p, (const float *)buf,
+	                               size / sizeof(float), arg_f64(info, 3),
+	                               arg_f64(info, 4));
+}
+
+void nx_audio_param_cancel_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n;
+	nx_audio_param *p = get_param(iso, info, &n);
+	if (!p)
+		return;
+	nx_audio_param_cancel(n, p, arg_f64(info, 2));
+}
+
+// ---------------------------------------------------------------------------
+// AudioBufferSourceNode
+// ---------------------------------------------------------------------------
+
+// audioSourceSetBuffer(node, channels: Float32Array[], length, sampleRate)
+//
+// The channel data is NOT copied: the render thread reads the Float32Arrays'
+// backing stores directly (kept alive via shared_ptr<BackingStore>). This is
+// the zero-copy equivalent of the spec's "acquire the content" step.
+void nx_audio_source_set_buffer_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> context = iso->GetCurrentContext();
+	nx_audio_node *n = get_node(iso, info[0]);
+	if (!n)
+		return;
+	if (!info[1]->IsArray()) {
+		nx_throw(iso, "expected array of Float32Array channel data");
+		return;
+	}
+	Local<Array> arr = info[1].As<Array>();
+	uint32_t num_channels = arr->Length();
+	if (num_channels == 0 || num_channels > NX_AUDIO_DECODE_MAX_CHANNELS) {
+		nx_throw(iso, "unsupported number of channels");
+		return;
+	}
+	std::vector<const float *> channels;
+	std::vector<std::shared_ptr<void>> holds;
+	for (uint32_t i = 0; i < num_channels; i++) {
+		Local<Value> v;
+		if (!arr->Get(context, i).ToLocal(&v))
+			return;
+		if (!v->IsFloat32Array()) {
+			nx_throw(iso, "expected Float32Array channel data");
+			return;
+		}
+		Local<Float32Array> ta = v.As<Float32Array>();
+		std::shared_ptr<BackingStore> bs = ta->Buffer()->GetBackingStore();
+		channels.push_back(reinterpret_cast<const float *>(
+		    static_cast<uint8_t *>(bs->Data()) + ta->ByteOffset()));
+		holds.push_back(std::move(bs));
+	}
+	uint32_t length = (uint32_t)arg_f64(info, 2);
+	double sample_rate = arg_f64(info, 3);
+	nx_audio_source_set_buffer(n, channels.data(), (int)num_channels, length,
+	                           sample_rate, std::move(holds));
+}
+
+// audioSourceStart(node, when, offset, duration) — duration < 0 = unlimited
+void nx_audio_source_start_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n = get_node(iso, info[0]);
+	if (!n)
+		return;
+	nx_audio_source_start(n, arg_f64(info, 1), arg_f64(info, 2),
+	                      arg_f64(info, 3));
+}
+
+void nx_audio_source_stop_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n = get_node(iso, info[0]);
+	if (!n)
+		return;
+	nx_audio_source_stop(n, arg_f64(info, 1));
+}
+
+void nx_audio_source_set_loop_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n = get_node(iso, info[0]);
+	if (!n)
+		return;
+	nx_audio_source_set_loop(n, info[1]->BooleanValue(iso), arg_f64(info, 2),
+	                         arg_f64(info, 3));
+}
+
+void nx_audio_source_state_cb(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_audio_node *n = get_node(iso, info[0]);
+	if (!n)
+		return;
+	info.GetReturnValue().Set(
+	    Integer::New(iso, nx_audio_source_playback_state(n)));
+}
+
+// ---------------------------------------------------------------------------
+// decodeAudioData
+// ---------------------------------------------------------------------------
+
+enum AudioFormat {
+	AUDIO_FORMAT_UNKNOWN,
+	AUDIO_FORMAT_MP3,
+	AUDIO_FORMAT_WAV,
+	AUDIO_FORMAT_OGG,
 };
 
-// ---- async decode ----
-typedef struct {
-	const char *err_str;
-	uint8_t *input;
-	size_t input_size;
-	char *mime_type; // owned copy
-	int16_t *pcm_data;
-	uint32_t sample_rate;
-	uint32_t channels;
-	uint64_t total_samples;
-	Global<Value> buffer_val;
-} decode_audio_t;
+AudioFormat identify_audio_format(const uint8_t *data, size_t size) {
+	if (size >= 12 && !memcmp(data, "RIFF", 4) && !memcmp(data + 8, "WAVE", 4))
+		return AUDIO_FORMAT_WAV;
+	if (size >= 4 && !memcmp(data, "OggS", 4))
+		return AUDIO_FORMAT_OGG;
+	if (size >= 3 && !memcmp(data, "ID3", 3))
+		return AUDIO_FORMAT_MP3;
+	// MPEG audio frame sync: 11 set bits.
+	if (size >= 2 && data[0] == 0xFF && (data[1] & 0xE0) == 0xE0)
+		return AUDIO_FORMAT_MP3;
+	return AUDIO_FORMAT_UNKNOWN;
+}
+
+struct decode_audio_t {
+	const char *err_str = nullptr;
+	uint8_t *input = nullptr;
+	size_t input_size = 0;
+	Global<Value> buffer_val; // pins the input ArrayBuffer during decode
+	float *channels[NX_AUDIO_DECODE_MAX_CHANNELS] = {};
+	int num_channels = 0;
+	uint32_t length = 0; // frames
+	uint32_t sample_rate = 0;
+};
+
+// Split interleaved f32 frames into per-channel malloc'd planar arrays.
+// Returns false on allocation failure (frees what it allocated).
+bool deinterleave(decode_audio_t *data, const float *frames, uint64_t count,
+                  int channels) {
+	if (channels > NX_AUDIO_DECODE_MAX_CHANNELS)
+		channels = NX_AUDIO_DECODE_MAX_CHANNELS;
+	for (int c = 0; c < channels; c++) {
+		data->channels[c] = (float *)malloc(count * sizeof(float));
+		if (!data->channels[c]) {
+			for (int j = 0; j < c; j++) {
+				free(data->channels[j]);
+				data->channels[j] = nullptr;
+			}
+			return false;
+		}
+	}
+	for (uint64_t i = 0; i < count; i++)
+		for (int c = 0; c < channels; c++)
+			data->channels[c][i] = frames[i * data->num_channels + c];
+	return true;
+}
 
 void decode_audio_work(nx_work_t *req) {
 	decode_audio_t *data = (decode_audio_t *)req->data;
-	if (!strcmp(data->mime_type, "audio/mpeg") ||
-	    !strcmp(data->mime_type, "audio/mp3")) {
+	AudioFormat format = identify_audio_format(data->input, data->input_size);
+	if (format == AUDIO_FORMAT_MP3) {
 		drmp3_config cfg;
 		drmp3_uint64 frame_count;
-		drmp3_int16 *frames = drmp3_open_memory_and_read_pcm_frames_s16(
+		float *frames = drmp3_open_memory_and_read_pcm_frames_f32(
 		    data->input, data->input_size, &cfg, &frame_count, NULL);
 		if (!frames) {
 			data->err_str = "Failed to decode MP3";
 			return;
 		}
-		data->pcm_data = frames;
-		data->sample_rate = cfg.channels > 0 ? cfg.sampleRate : 44100;
-		data->channels = cfg.channels;
-		data->total_samples = frame_count;
-	} else if (!strcmp(data->mime_type, "audio/wav") ||
-	           !strcmp(data->mime_type, "audio/wave") ||
-	           !strcmp(data->mime_type, "audio/x-wav")) {
+		data->num_channels = (int)cfg.channels;
+		data->sample_rate = cfg.sampleRate;
+		data->length = (uint32_t)frame_count;
+		if (!deinterleave(data, frames, frame_count, (int)cfg.channels))
+			data->err_str = "Out of memory decoding MP3";
+		drmp3_free(frames, NULL);
+	} else if (format == AUDIO_FORMAT_WAV) {
 		drwav wav;
 		if (!drwav_init_memory(&wav, data->input, data->input_size, NULL)) {
 			data->err_str = "Failed to decode WAV";
 			return;
 		}
 		drwav_uint64 frame_count = wav.totalPCMFrameCount;
-		int16_t *frames =
-		    (int16_t *)malloc(frame_count * wav.channels * sizeof(int16_t));
+		float *frames =
+		    (float *)malloc(frame_count * wav.channels * sizeof(float));
 		if (!frames) {
 			drwav_uninit(&wav);
 			data->err_str = "Out of memory decoding WAV";
 			return;
 		}
-		drwav_read_pcm_frames_s16(&wav, frame_count, frames);
-		data->pcm_data = frames;
+		drwav_read_pcm_frames_f32(&wav, frame_count, frames);
+		data->num_channels = (int)wav.channels;
 		data->sample_rate = wav.sampleRate;
-		data->channels = wav.channels;
-		data->total_samples = frame_count;
+		data->length = (uint32_t)frame_count;
+		if (!deinterleave(data, frames, frame_count, (int)wav.channels))
+			data->err_str = "Out of memory decoding WAV";
+		free(frames);
 		drwav_uninit(&wav);
-	} else if (!strcmp(data->mime_type, "audio/ogg") ||
-	           !strcmp(data->mime_type, "audio/vorbis")) {
-		int channels, sample_rate;
-		short *output;
-		int samples = stb_vorbis_decode_memory(data->input,
-		                                       (int)data->input_size, &channels,
-		                                       &sample_rate, &output);
-		if (samples < 0) {
+	} else if (format == AUDIO_FORMAT_OGG) {
+		int verr = 0;
+		stb_vorbis *v = stb_vorbis_open_memory(data->input,
+		                                       (int)data->input_size, &verr,
+		                                       NULL);
+		if (!v) {
 			data->err_str = "Failed to decode OGG Vorbis";
 			return;
 		}
-		data->pcm_data = output;
-		data->sample_rate = sample_rate;
-		data->channels = channels;
-		data->total_samples = samples;
+		stb_vorbis_info vi = stb_vorbis_get_info(v);
+		uint32_t total = stb_vorbis_stream_length_in_samples(v);
+		int channels = vi.channels;
+		if (channels > NX_AUDIO_DECODE_MAX_CHANNELS)
+			channels = NX_AUDIO_DECODE_MAX_CHANNELS;
+		data->num_channels = channels;
+		data->sample_rate = vi.sample_rate;
+		data->length = total;
+		bool oom = false;
+		for (int c = 0; c < channels; c++) {
+			data->channels[c] = (float *)malloc((size_t)total * sizeof(float));
+			if (!data->channels[c]) {
+				oom = true;
+				break;
+			}
+		}
+		if (oom) {
+			for (int c = 0; c < channels; c++) {
+				free(data->channels[c]);
+				data->channels[c] = nullptr;
+			}
+			stb_vorbis_close(v);
+			data->err_str = "Out of memory decoding OGG Vorbis";
+			return;
+		}
+		// stb_vorbis fills planar output buffers directly.
+		float *bufs[NX_AUDIO_DECODE_MAX_CHANNELS];
+		uint32_t offset = 0;
+		while (offset < total) {
+			for (int c = 0; c < channels; c++)
+				bufs[c] = data->channels[c] + offset;
+			int got = stb_vorbis_get_samples_float(v, channels, bufs,
+			                                       (int)(total - offset));
+			if (got <= 0)
+				break;
+			offset += (uint32_t)got;
+		}
+		data->length = offset;
+		stb_vorbis_close(v);
 	} else {
-		data->err_str = "Unsupported audio MIME type";
+		data->err_str = "Unsupported audio format";
 	}
+	if (!data->err_str && (data->length == 0 || data->num_channels == 0))
+		data->err_str = "Audio file contains no audio data";
 }
 
 MaybeLocal<Value> decode_audio_after(Isolate *iso, nx_work_t *req) {
 	Local<Context> context = iso->GetCurrentContext();
 	decode_audio_t *data = (decode_audio_t *)req->data;
 	data->buffer_val.Reset();
-	free(data->mime_type);
-	data->mime_type = nullptr;
-
 	if (data->err_str) {
+		for (int c = 0; c < NX_AUDIO_DECODE_MAX_CHANNELS; c++) {
+			free(data->channels[c]);
+			data->channels[c] = nullptr;
+		}
 		iso->ThrowException(Exception::Error(nx_str(iso, data->err_str)));
-		if (data->pcm_data)
-			free(data->pcm_data);
-		data->pcm_data = nullptr;
 		return MaybeLocal<Value>();
 	}
-
-	size_t pcm_byte_size =
-	    data->total_samples * data->channels * sizeof(int16_t);
-	size_t aligned_size = ALIGN_UP(pcm_byte_size, AUDIO_ALIGN);
-	void *aligned_buf = memalign(AUDIO_ALIGN, aligned_size);
-	if (!aligned_buf) {
-		if (data->pcm_data)
-			free(data->pcm_data);
-		data->pcm_data = nullptr;
-		nx_throw(iso, "Failed to allocate aligned PCM buffer");
-		return MaybeLocal<Value>();
+	int channels = data->num_channels > NX_AUDIO_DECODE_MAX_CHANNELS
+	                   ? NX_AUDIO_DECODE_MAX_CHANNELS
+	                   : data->num_channels;
+	Local<Array> channel_data = Array::New(iso, channels);
+	for (int c = 0; c < channels; c++) {
+		std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+		    data->channels[c], (size_t)data->length * sizeof(float),
+		    [](void *p, size_t, void *) { free(p); }, nullptr);
+		data->channels[c] = nullptr; // ownership moved to the ArrayBuffer
+		Local<ArrayBuffer> ab = ArrayBuffer::New(iso, std::move(bs));
+		channel_data->Set(context, c, ab).Check();
 	}
-	memcpy(aligned_buf, data->pcm_data, pcm_byte_size);
-	memset((uint8_t *)aligned_buf + pcm_byte_size, 0,
-	       aligned_size - pcm_byte_size);
-	armDCacheFlush(aligned_buf, aligned_size);
-	if (data->pcm_data)
-		free(data->pcm_data);
-	data->pcm_data = nullptr;
-
-	std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
-	    aligned_buf, aligned_size,
-	    [](void *p, size_t, void *) { free(p); }, nullptr);
-	Local<ArrayBuffer> ab = ArrayBuffer::New(iso, std::move(bs));
-
 	Local<Object> result = Object::New(iso);
-	result->Set(context, nx_str(iso, "pcmData"), ab).Check();
+	result->Set(context, nx_str(iso, "channelData"), channel_data).Check();
+	result->Set(context, nx_str(iso, "length"),
+	            Number::New(iso, (double)data->length))
+	    .Check();
 	result->Set(context, nx_str(iso, "sampleRate"),
 	            Integer::NewFromUnsigned(iso, data->sample_rate))
-	    .Check();
-	result->Set(context, nx_str(iso, "channels"),
-	            Integer::NewFromUnsigned(iso, data->channels))
-	    .Check();
-	result->Set(context, nx_str(iso, "samples"),
-	            Number::New(iso, (double)data->total_samples))
-	    .Check();
-	result->Set(context, nx_str(iso, "byteLength"),
-	            Number::New(iso, (double)pcm_byte_size))
 	    .Check();
 	return result.As<Value>();
 }
 
-void nx_audio_init(const FunctionCallbackInfo<Value> &info) {
-	Isolate *iso = info.GetIsolate();
-	if (audio_initialized)
-		return;
-	Result rc = audrenInitialize(&arConfig);
-	if (R_FAILED(rc)) {
-		nx_throw_libnx_error(iso, rc, "audrenInitialize");
-		return;
-	}
-	rc = audrvCreate(&audio_driver, &arConfig, 2);
-	if (R_FAILED(rc)) {
-		audrenExit();
-		nx_throw_libnx_error(iso, rc, "audrvCreate");
-		return;
-	}
-	audio_mempool_size = ALIGN_UP(1024 * 1024, AUDIO_ALIGN);
-	audio_mempool_ptr = memalign(AUDIO_ALIGN, audio_mempool_size);
-	if (!audio_mempool_ptr) {
-		audrvClose(&audio_driver);
-		audrenExit();
-		nx_throw(iso, "Failed to allocate audio mempool");
-		return;
-	}
-	memset(audio_mempool_ptr, 0, audio_mempool_size);
-	armDCacheFlush(audio_mempool_ptr, audio_mempool_size);
-	audio_mempool_id =
-	    audrvMemPoolAdd(&audio_driver, audio_mempool_ptr, audio_mempool_size);
-	audrvMemPoolAttach(&audio_driver, audio_mempool_id);
-	static const u8 sink_channels[] = {0, 1};
-	audrvDeviceSinkAdd(&audio_driver, AUDREN_DEFAULT_DEVICE_NAME, 2,
-	                   sink_channels);
-	rc = audrenStartAudioRenderer();
-	if (R_FAILED(rc)) {
-		audrvClose(&audio_driver);
-		audrenExit();
-		nx_throw_libnx_error(iso, rc, "audrenStartAudioRenderer");
-		return;
-	}
-	audrvUpdate(&audio_driver);
-	memset(voice_in_use, 0, sizeof(voice_in_use));
-	memset(voice_wavebufs, 0, sizeof(voice_wavebufs));
-	audio_initialized = true;
-}
-
-void nx_audio_exit(const FunctionCallbackInfo<Value> &info) {
-	if (!audio_initialized)
-		return;
-	for (int i = 0; i < AUDIO_NUM_VOICES; i++)
-		if (voice_in_use[i])
-			audrvVoiceStop(&audio_driver, i);
-	audrvUpdate(&audio_driver);
-	if (audio_mempool_id >= 0) {
-		audrvMemPoolDetach(&audio_driver, audio_mempool_id);
-		audrvMemPoolRemove(&audio_driver, audio_mempool_id);
-	}
-	audrvClose(&audio_driver);
-	audrenExit();
-	if (audio_mempool_ptr) {
-		free(audio_mempool_ptr);
-		audio_mempool_ptr = NULL;
-	}
-	audio_initialized = false;
-}
-
+// audioDecode(buf) -> Promise<{ channelData: ArrayBuffer[], length, sampleRate }>
 void nx_audio_decode(const FunctionCallbackInfo<Value> &info) {
 	Isolate *iso = info.GetIsolate();
 	size_t size = 0;
@@ -248,193 +583,117 @@ void nx_audio_decode(const FunctionCallbackInfo<Value> &info) {
 		nx_throw(iso, "expected ArrayBuffer");
 		return;
 	}
-	String::Utf8Value mime(iso, info[1]);
-	if (!*mime)
-		return;
-	nx_work_t *req = new nx_work_t();
-	decode_audio_t *data = new decode_audio_t();
-	req->data = data;
+	NX_INIT_WORK_T_CPP(decode_audio_t);
 	data->buffer_val.Reset(iso, info[0]);
 	data->input = buf;
 	data->input_size = size;
-	data->mime_type = strdup(*mime);
 	info.GetReturnValue().Set(
 	    nx_queue_async(iso, req, decode_audio_work, decode_audio_after));
 }
 
-// Argument helpers.
-int arg_i32(const FunctionCallbackInfo<Value> &info, int i) {
-	int32_t v = 0;
-	if (!info[i]
-	         ->Int32Value(info.GetIsolate()->GetCurrentContext())
-	         .To(&v)) {
-		v = 0; // conversion threw/failed; default to 0
+// ---------------------------------------------------------------------------
+// OfflineAudioContext rendering
+// ---------------------------------------------------------------------------
+
+struct offline_render_t {
+	const char *err_str = nullptr;
+	nx_audio_graph *graph = nullptr; // ref held for the duration of the render
+	Global<Value> ctx_val;           // pins the JS context wrapper
+	float *channels[NX_AUDIO_CHANNELS] = {};
+	int num_channels = 0;
+	uint32_t length = 0;
+	~offline_render_t() {
+		if (graph)
+			nx_audio_graph_unref(graph);
 	}
-	return v;
-}
-double arg_f64(const FunctionCallbackInfo<Value> &info, int i) {
-	double v = 0;
-	if (!info[i]
-	         ->NumberValue(info.GetIsolate()->GetCurrentContext())
-	         .To(&v)) {
-		v = 0; // conversion threw/failed; default to 0
-	}
-	return v;
+};
+
+void offline_render_work(nx_work_t *req) {
+	offline_render_t *data = (offline_render_t *)req->data;
+	nx_audio_graph_render_offline(data->graph, data->channels,
+	                              data->num_channels, data->length);
 }
 
-void nx_audio_play(const FunctionCallbackInfo<Value> &info) {
+MaybeLocal<Value> offline_render_after(Isolate *iso, nx_work_t *req) {
+	Local<Context> context = iso->GetCurrentContext();
+	offline_render_t *data = (offline_render_t *)req->data;
+	data->ctx_val.Reset();
+	Local<Array> channel_data = Array::New(iso, data->num_channels);
+	for (int c = 0; c < data->num_channels; c++) {
+		std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+		    data->channels[c], (size_t)data->length * sizeof(float),
+		    [](void *p, size_t, void *) { free(p); }, nullptr);
+		data->channels[c] = nullptr;
+		Local<ArrayBuffer> ab = ArrayBuffer::New(iso, std::move(bs));
+		channel_data->Set(context, c, ab).Check();
+	}
+	return channel_data.As<Value>();
+}
+
+// audioOfflineRender(ctx, numberOfChannels, length) -> Promise<ArrayBuffer[]>
+void nx_audio_offline_render(const FunctionCallbackInfo<Value> &info) {
 	Isolate *iso = info.GetIsolate();
-	if (!audio_initialized) {
-		nx_throw(iso, "Audio not initialized");
+	nx_audio_ctx_t *ctx = get_ctx(iso, info[0]);
+	if (!ctx)
+		return;
+	int num_channels = arg_i32(info, 1);
+	uint32_t length = (uint32_t)arg_f64(info, 2);
+	if (num_channels < 1 || num_channels > NX_AUDIO_CHANNELS) {
+		iso->ThrowException(Exception::RangeError(
+		    nx_str(iso, "numberOfChannels must be 1 or 2")));
 		return;
 	}
-	size_t pcm_size = 0;
-	uint8_t *pcm_data = NX_GetBufferSource(iso, &pcm_size, info[0]);
-	if (!pcm_data)
-		return;
-	int voice_id = arg_i32(info, 1);
-	if (voice_id < 0 || voice_id >= AUDIO_NUM_VOICES) {
+	if (length == 0) {
 		iso->ThrowException(
-		    Exception::RangeError(nx_str(iso, "Invalid voice ID")));
+		    Exception::RangeError(nx_str(iso, "length must be at least 1")));
 		return;
 	}
-	double volume = arg_f64(info, 2);
-	bool loop = info[3]->BooleanValue(iso);
-	int32_t sample_rate = arg_i32(info, 4);
-	int32_t channels = arg_i32(info, 5);
-	uint64_t total_samples = (uint64_t)arg_f64(info, 6);
-
-	size_t aligned_size = ALIGN_UP(pcm_size, AUDIO_ALIGN);
-	int pool_id = audrvMemPoolAdd(&audio_driver, pcm_data, aligned_size);
-	if (pool_id < 0) {
-		nx_throw(iso, "Failed to add audio mempool");
-		return;
-	}
-	audrvMemPoolAttach(&audio_driver, pool_id);
-	audrvVoiceInit(&audio_driver, voice_id, channels, PcmFormat_Int16,
-	               sample_rate);
-	audrvVoiceSetDestinationMix(&audio_driver, voice_id, AUDREN_FINAL_MIX_ID);
-	if (channels == 1) {
-		audrvVoiceSetMixFactor(&audio_driver, voice_id, 1.0f, 0, 0);
-		audrvVoiceSetMixFactor(&audio_driver, voice_id, 1.0f, 0, 1);
-	} else {
-		audrvVoiceSetMixFactor(&audio_driver, voice_id, 1.0f, 0, 0);
-		audrvVoiceSetMixFactor(&audio_driver, voice_id, 0.0f, 0, 1);
-		audrvVoiceSetMixFactor(&audio_driver, voice_id, 0.0f, 1, 0);
-		audrvVoiceSetMixFactor(&audio_driver, voice_id, 1.0f, 1, 1);
-	}
-	audrvVoiceSetVolume(&audio_driver, voice_id, (float)volume);
-	AudioDriverWaveBuf *wavebuf = &voice_wavebufs[voice_id];
-	memset(wavebuf, 0, sizeof(AudioDriverWaveBuf));
-	wavebuf->data_raw = pcm_data;
-	wavebuf->size = pcm_size;
-	wavebuf->start_sample_offset = 0;
-	wavebuf->end_sample_offset = total_samples;
-	wavebuf->is_looping = loop;
-	audrvVoiceAddWaveBuf(&audio_driver, voice_id, wavebuf);
-	audrvVoiceStart(&audio_driver, voice_id);
-	audrvUpdate(&audio_driver);
-}
-
-void nx_audio_stop(const FunctionCallbackInfo<Value> &info) {
-	Isolate *iso = info.GetIsolate();
-	if (!audio_initialized)
-		return;
-	int voice_id = arg_i32(info, 0);
-	if (voice_id < 0 || voice_id >= AUDIO_NUM_VOICES) {
-		iso->ThrowException(
-		    Exception::RangeError(nx_str(iso, "Invalid voice ID")));
-		return;
-	}
-	audrvVoiceStop(&audio_driver, voice_id);
-	audrvUpdate(&audio_driver);
-	voice_in_use[voice_id] = false;
-}
-
-void nx_audio_pause(const FunctionCallbackInfo<Value> &info) {
-	Isolate *iso = info.GetIsolate();
-	if (!audio_initialized)
-		return;
-	int voice_id = arg_i32(info, 0);
-	bool paused = info[1]->BooleanValue(iso);
-	audrvVoiceSetPaused(&audio_driver, voice_id, paused);
-	audrvUpdate(&audio_driver);
-}
-
-void nx_audio_set_volume(const FunctionCallbackInfo<Value> &info) {
-	if (!audio_initialized)
-		return;
-	audrvVoiceSetVolume(&audio_driver, arg_i32(info, 0),
-	                    (float)arg_f64(info, 1));
-	audrvUpdate(&audio_driver);
-}
-void nx_audio_set_pitch(const FunctionCallbackInfo<Value> &info) {
-	if (!audio_initialized)
-		return;
-	audrvVoiceSetPitch(&audio_driver, arg_i32(info, 0),
-	                   (float)arg_f64(info, 1));
-	audrvUpdate(&audio_driver);
-}
-void nx_audio_update(const FunctionCallbackInfo<Value> &info) {
-	if (audio_initialized)
-		audrvUpdate(&audio_driver);
-}
-void nx_audio_get_played_samples(const FunctionCallbackInfo<Value> &info) {
-	Isolate *iso = info.GetIsolate();
-	if (!audio_initialized) {
-		info.GetReturnValue().Set(Number::New(iso, 0));
-		return;
-	}
-	u64 count =
-	    audrvVoiceGetPlayedSampleCount(&audio_driver, arg_i32(info, 0));
-	info.GetReturnValue().Set(Number::New(iso, (double)count));
-}
-void nx_audio_alloc_voice(const FunctionCallbackInfo<Value> &info) {
-	Isolate *iso = info.GetIsolate();
-	for (int i = 0; i < AUDIO_NUM_VOICES; i++) {
-		if (!voice_in_use[i]) {
-			voice_in_use[i] = true;
-			info.GetReturnValue().Set(Integer::New(iso, i));
+	NX_INIT_WORK_T_CPP(offline_render_t);
+	data->graph = ctx->graph;
+	nx_audio_graph_ref(ctx->graph);
+	data->ctx_val.Reset(iso, info[0]);
+	data->num_channels = num_channels;
+	data->length = length;
+	for (int c = 0; c < num_channels; c++) {
+		data->channels[c] = (float *)calloc(length, sizeof(float));
+		if (!data->channels[c]) {
+			for (int j = 0; j < c; j++)
+				free(data->channels[j]);
+			req->data_dtor(data);
+			delete req;
+			nx_throw_oom(iso, (size_t)length * sizeof(float));
 			return;
 		}
 	}
-	nx_throw(iso, "No free audio voices");
-}
-void nx_audio_free_voice(const FunctionCallbackInfo<Value> &info) {
-	int voice_id = arg_i32(info, 0);
-	if (voice_id >= 0 && voice_id < AUDIO_NUM_VOICES) {
-		if (audio_initialized) {
-			audrvVoiceStop(&audio_driver, voice_id);
-			audrvUpdate(&audio_driver);
-		}
-		voice_in_use[voice_id] = false;
-	}
-}
-void nx_audio_is_playing(const FunctionCallbackInfo<Value> &info) {
-	Isolate *iso = info.GetIsolate();
-	if (!audio_initialized) {
-		info.GetReturnValue().Set(false);
-		return;
-	}
-	AudioDriverWaveBuf *wb = &voice_wavebufs[arg_i32(info, 0)];
 	info.GetReturnValue().Set(
-	    Boolean::New(iso, wb->state == AudioDriverWaveBufState_Playing));
+	    nx_queue_async(iso, req, offline_render_work, offline_render_after));
 }
 
 } // namespace
 
 void nx_init_audio(Isolate *iso, Local<Object> init_obj) {
-	NX_SET_FUNC(init_obj, "audioInit", nx_audio_init);
-	NX_SET_FUNC(init_obj, "audioExit", nx_audio_exit);
+	NX_SET_FUNC(init_obj, "audioContextNew", nx_audio_context_new);
+	NX_SET_FUNC(init_obj, "audioContextClose", nx_audio_context_close);
+	NX_SET_FUNC(init_obj, "audioContextSuspend", nx_audio_context_suspend);
+	NX_SET_FUNC(init_obj, "audioContextResume", nx_audio_context_resume);
+	NX_SET_FUNC(init_obj, "audioContextCurrentTime",
+	            nx_audio_context_current_time);
+	NX_SET_FUNC(init_obj, "audioContextDestination",
+	            nx_audio_context_destination);
+	NX_SET_FUNC(init_obj, "audioNodeNew", nx_audio_node_new);
+	NX_SET_FUNC(init_obj, "audioNodeConnect", nx_audio_node_connect_cb);
+	NX_SET_FUNC(init_obj, "audioNodeDisconnect", nx_audio_node_disconnect_cb);
+	NX_SET_FUNC(init_obj, "audioParamValue", nx_audio_param_value_cb);
+	NX_SET_FUNC(init_obj, "audioParamSetValue", nx_audio_param_set_value_cb);
+	NX_SET_FUNC(init_obj, "audioParamSchedule", nx_audio_param_schedule_cb);
+	NX_SET_FUNC(init_obj, "audioParamSetValueCurve",
+	            nx_audio_param_set_value_curve_cb);
+	NX_SET_FUNC(init_obj, "audioParamCancel", nx_audio_param_cancel_cb);
+	NX_SET_FUNC(init_obj, "audioSourceSetBuffer", nx_audio_source_set_buffer_cb);
+	NX_SET_FUNC(init_obj, "audioSourceStart", nx_audio_source_start_cb);
+	NX_SET_FUNC(init_obj, "audioSourceStop", nx_audio_source_stop_cb);
+	NX_SET_FUNC(init_obj, "audioSourceSetLoop", nx_audio_source_set_loop_cb);
+	NX_SET_FUNC(init_obj, "audioSourceState", nx_audio_source_state_cb);
 	NX_SET_FUNC(init_obj, "audioDecode", nx_audio_decode);
-	NX_SET_FUNC(init_obj, "audioPlay", nx_audio_play);
-	NX_SET_FUNC(init_obj, "audioStop", nx_audio_stop);
-	NX_SET_FUNC(init_obj, "audioPause", nx_audio_pause);
-	NX_SET_FUNC(init_obj, "audioSetVolume", nx_audio_set_volume);
-	NX_SET_FUNC(init_obj, "audioSetPitch", nx_audio_set_pitch);
-	NX_SET_FUNC(init_obj, "audioUpdate", nx_audio_update);
-	NX_SET_FUNC(init_obj, "audioGetPlayedSamples", nx_audio_get_played_samples);
-	NX_SET_FUNC(init_obj, "audioAllocVoice", nx_audio_alloc_voice);
-	NX_SET_FUNC(init_obj, "audioFreeVoice", nx_audio_free_voice);
-	NX_SET_FUNC(init_obj, "audioIsPlaying", nx_audio_is_playing);
+	NX_SET_FUNC(init_obj, "audioOfflineRender", nx_audio_offline_render);
 }

--- a/source/audio.cc
+++ b/source/audio.cc
@@ -130,6 +130,10 @@ void nx_audio_context_close(const FunctionCallbackInfo<Value> &info) {
 		nx_audio_sink_detach(ctx->sink);
 		ctx->sink = NULL;
 	}
+	// `closed` is read by render threads under the graph mutex, so the write
+	// must be guarded too (for an online context the sink is already detached
+	// at this point, but an OfflineAudioContext render may be in flight).
+	std::lock_guard<std::mutex> lock(ctx->graph->mutex);
 	ctx->graph->closed = true;
 }
 
@@ -331,6 +335,7 @@ void nx_audio_source_set_buffer_cb(const FunctionCallbackInfo<Value> &info) {
 	}
 	std::vector<const float *> channels;
 	std::vector<std::shared_ptr<void>> holds;
+	uint32_t length = (uint32_t)arg_f64(info, 2);
 	for (uint32_t i = 0; i < num_channels; i++) {
 		Local<Value> v;
 		if (!arr->Get(context, i).ToLocal(&v))
@@ -340,12 +345,17 @@ void nx_audio_source_set_buffer_cb(const FunctionCallbackInfo<Value> &info) {
 			return;
 		}
 		Local<Float32Array> ta = v.As<Float32Array>();
+		// Never trust the `length` argument beyond what the typed arrays
+		// actually contain — the render thread reads the backing stores
+		// directly, so an oversized `length` would be an OOB read.
+		uint32_t elements = (uint32_t)(ta->ByteLength() / sizeof(float));
+		if (elements < length)
+			length = elements;
 		std::shared_ptr<BackingStore> bs = ta->Buffer()->GetBackingStore();
 		channels.push_back(reinterpret_cast<const float *>(
 		    static_cast<uint8_t *>(bs->Data()) + ta->ByteOffset()));
 		holds.push_back(std::move(bs));
 	}
-	uint32_t length = (uint32_t)arg_f64(info, 2);
 	double sample_rate = arg_f64(info, 3);
 	nx_audio_source_set_buffer(n, channels.data(), (int)num_channels, length,
 	                           sample_rate, std::move(holds));

--- a/source/audio.h
+++ b/source/audio.h
@@ -1,4 +1,4 @@
 #pragma once
 #include "types.h"
 
-void nx_init_audio(JSContext *ctx, JSValueConst init_obj);
+void nx_init_audio(v8::Isolate *iso, v8::Local<v8::Object> init_obj);


### PR DESCRIPTION
## Summary

Implements proper Web Audio API support, superseding (and re-implemented from scratch versus) #79. Closes #45.

### Architecture

- **Native graph engine** (`source/audio-graph.cc`/`.h`) — portable C++ (no V8/libnx/libuv) that processes the audio node graph in 128-frame render quanta on a dedicated real-time thread, exactly like browsers. Compiled into **both** the device runtime and the host `nxjs-test` binary, so they can never drift.
- **Platform sinks** behind `source/audio-sink.h`:
  - `source/audio-sink-audren.cc` (device): one shared audren session + `AudioDriver` + render thread; each running `AudioContext` gets its own voice on the final mix, streamed via double-buffered wavebufs (2 × 1024 frames ≈ 43 ms total latency).
  - `packages/runtime/test/src/audio-sink.cc` (host): wall-clock paced consumer thread, so `currentTime` advances in real time during conformance tests.
- **V8 bindings** (`source/audio.cc`, now fully portable): context/node/param ops, plus `decodeAudioData` (MP3/WAV/OGG **sniffed by magic bytes**, decoded to planar f32 on the libuv thread pool) and `OfflineAudioContext` rendering (also on the thread pool). AudioBuffer channel data is **zero-copy**: the render thread reads the `Float32Array` backing stores directly (pinned via `shared_ptr<BackingStore>`).

### API surface (game-focused core)

`AudioContext`, `OfflineAudioContext`, `BaseAudioContext`, `AudioBuffer`, `AudioBufferSourceNode` (loop/loopStart/loopEnd, playbackRate, detune, start offset/duration, `ended` event), `GainNode`, `StereoPannerNode` (spec equal-power algorithm, with correct mono-vs-stereo input behavior), `AudioDestinationNode`, `AudioParam` with the full automation timeline (`setValueAtTime`, `linearRampToValueAtTime`, `exponentialRampToValueAtTime`, `setTargetAtTime`, `setValueCurveAtTime`, `cancelScheduledValues`), `OfflineAudioCompletionEvent`.

### Audio element rebased

The `Audio` (HTMLAudioElement-like) class is re-implemented on top of the new engine (shared `AudioContext` + per-element `GainNode` + `AudioBufferSourceNode`), deleting the old per-voice audren path and its 13 `$` bindings.

### Testing

- **`fixtures/webaudio.ts`** — 103 TAP assertions, all rendering through `OfflineAudioContext` for deterministic output, **passing assertion-for-assertion against Chrome** in the conformance harness: buffer semantics, sample-accurate playback/offset/duration/delayed start, looping, playbackRate, all five automation event types, panning (mono + stereo), downmix, fan-in summing, `ended`/`complete` events, `decodeAudioData` of a WAV generated in JS (including ArrayBuffer detach), and error types (`InvalidStateError`/`NotSupportedError`/`IndexSizeError`/`InvalidAccessError`/`RangeError` matching Chrome by `err.name`).
- **On-device** (fat NRO on real hardware): 15/15 assertions passing — offline render correctness, decode, real-time `currentTime` advance, suspend freezing time, audible playback with gain fade + pan sweep, `Audio` element load/play/ended.

### Example app

`apps/web-audio` — interactive synth demo (all sounds generated procedurally into AudioBuffers; no asset files).

### Notable engine limitations (documented)

- Internal buses are stereo; buffers with >2 channels mix using the first two.
- `OfflineAudioContext` supports 1–2 channels; `suspend(time)`/`resume()` on offline contexts are not implemented.
- `decodeAudioData` does not resample to the context rate (playback-time resampling instead).
- No `AudioParam` connections (`node.connect(param)` throws `InvalidAccessError`).