### PR TITLE
Fix drawImage() type confusion between wrapped Canvas and Image sources

### DIFF
--- a/.changeset/canvas-image-type-confusion.md
+++ b/.changeset/canvas-image-type-confusion.md
@@ -1,0 +1,16 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: `drawImage()` type confusion between wrapped Canvas and Image sources
+
+All wrapped native objects share one ObjectTemplate, so `drawImage()`
+duck-typed every source as an `nx_image_t` — a canvas source aliased its
+`surface_dirty`/`gpu` flags with the image's `cached_sk_image` slot, turning
+a bool into a dereferenced pointer (a crash in the console present path,
+which draws the terminal canvas every frame in console-only apps). Both
+structs now carry a leading magic discriminator validated by
+`nx_get_image()`/`nx_get_canvas()`, and canvas sources are drawn through the
+proper `SkSurface::makeImageSnapshot()` path (which keeps a stable SkImage
+identity while the surface is unchanged, so the GPU texture cache stays
+effective).

--- a/source/canvas.cc
+++ b/source/canvas.cc
@@ -1857,6 +1857,7 @@ void nx_canvas_new(const FunctionCallbackInfo<Value> &info) {
 		return;
 	}
 	nx_canvas_t *canvas = new nx_canvas_t();
+	canvas->magic = NX_CANVAS_MAGIC;
 	canvas->width = width;
 	canvas->height = height;
 	canvas->data = buffer;
