### PR TITLE
fix: make async native ops survive applet-mode memory limits (threadpool, GC pressure, clean failure)

### DIFF
--- a/.changeset/spicy-pugs-attack.md
+++ b/.changeset/spicy-pugs-attack.md
@@ -1,0 +1,27 @@
+---
+"@nx.js/runtime": minor
+---
+
+feat: configurable libuv worker thread pool via `[threadpool]` in `nxjs.ini`, with applet-safe defaults
+
+The libuv worker pool (which services every async native op — fs, crypto,
+compression, image decode, dns) previously initialized lazily with upstream
+defaults of 4 threads × 8 MiB stacks. In applet mode that 32 MiB commit could
+not be satisfied next to the JIT code arena, so the **first async operation
+hard-aborted the process** (skipping the applet exit handshake and
+destabilizing the system until reboot).
+
+- New `[threadpool]` section in `nxjs.ini`: `size` (worker count) and
+  `stack_size` (per-worker stack, 256 KiB floor / 32 MiB cap). Defaults:
+  2 workers × 1 MiB in applet mode, 4 × 1 MiB in application mode. Effective
+  values are exposed on `$.config.threadpool`. Requires `switch-libuv`
+  ≥ 1.52.1-3 (adds the `UV_THREADPOOL_STACK_SIZE` env var).
+- Applet+JIT memory reserve raised 64 → 96 MiB (V8 max heap ~41 MiB) so
+  native-heavy workloads like streaming zstd decompression (8 MiB window)
+  complete instead of exhausting the ~168 MiB applet native heap.
+- V8 fatal errors / OOMs now log diagnostics to `nxjs-debug.log` and exit
+  cleanly back to hbmenu instead of aborting (which poisoned the system in
+  applet mode).
+- `Switch.memoryUsage()` gains `externalMemory` and `nativeHeapTotal` /
+  `nativeHeapArena` / `nativeHeapUsed` / `nativeHeapFree` (newlib mallinfo)
+  fields for diagnosing native memory pressure.

--- a/.changeset/spicy-pugs-attack.md
+++ b/.changeset/spicy-pugs-attack.md
@@ -16,9 +16,21 @@ destabilizing the system until reboot).
   2 workers × 1 MiB in applet mode, 4 × 1 MiB in application mode. Effective
   values are exposed on `$.config.threadpool`. Requires `switch-libuv`
   ≥ 1.52.1-3 (adds the `UV_THREADPOOL_STACK_SIZE` env var).
-- Applet+JIT memory reserve raised 64 → 96 MiB (V8 max heap ~41 MiB) so
-  native-heavy workloads like streaming zstd decompression (8 MiB window)
-  complete instead of exhausting the ~168 MiB applet native heap.
+- Native-heap back-pressure for high-rate async allocators: after each async
+  op, if the native malloc heap is running low the runtime fires a V8
+  `MemoryPressureNotification(kCritical)` to reclaim unreferenced external
+  `ArrayBuffer` backing stores. Without it, a tight async loop (e.g. reading a
+  `DecompressionStream` chunk by chunk) let external buffers pile up faster
+  than V8's GC scheduled around its tiny managed heap, exhausting the
+  ~30 MiB free applet native heap in seconds. Verified on-device: a full
+  594 MB streaming zstd decompression that previously OOM'd at ~8 MB now runs
+  to completion in applet mode.
+- Async after-work callbacks no longer crash when they fire during teardown
+  (e.g. `Switch.exit()` / HOME pressed mid-operation): the callback captures
+  the queuing context and falls back to it (or drops the result) instead of
+  entering an empty `v8::Context` (a Data Abort at 0x0 in `Context::Enter()`).
+- Applet+JIT memory reserve raised 64 → 96 MiB (V8 max heap ~41 MiB) for the
+  opt-in `[v8] jit = on` applet case (the default applet regime is jitless).
 - V8 fatal errors / OOMs now log diagnostics to `nxjs-debug.log` and exit
   cleanly back to hbmenu instead of aborting (which poisoned the system in
   applet mode).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: ghcr.io/tootallnate/pacman-packages@sha256:5fd521a2e2e884e41a42ce5bd412b17ae0498d5a5e61a66b6ca836b6b7bc66b8
+    container: ghcr.io/tootallnate/pacman-packages@sha256:92880d77878639768fe3696800104d68de1dfec65802bf7915689dd7bd718e53
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
@@ -167,7 +167,7 @@ jobs:
     # into a host ELF), plus the clang-19/lld-19 toolchain. The harness + Skia +
     # V8 are all built against the system libstdc++, so compile the harness with
     # clang-19/lld against /opt/host.
-    container: ghcr.io/tootallnate/pacman-packages@sha256:5fd521a2e2e884e41a42ce5bd412b17ae0498d5a5e61a66b6ca836b6b7bc66b8
+    container: ghcr.io/tootallnate/pacman-packages@sha256:92880d77878639768fe3696800104d68de1dfec65802bf7915689dd7bd718e53
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,10 @@ background     = #002b36
 foreground     = #839496
 black = #073642   red = #dc322f   ...  bright_white = #fdf6e3
 
+[threadpool]                       ; libuv worker pool (services ALL async native ops)
+size       = 4                     ; worker count; default 2 in applet, 4 in application
+stack_size = 1MiB                  ; per-worker stack; default 1MiB (256KiB floor, 32MiB cap)
+
 [socket]                           ; field-level overrides on the regime base (lean/full)
 tcp_tx_buf_size = 256KiB
 tcp_rx_buf_size = 256KiB
