### PR TITLE
ci: drop redundant switch-ffmpeg install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,6 @@ jobs:
       - name: Check bundle for esbuild class renames
         run: node packages/runtime/check-def-names.mjs
 
-      # Media decode portlib (Video element + decodeAudioData). TODO: bake
-      # into the pacman-packages image and drop this step.
-      - name: Install switch-ffmpeg
-        run: |
-          dkp-pacman -Sy --noconfirm switch-ffmpeg || \
-            pacman -Sy --noconfirm switch-ffmpeg
-
       - name: Build `nxjs.nro`
         run: make V=1
 


### PR DESCRIPTION
## Summary
- The Build job's "Install switch-ffmpeg" step started failing with `403` errors from `pkg.devkitpro.org` (devkitPro's package server is rejecting GitHub CI IPs), with the `pacman` fallback failing too since it doesn't exist in the container (exit 127). Example: https://github.com/TooTallNate/nx.js/actions/runs/27333927835/job/80753608151
- The step is no longer necessary: the pinned `pacman-packages` image (`sha256:5fd521a2…`) already contains `switch-ffmpeg 7.1-5` with all the static libs (`libavcodec.a`, `libavformat.a`, `libavutil.a`, `libswresample.a`, `libswscale.a`) — verified by running `dkp-pacman -Q switch-ffmpeg` in the exact pinned image. The TODO from #382 ("bake into the pacman-packages image and drop this step") has been completed on the image side, so this drops the step.
- Side benefit: removes a fragile network dependency on `pkg.devkitpro.org` at CI time, and avoids the `-Sy` partial-sync risk of pulling a newer ffmpeg than the other portlibs in the image were built against.