@@ -2321,10 +2322,17 @@ void nx_canvas_context_2d_draw_image(const FunctionCallbackInfo<Value> &info) {
 		source_h = img->height;
 	} else {
 		nx_canvas_t *canvas = nx_get_canvas(iso, info[0]);
-		if (!canvas || !canvas->surface) {
+		if (!canvas) {
 			nx_throw(iso, "Image or Canvas expected");
 			return;
 		}
+		// A canvas that has never been drawn to has no surface yet — it is
+		// fully transparent, so drawing it is a no-op.
+		if (!canvas->surface)
+			return;
+		// makeImageSnapshot() returns the SAME SkImage (stable uniqueID)
+		// while the surface is unchanged, so Ganesh's texture cache stays
+		// effective across repeated draws of a static canvas.
 		image = canvas->surface->makeImageSnapshot();
 		source_w = canvas->width;
 		source_h = canvas->height;
@@ -2705,7 +2713,13 @@ bool nx_resolve_round_rect_radii(Isolate *iso, Local<Value> radii,
 
 nx_canvas_t *nx_get_canvas(Isolate *iso, Local<Value> obj) {
 	(void)iso;
-	return nx::Unwrap<nx_canvas_t>(obj);
+	nx_canvas_t *canvas = nx::Unwrap<nx_canvas_t>(obj);
+	// All wrapped objects share one ObjectTemplate, so validate the type
+	// discriminator — unwrapping an Image (or any other wrapped object) as a
+	// canvas would misread aliased fields (see NX_IMAGE_MAGIC in image.h).
+	if (canvas && canvas->magic != NX_CANVAS_MAGIC)
+		return nullptr;
+	return canvas;
 }
 nx_canvas_context_2d_t *nx_get_canvas_context_2d(Isolate *iso,
                                                  Local<Value> obj) {

--- a/source/canvas.h
+++ b/source/canvas.h
@@ -25,7 +25,12 @@
  * Keeping `data` lets the screen present path stay a plain memcpy and
  * get/putImageData stay cheap CPU ops. GPU backing is a Phase 2.2 follow-up.
  */
+// See NX_IMAGE_MAGIC in image.h — discriminates wrapped canvases from
+// wrapped images in `nx_get_canvas`/`nx_get_image`.
+#define NX_CANVAS_MAGIC 0x5643584eu // 'NXCV'
+
 typedef struct nx_canvas_s {
+	uint32_t magic; // must be first: NX_CANVAS_MAGIC
 	uint32_t width;
 	uint32_t height;
 	uint8_t *data;

--- a/source/image.cc
+++ b/source/image.cc
@@ -196,6 +196,7 @@ void nx_image_new(const FunctionCallbackInfo<Value> &info) {
 	Local<Context> context = iso->GetCurrentContext();
 	Local<Object> img = nx::NewWrapped(iso);
 	nx_image_t *data = (nx_image_t *)calloc(1, sizeof(nx_image_t));
+	data->magic = NX_IMAGE_MAGIC;
 	nx::Wrap<nx_image_t>(iso, img, data, free_image);
 	if (info.Length() == 2) {
 		uint32_t w = 0, h = 0;
@@ -254,7 +255,13 @@ void nx_image_init_class(const FunctionCallbackInfo<Value> &info) {
 
 nx_image_t *nx_get_image(Isolate *iso, Local<Value> obj) {
 	(void)iso;
-	return nx::Unwrap<nx_image_t>(obj);
+	nx_image_t *image = nx::Unwrap<nx_image_t>(obj);
+	// Validate the type discriminator: a wrapped Canvas unwrapped as an
+	// image would alias `surface_dirty`/`gpu` with `cached_sk_image`,
+	// turning a bool into a dereferenced pointer (crash). See image.h.
+	if (image && image->magic != NX_IMAGE_MAGIC)
+		return nullptr;
+	return image;
 }
 
 int decode_jpeg(uint8_t *jpegBuf, size_t jpegSize, uint8_t **output, int *width,

--- a/source/image.h
+++ b/source/image.h
@@ -19,7 +19,16 @@ enum ImageFormat { FORMAT_PNG, FORMAT_JPEG, FORMAT_WEBP, FORMAT_UNKNOWN };
 // this C-style header doesn't have to pull in the Skia C++ headers; canvas.cc
 // owns its construction and `close_image` releases it via
 // `nx_image_release_cache`.
+// Type discriminator for wrapped native objects that can be passed as a
+// `CanvasImageSource`. All wrapped nx.js objects share one ObjectTemplate, so
+// `nx::Unwrap<T>` alone cannot tell an Image from a Canvas — and misreading
+// an `nx_canvas_t` as `nx_image_t` aliases `surface_dirty`/`gpu` with
+// `cached_sk_image` (a bool read back as a pointer ⇒ crash). `nx_get_image`/
+// `nx_get_canvas` validate this magic and return NULL on mismatch.
+#define NX_IMAGE_MAGIC 0x4d49584eu  // 'NXIM'
+
 typedef struct {
+	u32 magic; // must be first: NX_IMAGE_MAGIC
 	u32 width;
 	u32 height;
 	u8 *data;

--- a/source/video.cc
+++ b/source/video.cc
@@ -86,6 +86,7 @@ void nx_video_new(const FunctionCallbackInfo<Value> &info) {
 	Local<Object> obj = nx::NewWrapped(iso);
 	nx_video_t *v = new nx_video_t();
 	memset(&v->image, 0, sizeof(v->image));
+	v->image.magic = NX_IMAGE_MAGIC;
 	v->image.format = FORMAT_UNKNOWN;
 	nx::Wrap<nx_video_t>(iso, obj, v, free_video);
 	info.GetReturnValue().Set(obj);


### PR DESCRIPTION
## Summary

Fixes a crash affecting **console-only apps** (any app that doesn't take over the screen with its own rendering): a Data Abort at address `0x9` in the console present path, root-caused while testing the Web Bluetooth branch (#383) and symbolized to `nx_canvas_context_2d_draw_image`.

### Root cause

All wrapped native objects share a single `ObjectTemplate`, so `drawImage()` duck-types every source by unwrapping it as `nx_image_t`. When the source is actually a **canvas** (e.g. `console-screen.ts` drawing the terminal canvas each present), the struct layouts alias:

| offset | `nx_image_t` | `nx_canvas_t` |
|---|---|---|
| 24 | `void *cached_sk_image` | `bool surface_dirty` (24), `bool gpu` (25) |

The SkImage memo introduced in #373 reads offset 24 as a pointer — `surface_dirty = true` on a freshly-(re)created canvas reads back as `0x1`, which is then dereferenced as an `sk_sp<SkImage>*` (refcount load at `0x1 + 8` = the faulting `0x9`). The memo write-back also scribbles a heap pointer over the canvas's bools. The bug shipped with #373 but was masked by #378, which skips console present while an app owns the screen — so only console-only apps hit it.

### Fix

- `nx_image_t` and `nx_canvas_t` now carry a **leading magic discriminator** (`NX_IMAGE_MAGIC` / `NX_CANVAS_MAGIC`), validated by `nx_get_image()` / `nx_get_canvas()` — type-confused unwraps (including any other wrapped object passed as a `CanvasImageSource`) return `NULL` instead of misreading aliased fields, turning potential crashes into the existing throw/no-op paths.
- Canvas sources now flow through the proper `SkSurface::makeImageSnapshot()` branch. Snapshots keep a **stable SkImage identity while the surface is unchanged**, so Ganesh's texture cache remains effective across repeated draws of a static canvas (the perf property #373's memo provided for images). A never-rendered canvas (no surface yet) draws as transparent.

### Verification

- Reproduced on hardware (console-only Bluetooth diagnostic app, crash report symbolized against a matching `nxjs.elf`); the same app runs crash-free with this fix through many long sessions on the #383 branch (which carried these changes during development — extracted here as a standalone PR per review).
- Device build green.