@@ -198,7 +202,15 @@ version = ^1                       ; semver requirement for the shared runtime N
 ```
 
 - **Effective** (post-clamp) values are exposed to JS as `$.config`
-  (`{ jit, heapLimit, renderer, v8Flags, socket:{…}, loaded }`).
+  (`{ jit, heapLimit, renderer, v8Flags, socket:{…}, threadpool:{…}, loaded }`).
+- **`[threadpool]` exists because libuv's upstream defaults (4 workers ×
+  8 MiB stacks = 32 MiB, committed lazily on the FIRST async op) cannot be
+  satisfied in applet mode next to the JIT code arena — and a failed worker
+  create is a hard libuv `abort()` that skips the applet exit handshake and
+  destabilizes the system until reboot.** `main.cc` exports the effective
+  values via `UV_THREADPOOL_SIZE` / `UV_THREADPOOL_STACK_SIZE` env vars before
+  the pool spins up; the stack-size var is a **switch-libuv port extension**
+  (pacman-packages `switch-libuv` ≥ 1.52.1-3 required).
 - **Every value that can't be honored is logged** to `nxjs-debug.log` as a
   `[config] … not honored: <reason>` line (clamped heap, invalid value, GPU
   init fallback, socket reservation too big, etc.). A missing file is silent.
@@ -229,6 +241,22 @@ version = ^1                       ; semver requirement for the shared runtime N
   reserve the 64 MiB WASM headroom unconditionally → a ~256 MiB-real arena that
   left ~10 MiB for everything in applet → bsdsocket/heap/Skia failures. Fixed by
   regime-gating the headroom (commit 71eecc2).
+- **Applet-mode memory ground truth** (measured via the `nativeHeap*` fields of
+  `Switch.memoryUsage()`, which wrap newlib `mallinfo` + the `fake_heap`
+  bounds): the native malloc heap is ~168 MiB TOTAL, with >130 MiB consumed at
+  startup under JIT (64 MiB jit arena + V8 slabs + Skia raster + console). The
+  V8 heap, JIT arena, Skia surfaces, libuv stacks, zstd windows, and ArrayBuffer
+  backings ALL compete in this one budget — V8 commits its heap from it in
+  16 MiB slabs. That is why the applet+JIT `reserve` is 96 MiB (V8 max heap
+  ~41 MiB): a 64 MiB reserve left streaming-decompression workloads (8 MiB zstd
+  window + one V8 slab commit) ~5 MiB short → native ENOMEM, then a FATAL V8
+  Zone OOM on the next JIT compile.
+- **V8 fatal/OOM no longer takes down the system**: `main.cc` installs
+  `fatal_error_callback`/`oom_error_callback` (see `nx_v8_fatal_exit`) that log
+  the reason + `mallinfo` stats to `nxjs-debug.log` and `exit(1)` back through
+  hbloader, instead of V8's default `OS::Abort()` undefined-instruction trap —
+  which, under the Album applet, skipped the applet exit handshake and made any
+  subsequent applet launch crash the OS until reboot.
 - The host `nxjs-test` reads **no** INI; its `build_init_object` exposes a
   default `$.config`. Keep that mirror in sync if you change `$.config`'s shape.
 - `[runtime]` is read by the **slim bootstrap launcher**, not the runtime. The

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -143,6 +143,20 @@ export interface NxSocketConfig {
 }
 
 /**
+ * Effective libuv worker thread pool settings (after `[threadpool]` overrides
+ * from `nxjs.ini` are clamped). The pool services every async native operation
+ * (fs, crypto, compression, image decode, dns, …). Defaults: 4 workers with
+ * 1 MiB stacks (Switch-appropriate; upstream libuv's 8 MiB stacks cannot be
+ * committed in applet mode).
+ */
+export interface NxThreadpoolConfig {
+	/** Number of worker threads. */
+	size: number;
+	/** Stack size per worker thread, in bytes. */
+	stackSize: number;
+}
+
+/**
  * On-screen console styling from the `[console]` section of `nxjs.ini`. Only the
  * keys present in the file are set. The global `console` seeds its options from
  * this at startup; an explicit `console.options =` assignment overrides it. The
@@ -177,6 +191,8 @@ export interface NxConfig {
 	v8Flags: string;
 	/** Effective libnx socket configuration. */
 	socket: NxSocketConfig;
+	/** Effective libuv worker thread pool configuration. */
+	threadpool: NxThreadpoolConfig;
 	/** On-screen console styling from the `[console]` section (empty if none). */
 	console: NxConsoleConfig;
 	/** Whether an `nxjs.ini` file was found and parsed. */

--- a/packages/runtime/src/switch/index.ts
+++ b/packages/runtime/src/switch/index.ts
@@ -155,6 +155,24 @@ export interface MemoryUsage {
 	numberOfNativeContexts: number;
 	/** Number of detached (pending GC) contexts. */
 	numberOfDetachedContexts: number;
+	/**
+	 * Bytes of off-heap memory (e.g. `ArrayBuffer` backing stores) that V8 is
+	 * keeping alive. A large value with a small {@link MemoryUsage.usedHeapSize | `usedHeapSize`}
+	 * means native memory is held by not-yet-collected JS objects.
+	 */
+	externalMemory: number;
+	/**
+	 * Total native (newlib) heap capacity of the process, in bytes. Every
+	 * native allocation — the V8 heap, JIT code arena, render surfaces, worker
+	 * thread stacks, `ArrayBuffer` backings — competes within this budget.
+	 */
+	nativeHeapTotal: number;
+	/** Current size of the native allocator's arena, in bytes. */
+	nativeHeapArena: number;
+	/** Bytes currently allocated from the native heap. */
+	nativeHeapUsed: number;
+	/** Bytes free within the native allocator's current arena. */
+	nativeHeapFree: number;
 }
 
 export interface NetworkInfo {

--- a/packages/runtime/test/fixtures/compression-zstd.ts
+++ b/packages/runtime/test/fixtures/compression-zstd.ts
@@ -80,3 +80,56 @@ test('zstd large data roundtrip', async (t) => {
 		'decompressed content matches',
 	);
 });
+
+// --- streaming pipe through pipeThrough (regression for the applet-mode
+// native-heap back-pressure fix) ---
+//
+// Reading a DecompressionStream chunk-by-chunk via pipeThrough is the exact
+// path that, on a memory-constrained device, accumulated external ArrayBuffer
+// backing stores faster than V8 collected them (until the runtime began
+// firing MemoryPressureNotification under native-heap pressure). This can't
+// reproduce the OOM on the host (plenty of RAM), but it locks in that the
+// pipe yields byte-exact output — the functional contract the GC nudge must
+// not regress. (Chunk count is implementation-defined — the host may emit the
+// whole stream in one chunk while the device emits many — so this only asserts
+// byte-exactness, not the chunk count.)
+test('zstd streaming pipeThrough roundtrip', async (t) => {
+	// ~8 MB of semi-compressible data, exercising a long decompression stream.
+	const block = new Uint8Array(64 * 1024);
+	for (let i = 0; i < block.length; i++) block[i] = (i * 31 + 7) & 0xff;
+	const blocks: Uint8Array[] = [];
+	let total = 0;
+	for (let i = 0; i < 128; i++) {
+		blocks.push(block);
+		total += block.length;
+	}
+
+	const compressed = await new Response(
+		new Blob(blocks).stream().pipeThrough(new CompressionStream('zstd')),
+	).arrayBuffer();
+	t.ok(compressed.byteLength > 0, 'compressed has data');
+
+	// Decompress via pipeThrough and verify length + a content checksum.
+	const ds = new Blob([compressed])
+		.stream()
+		.pipeThrough(new DecompressionStream('zstd'));
+	const reader = ds.getReader();
+	let outLen = 0;
+	let phase = 0;
+	let mismatch = -1;
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		// Verify the byte pattern is preserved across chunk boundaries.
+		for (let i = 0; i < value.length; i++) {
+			const expected = (phase * 31 + 7) & 0xff;
+			if (value[i] !== expected && mismatch < 0) {
+				mismatch = outLen + i;
+			}
+			phase = (phase + 1) % block.length;
+		}
+		outLen += value.length;
+	}
+	t.equal(outLen, total, 'streamed decompressed length matches');
+	t.equal(mismatch, -1, 'streamed bytes match the source pattern exactly');
+});

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -439,6 +439,20 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 		sset("serviceType", 3u); // BsdServiceType_Auto
 		conf->Set(context, nx_str(iso, "socket"), sock).Check();
 
+		// `$.config.threadpool`: mirror the device defaults (4 workers x
+		// 1 MiB stacks). The host harness uses the system libuv (no env
+		// export needed); this only keeps the `$.config` shape in sync.
+		{
+			Local<Object> tp = Object::New(iso);
+			tp->Set(context, nx_str(iso, "size"),
+			        Integer::NewFromUnsigned(iso, 4u))
+			    .Check();
+			tp->Set(context, nx_str(iso, "stackSize"),
+			        Integer::NewFromUnsigned(iso, 1024u * 1024u))
+			    .Check();
+			conf->Set(context, nx_str(iso, "threadpool"), tp).Check();
+		}
+
 		// `$.config.console`: the host reads no nxjs.ini, so expose an empty
 		// object (no overrides) to match the device `$.config` shape.
 		conf->Set(context, nx_str(iso, "console"), Object::New(iso)).Check();

--- a/packages/runtime/test/src/stubs.cc
+++ b/packages/runtime/test/src/stubs.cc
@@ -19,6 +19,15 @@
 #include "types.h"
 #include <v8.h>
 
+// libnx exposes the newlib heap bounds as `fake_heap_start`/`fake_heap_end`;
+// async.cc (compiled from source/) uses them to gauge native-heap pressure on
+// device. The host has a normal glibc heap with no such bounds, so provide the
+// symbols as a zero-width sentinel: async.cc's pressure check treats a zero
+// total as "unknown" and returns early (a no-op), which is the right behavior
+// on a host with plenty of RAM.
+extern "C" char *fake_heap_start = nullptr;
+extern "C" char *fake_heap_end = nullptr;
+
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;

--- a/source/async.cc
+++ b/source/async.cc
@@ -1,8 +1,51 @@
 #include "async.h"
 #include "error.h"
+#include <malloc.h>
 #include <stdlib.h>
 
 using namespace v8;
+
+// newlib heap bounds: the process's total native malloc capacity.
+extern "C" char *fake_heap_start;
+extern "C" char *fake_heap_end;
+
+// Native-heap back-pressure for high-rate async allocators.
+//
+// Async ops that hand large ArrayBuffers back to JS (zstd/zlib decompression,
+// image decode, file reads) allocate their result OFF the V8 heap as external
+// memory. V8's GC schedules around the *managed* heap, which stays tiny here,
+// so during a tight async loop (e.g. reading a DecompressionStream chunk by
+// chunk) it can let external backing stores pile up far faster than it
+// collects them. On a memory-constrained applet (~30 MiB free native heap)
+// that hits ENOMEM in seconds even though almost all of those buffers are
+// already unreferenced garbage.
+//
+// After each async op completes, if the native heap is running low we fire a
+// V8 MemoryPressureNotification(kCritical) — which performs a blocking GC and
+// reclaims the unreferenced external backing stores — before returning to the
+// loop to start the next op. mallinfo() is cheap but not free, so only sample
+// it every few ops.
+static void nx_async_relieve_native_pressure(Isolate *iso) {
+	size_t total = (size_t)(fake_heap_end - fake_heap_start);
+	if (total == 0)
+		return;
+	// Sampled on EVERY async completion. mallinfo() is a cheap arena walk
+	// compared to the multi-MiB decompress/crypto/decode op that just ran, and
+	// the producers spike fast enough (a single op can allocate several MiB of
+	// result + intermediate buffers) that throttling the sample let transient
+	// spikes overshoot the ceiling between checks. So check each time.
+	struct mallinfo mi = mallinfo();
+	size_t used = (size_t)mi.uordblks;
+	size_t free_bytes = total > used ? total - used : 0;
+	// Threshold: when under ~40 MiB of headroom remains, ask V8 to free now.
+	// Generous enough that even a burst of large allocations within one loop
+	// turn can't exhaust the heap before the next op's check fires. A no-op in
+	// the application regime (always far more than 40 MiB free). kCritical
+	// performs a blocking GC, reclaiming unreferenced external backing stores.
+	if (free_bytes < 40ull * 1024 * 1024) {
+		iso->MemoryPressureNotification(MemoryPressureLevel::kCritical);
+	}
+}
 
 // Runs on a libuv worker thread. NO V8 API allowed here.
 static void nx_uv_work_cb(uv_work_t *uvreq) {
@@ -19,7 +62,31 @@ static void nx_uv_after_work_cb(uv_work_t *uvreq, int status) {
 	{
 		Isolate::Scope iso_scope(iso);
 		HandleScope scope(iso);
+		// During teardown (Switch.exit / + / HOME mid-flight) the main loop's
+		// Context::Scope has already been popped, so the isolate has no current
+		// context. A queued work item's after-work callback can still fire here
+		// (the exit path drains the loop with uv_run before disposing the
+		// isolate), and entering an empty context would Data Abort @ 0x0 inside
+		// v8::Context::Enter(). Fall back to the context captured on the work
+		// request; if neither is available, the runtime is going away — drop the
+		// result (free data + delete req below) instead of resolving.
 		Local<Context> context = iso->GetCurrentContext();
+		if (context.IsEmpty() && !req->context.IsEmpty()) {
+			context = req->context.Get(iso);
+		}
+		if (context.IsEmpty()) {
+			req->resolver.Reset();
+			req->context.Reset();
+			if (req->data) {
+				if (req->data_dtor) {
+					req->data_dtor(req->data);
+				} else {
+					free(req->data);
+				}
+			}
+			delete req;
+			return;
+		}
 		Context::Scope ctx_scope(context);
 
 		Local<Promise::Resolver> resolver = req->resolver.Get(iso);
@@ -40,6 +107,7 @@ static void nx_uv_after_work_cb(uv_work_t *uvreq, int status) {
 	}
 
 	req->resolver.Reset();
+	req->context.Reset();
 	if (req->data) {
 		if (req->data_dtor) {
 			req->data_dtor(req->data);
@@ -53,6 +121,11 @@ static void nx_uv_after_work_cb(uv_work_t *uvreq, int status) {
 	// this each frame, but doing it here keeps short async chains snappy).
 	iso->PerformMicrotaskCheckpoint();
 
+	// If the native heap is running low (high-rate ArrayBuffer producers
+	// outpacing GC), ask V8 to reclaim unreferenced external backing stores
+	// now, before the loop starts the next op. See the helper above.
+	nx_async_relieve_native_pressure(iso);
+
 	(void)ctx;
 	(void)status;
 }
@@ -65,6 +138,10 @@ Local<Promise> nx_queue_async(Isolate *iso, nx_work_t *req, nx_work_cb work_cb,
 
 	req->iso = iso;
 	req->resolver.Reset(iso, resolver);
+	// Capture the context the work was queued in, so the after-work callback
+	// can still resolve/reject even if it fires after the main loop's
+	// Context::Scope was popped during teardown (see nx_uv_after_work_cb).
+	req->context.Reset(iso, context);
 	req->work_cb = work_cb;
 	req->after_work_cb = after_work_cb;
 	req->failed = false;

--- a/source/config.cc
+++ b/source/config.cc
@@ -257,6 +257,21 @@ static int ini_cb(void *user, const char *section, const char *name,
 		return 1;
 	}
 
+	if (str_ieq(section, "threadpool")) {
+		nx_threadpool_config_t *t = &cfg->threadpool;
+		uint32_t u;
+		if (str_ieq(name, "size")) {
+			if (parse_u32(value, &u) && u >= 1) { t->size = u; t->has_size = true; }
+			else cfg_log("threadpool.size=\"%s\" not honored: invalid (positive count)", value);
+		} else if (str_ieq(name, "stack_size")) {
+			if (parse_u32(value, &u) && u >= 1) { t->stack_size = u; t->has_stack_size = true; }
+			else cfg_log("threadpool.stack_size=\"%s\" not honored: invalid size", value);
+		} else {
+			cfg_log("threadpool.%s ignored: unknown key", name);
+		}
+		return 1;
+	}
+
 	if (str_ieq(section, "console")) {
 		nx_console_config_t *c = &cfg->console;
 		double d;
@@ -495,6 +510,52 @@ void nx_config_apply_socket(SocketInitConfig *base, const nx_config_t *cfg,
 		        (unsigned long long)(reservation() / (1024 * 1024)),
 		        (unsigned long long)(cap / (1024 * 1024)));
 	}
+}
+
+void nx_config_apply_threadpool(nx_config_t *cfg, bool tight_memory) {
+	// Defaults: 4 workers (libuv's own default count) x 1 MiB stacks; applet
+	// (tight) regime drops to 2 workers — its native heap is ~168 MiB total
+	// with >130 MiB consumed at startup, so both the stacks themselves and
+	// the peak of concurrent native work buffers matter. The worker callbacks
+	// are shallow C (zlib's 16 KiB stack CHUNK buffers, mbedtls handshakes
+	// ~64 KiB, image decoders), so 1 MiB has ample margin while costing
+	// 2-4 MiB total instead of upstream libuv's 32 MiB — which applet mode
+	// could not commit next to the JIT code arena, turning the first async op
+	// into a hard libuv abort().
+	uint32_t size = tight_memory ? 2 : 4;
+	uint32_t stack_size = 1024 * 1024;
+
+	if (cfg->threadpool.has_size) {
+		uint32_t req = cfg->threadpool.size;
+		size = req;
+		// libuv caps at 1024; anything past 64 is senseless on 4 cores and
+		// multiplies stack cost.
+		if (size > 64) {
+			cfg_log("threadpool.size=%u not honored: above 64, clamped", req);
+			size = 64;
+		}
+	}
+	if (cfg->threadpool.has_stack_size) {
+		uint32_t req = cfg->threadpool.stack_size;
+		stack_size = req;
+		// Floor: a too-small worker stack overflows silently (memory
+		// corruption, not a clean error). 256 KiB is the smallest safe value
+		// given the native work callbacks. Cap at 32 MiB (upstream is 8 MiB).
+		if (stack_size < 256 * 1024) {
+			cfg_log("threadpool.stack_size=%u not honored: below 256 KiB "
+			        "floor, clamped",
+			        req);
+			stack_size = 256 * 1024;
+		} else if (stack_size > 32 * 1024 * 1024) {
+			cfg_log("threadpool.stack_size=%u not honored: above 32 MiB cap, "
+			        "clamped",
+			        req);
+			stack_size = 32 * 1024 * 1024;
+		}
+	}
+
+	cfg->effective_threadpool_size = size;
+	cfg->effective_threadpool_stack_size = stack_size;
 }
 
 void nx_config_free(nx_config_t *cfg) {

--- a/source/config.h
+++ b/source/config.h
@@ -35,6 +35,10 @@
 //   black = #073642   red = #dc322f   green = #859900   ...  white = #eee8d5
 //   bright_black = #586e75  ...  bright_white = #fdf6e3
 //
+//   [threadpool]            ; libuv worker thread pool (async fs/crypto/zstd/...)
+//   size       = 4          ; worker thread count (1-64)
+//   stack_size = 1MiB       ; per-worker stack; KiB/MiB suffix or raw bytes
+//
 //   [socket]                ; overrides on the regime-selected SocketInitConfig
 //   tcp_tx_buf_size     = 256KiB
 //   tcp_rx_buf_size     = 256KiB
@@ -143,6 +147,22 @@ typedef struct {
 	BsdServiceType service_type;
 } nx_socket_config_t;
 
+// libuv worker thread pool overrides (`[threadpool]` section). The pool
+// services every async native op (fs, crypto, zstd, image decode, dns, ...)
+// and initializes lazily on the first one. Upstream libuv defaults to
+// 4 threads x 8 MiB stacks = 32 MiB committed at first use — applet mode
+// (~380 MiB process grant) cannot afford that next to the JIT code arena, and
+// a failed thread create inside libuv is a hard abort(). The runtime applies
+// Switch-appropriate defaults (4 threads x 1 MiB) via the UV_THREADPOOL_SIZE /
+// UV_THREADPOOL_STACK_SIZE env vars (the latter is a switch-libuv port
+// extension) before the pool spins up; this section overrides them.
+typedef struct {
+	bool has_size;
+	uint32_t size; // worker thread count
+	bool has_stack_size;
+	uint32_t stack_size; // bytes per worker stack
+} nx_threadpool_config_t;
+
 typedef struct {
 	nx_jit_mode_t jit;
 	char *v8_flags;       // strdup'd app-provided flag string, or NULL
@@ -166,6 +186,7 @@ typedef struct {
 	// overrides the regime default.
 	uint32_t gpu_cache_mib;
 	nx_socket_config_t socket;
+	nx_threadpool_config_t threadpool; // [threadpool] libuv pool overrides
 	nx_console_config_t console; // [console] styling, exposed on $.config.console
 	bool loaded;          // true if an nxjs.ini was found + parsed
 
@@ -176,6 +197,8 @@ typedef struct {
 	bool effective_jit;
 	uint64_t effective_heap_limit; // bytes actually passed to V8
 	uint32_t effective_code_headroom_mb; // WASM headroom actually applied (0 if !jit)
+	uint32_t effective_threadpool_size;       // worker count actually applied
+	uint32_t effective_threadpool_stack_size; // bytes/worker actually applied
 } nx_config_t;
 
 // Initialize `cfg` to defaults (everything auto/unset).
@@ -199,6 +222,14 @@ char *nx_config_ini_path_for(const char *entrypoint);
 // ceiling used for clamping the total buffer reservation.
 void nx_config_apply_socket(SocketInitConfig *base, const nx_config_t *cfg,
                             bool tight_memory);
+
+// Compute the effective libuv threadpool settings (regime defaults +
+// [threadpool] overrides, clamped to safe ranges with not-honored logging)
+// into `cfg->effective_threadpool_*`. The caller (main) exports them via the
+// UV_THREADPOOL_SIZE / UV_THREADPOOL_STACK_SIZE env vars BEFORE the first
+// async native op (the pool initializes lazily and aborts on failure).
+// `tight_memory` selects the applet (2 workers) vs application (4) default.
+void nx_config_apply_threadpool(nx_config_t *cfg, bool tight_memory);
 
 // Free any heap memory owned by `cfg` (the v8_flags string).
 void nx_config_free(nx_config_t *cfg);

--- a/source/main.cc
+++ b/source/main.cc
@@ -103,6 +103,55 @@ extern "C" void horizon_mman_set_code_budget(size_t wasm_headroom_mb,
 // size the V8 max heap against the real committable ceiling.
 extern "C" size_t horizon_mman_data_arena_size(void);
 
+// newlib heap bounds (set up by libnx/hbloader): the process's total native
+// malloc capacity. Logged by the V8 fatal/OOM handlers below.
+extern "C" char *fake_heap_start;
+extern "C" char *fake_heap_end;
+
+// ---------------------------------------------------------------------------
+// V8 fatal error / OOM handlers.
+//
+// V8's default response to an unrecoverable error (JS heap OOM, Zone/compiler
+// arena OOM, internal invariant failure) is OS::Abort() — an
+// undefined-instruction trap. Under hbloader that kills the HOST process (in
+// applet mode, the Album applet) without the applet exit handshake, which
+// destabilizes the whole system until reboot (verified on-device: after such
+// an abort, launching any applet or pressing Home crashes the OS).
+//
+// There is no recovering a V8 isolate from a fatal/OOM condition, but we can
+// at least die cleanly: log the reason + native heap stats to nxjs-debug.log,
+// then exit(1). libnx's exit() unwinds through the homebrew environment back
+// to hbloader/hbmenu with the proper handshake, so the rest of the system
+// stays healthy.
+// ---------------------------------------------------------------------------
+static void nx_v8_fatal_exit(const char *kind, const char *location,
+                             const char *detail) {
+	struct mallinfo mi = mallinfo();
+	fprintf(stderr,
+	        "[v8] FATAL %s at %s: %s\n"
+	        "[v8] native heap: used=%zu KiB free=%zu KiB arena=%zu KiB "
+	        "total=%zu KiB\n"
+	        "[v8] exiting cleanly (V8 cannot recover from this)\n",
+	        kind, location ? location : "?", detail ? detail : "",
+	        (size_t)mi.uordblks / 1024, (size_t)mi.fordblks / 1024,
+	        (size_t)mi.arena / 1024,
+	        (size_t)(fake_heap_end - fake_heap_start) / 1024);
+	fflush(stderr);
+	// NOT abort(): exit() runs the libnx exit path (back to hbloader) so the
+	// applet host process survives. Skipping the runtime's normal teardown is
+	// acceptable — the alternative is taking down the whole system.
+	exit(1);
+}
+
+static void nx_v8_fatal_cb(const char *location, const char *message) {
+	nx_v8_fatal_exit("error", location, message);
+}
+
+static void nx_v8_oom_cb(const char *location, const v8::OOMDetails &details) {
+	nx_v8_fatal_exit(details.is_heap_oom ? "JS heap OOM" : "process OOM",
+	                 location, details.detail);
+}
+
 // ---------------------------------------------------------------------------
 // Rendering state (Phase 1: Cairo raster -> libnx framebuffer memcpy).
 // ---------------------------------------------------------------------------
@@ -973,6 +1022,21 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 		sset("serviceType", (u32)esc->bsd_service_type);
 		conf->Set(context, nx_str(iso, "socket"), sock).Check();
 
+		// `$.config.threadpool`: effective libuv worker pool settings (the
+		// values exported via UV_THREADPOOL_SIZE / UV_THREADPOOL_STACK_SIZE).
+		{
+			Local<Object> tp = Object::New(iso);
+			tp->Set(context, nx_str(iso, "size"),
+			        Integer::NewFromUnsigned(
+			            iso, cfg->effective_threadpool_size))
+			    .Check();
+			tp->Set(context, nx_str(iso, "stackSize"),
+			        Integer::NewFromUnsigned(
+			            iso, cfg->effective_threadpool_stack_size))
+			    .Check();
+			conf->Set(context, nx_str(iso, "threadpool"), tp).Check();
+		}
+
 		// `$.config.console`: the `[console]` styling from nxjs.ini, passed
 		// through verbatim (only keys that were set). The JS console layer
 		// seeds the global console's options from this (an explicit
@@ -1270,6 +1334,27 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+	// libuv worker thread pool: initialized lazily inside libuv on the FIRST
+	// async native op (fs/crypto/zstd/image/dns), and a failed worker thread
+	// create there is a hard abort() that skips the applet exit handshake
+	// (poisoning system applets until reboot). Upstream libuv's 4 x 8 MiB
+	// stacks (32 MiB committed) is exactly what applet mode can't afford next
+	// to the JIT code arena, so export Switch-appropriate values (defaults
+	// 2 x 1 MiB applet / 4 x 1 MiB application, [threadpool] overrides) via
+	// the env vars libuv reads — UV_THREADPOOL_STACK_SIZE is a switch-libuv
+	// port extension. Must happen before any uv_queue_work; doing it here
+	// (pre-V8) is the earliest safe spot after the ini parse.
+	nx_config_apply_threadpool(&nx_ctx->config, tight_memory);
+	{
+		char buf[16];
+		snprintf(buf, sizeof(buf), "%u",
+		         nx_ctx->config.effective_threadpool_size);
+		setenv("UV_THREADPOOL_SIZE", buf, 1);
+		snprintf(buf, sizeof(buf), "%u",
+		         nx_ctx->config.effective_threadpool_stack_size);
+		setenv("UV_THREADPOOL_STACK_SIZE", buf, 1);
+	}
+
 	// Socket buffers: start from the regime-selected base, then apply any
 	// [socket] overrides from nxjs.ini (clamped + logged).
 	SocketInitConfig socket_cfg =
@@ -1417,6 +1502,10 @@ int main(int argc, char *argv[]) {
 	Isolate::CreateParams create_params;
 	create_params.array_buffer_allocator =
 	    ArrayBuffer::Allocator::NewDefaultAllocator();
+	// Die cleanly (exit back to hbloader/hbmenu) instead of V8's abort() on
+	// unrecoverable errors — see nx_v8_fatal_exit above.
+	create_params.fatal_error_callback = nx_v8_fatal_cb;
+	create_params.oom_error_callback = nx_v8_oom_cb;
 
 	// Size V8's heap for the device. Without this V8 uses desktop defaults
 	// (assuming GBs of RAM) and only discovers it's out of memory by fatally
@@ -1450,14 +1539,24 @@ int main(int argc, char *argv[]) {
 	// was explicitly requested:
 	//   - application + JIT: GPU/Mesa is the big consumer; reserve 180 MiB out
 	//     of the ~1 GiB address-space arena (heap then caps at 512 MiB below).
-	//   - applet + JIT, default (raster): no GPU, so the only large reservation
-	//     is the 64 MiB JIT code range (which libnx jitCreate dual-maps) plus
-	//     libuv / Skia raster / native. ~64 MiB leaves a usable heap from the
-	//     ~137 MiB applet grant. (The previous 180 MiB here was an
-	//     application-mode figure: it underflowed applet's free RAM to 0 and
-	//     collapsed the heap to the 32 MiB floor, which is too small for the
-	//     JIT/Wasm compiler and OOM'd — even though full JIT + a ~96 MiB heap is
-	//     known to work in applet mode. See the trifecta CPU example.)
+	//   - applet + JIT, opt-in `[v8] jit = on` (raster): NOT the applet
+	//     default (jitless is — see can_jit above), but when an app opts in the
+	//     big reservations are the 64 MiB JIT code range (which libnx jitCreate
+	//     dual-maps) PLUS enough native headroom for Skia raster, libuv, V8
+	//     Zone (compiler arena) spikes, and app-driven native allocs (zstd
+	//     decompression
+	//     windows, ArrayBuffer backings, ...). Measured on-device (mallinfo):
+	//     the applet native heap is ~168 MiB total with >130 MiB consumed at
+	//     startup, and a 64 MiB reserve left streaming-decompression workloads
+	//     ~5 MiB short of completing (native ENOMEM, then a fatal V8 Zone OOM
+	//     on the next JIT compile). 96 MiB keeps V8's max heap at ~41 MiB —
+	//     ample for typical applet apps (a JS-heap-heavy app can raise it via
+	//     [memory] heap_limit at the cost of native headroom). (The previous
+	//     180 MiB here was an application-mode figure: it underflowed applet's
+	//     free RAM to 0 and collapsed the heap to the 32 MiB floor, which is
+	//     too small for the JIT/Wasm compiler and OOM'd — even though full JIT
+	//     + a ~96 MiB heap is known to work in applet mode. See the trifecta
+	//     CPU example.)
 	//   - applet + JIT + explicit `[renderer] gpu`: GPU/Mesa IS active (this is
 	//     the known-unstable combo warned about above). Use the larger 180 MiB
 	//     reserve so the V8 heap stays small and leaves Mesa as much room as
@@ -1471,7 +1570,7 @@ int main(int argc, char *argv[]) {
 	if (!can_jit)
 		reserve = 48ull * 1024 * 1024;
 	else if (tight_memory && !applet_gpu)
-		reserve = 64ull * 1024 * 1024;
+		reserve = 96ull * 1024 * 1024;
 	else
 		reserve = 180ull * 1024 * 1024;
 	{

--- a/source/memory.cc
+++ b/source/memory.cc
@@ -1,6 +1,14 @@
 #include "types.h"
+#include <malloc.h>
 
 using namespace v8;
+
+// newlib heap bounds (set up by libnx / hbloader). The span between them is
+// the TOTAL native malloc capacity of the process — every native allocation
+// (V8 heap slabs, JIT arena, Skia surfaces, libuv stacks, zstd windows,
+// ArrayBuffer backings, ...) competes inside it.
+extern "C" char *fake_heap_start;
+extern "C" char *fake_heap_end;
 
 namespace {
 
@@ -27,6 +35,19 @@ void nx_memory_usage(const FunctionCallbackInfo<Value> &info) {
 	set("peakMallocedMemory", stats.peak_malloced_memory());
 	set("numberOfNativeContexts", stats.number_of_native_contexts());
 	set("numberOfDetachedContexts", stats.number_of_detached_contexts());
+	// Bytes of off-V8-heap memory (ArrayBuffer backing stores etc.) V8 knows
+	// it is keeping alive. Large values here with a small usedHeapSize mean
+	// native memory is held by not-yet-collected JS objects.
+	set("externalMemory", (size_t)stats.external_memory());
+
+	// Native (newlib) heap statistics. nativeHeapTotal is the process's whole
+	// malloc capacity; nativeHeapUsed/nativeHeapFree reflect the allocator's
+	// current arena (the arena can still grow until total is reached).
+	struct mallinfo mi = mallinfo();
+	set("nativeHeapTotal", (size_t)(fake_heap_end - fake_heap_start));
+	set("nativeHeapArena", (size_t)mi.arena);
+	set("nativeHeapUsed", (size_t)mi.uordblks);
+	set("nativeHeapFree", (size_t)mi.fordblks);
 	info.GetReturnValue().Set(obj);
 }
 

--- a/source/types.h
+++ b/source/types.h
@@ -119,6 +119,10 @@ struct nx_work_s {
 	uv_work_t req; // first member: uv hands this struct back to us
 	v8::Isolate *iso;
 	v8::Global<v8::Promise::Resolver> resolver;
+	// Context the work was queued in. Lets the after-work callback resolve the
+	// promise even when it fires during teardown, after the main loop's
+	// Context::Scope has been popped (iso->GetCurrentContext() is then empty).
+	v8::Global<v8::Context> context;
 	nx_work_cb work_cb;
 	nx_after_work_cb after_work_cb;
 	bool failed;          // set by work_cb to force rejection


### PR DESCRIPTION
## Summary

Investigating whether the #300 streaming-decompression OOM (a QuickJS-era promise-cycle leak) still reproduces under V8, I found it does **not** in application mode — but **applet mode** (the ~380 MiB regime) surfaced a chain of distinct problems that made async native ops (fs, crypto, compression, image decode, dns) unusable there. This PR fixes all of them. The end-to-end result: a **full 594 MB streaming NSZ decompression now completes byte-exact in applet mode**, verified on-device.

## Problems & fixes

1. **First async op hard-crashed the system in applet mode.** libuv lazily inits its threadpool on the first `uv_queue_work()` with upstream defaults of 4 workers × 8 MiB stacks (32 MiB) — unsatisfiable next to the applet memory budget, and a failed worker create is a hard libuv `abort()` that skips the applet exit handshake (every subsequent applet launch then crashed the OS until reboot).
   - New `[threadpool]` section in `nxjs.ini` (`size`, `stack_size`), exported via `UV_THREADPOOL_SIZE` / `UV_THREADPOOL_STACK_SIZE` before the pool spins up. Defaults: **2 × 1 MiB applet / 4 × 1 MiB application**. Effective values on `$.config.threadpool`. Requires **switch-libuv ≥ 1.52.1-3** (adds the `UV_THREADPOOL_STACK_SIZE` env var — TooTallNate/pacman-packages).

2. **Streaming decompression exhausted the applet native heap.** Async ops return large `ArrayBuffer`s allocated as V8 *external* memory; V8 schedules GC around its tiny managed heap, so a tight async loop (reading a `DecompressionStream` chunk by chunk) piled up external backing stores faster than they were collected — OOM at ~8 MB output.
   - After every async op, if the native malloc heap (newlib `mallinfo`) is under ~40 MiB free, fire `MemoryPressureNotification(kCritical)` to reclaim the unreferenced buffers. No-op in application mode.

3. **Async after-work callbacks crashed during teardown.** When an op completes after `Switch.exit()` / HOME mid-flight, the main loop's `Context::Scope` is already popped → `iso->GetCurrentContext()` empty → Data Abort at 0x0 in `v8::Context::Enter()`. Now the callback captures the queuing context and falls back to it (or drops the result cleanly).

4. **V8 fatal/OOM no longer poisons the system.** `fatal_error_callback`/`oom_error_callback` log diagnostics to `nxjs-debug.log` and `exit(1)` cleanly back to hbmenu instead of V8's default `OS::Abort()` trap.

Plus: `Switch.memoryUsage()` gains `externalMemory` + `nativeHeapTotal`/`nativeHeapArena`/`nativeHeapUsed`/`nativeHeapFree` (the diagnostics that made the above measurable).

## On-device verification (applet mode, jitless default)

| Build | NSZ decompression result |
| --- | --- |
| Before any fix | First async op hard-aborts → system crash until reboot |
| + threadpool fix | Survives async init; OOM at ~8 MB output (clean error, clean exit) |
| + GC nudge (40 MiB / every-op) | **PASS — full 594 MB byte-exact**, memory bounded the whole run, clean exit |

Final run: `DONE in 1032.1s written=622821376 ncaSize=622821376 / PASS`. The Album applet re-opens cleanly afterward (the operation that crashed the OS pre-fix). Application mode: full decompression passes byte-exact, unaffected.

## Tests

- New streaming-pipe regression fixture in `compression-zstd.ts` (drives `DecompressionStream` chunk-by-chunk via `pipeThrough`, asserts byte-exactness). Passes in nxjs-test and the conformance comparison.

## Dependency / CI

- Bumps the CI pacman-packages image to the digest that includes switch-libuv 1.52.1-3.