### PR TITLE
fix(v8): default to jitless interpreter in the applet regime

### DIFF
--- a/.changeset/plenty-pears-shake.md
+++ b/.changeset/plenty-pears-shake.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: default to the jitless interpreter in the applet regime again (`[v8] jit = auto`). The JIT's 64 MiB code-range minimum is dual-mapped by libnx jitCreate to ~128 MiB of real memory — a third of the applet grant — leaving so little slack that the console's canvas terminal (and other multi-MiB allocations) degrade or fail. Jitless keeps the full canvas-terminal experience reliably working in applet mode; apps that want JIT performance there can opt in with `[v8] jit = on`. Application mode is unchanged (full JIT).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,11 +202,19 @@ version = ^1                       ; semver requirement for the shared runtime N
 - **Every value that can't be honored is logged** to `nxjs-debug.log` as a
   `[config] … not honored: <reason>` line (clamped heap, invalid value, GPU
   init fallback, socket reservation too big, etc.). A missing file is silent.
-- **JIT is ON by default in BOTH regimes** (`jit = auto` → `can_jit = true`;
-  was regime-gated/jitless-in-applet before). Applet mode still uses CPU raster
-  rendering (chosen independently of JIT). `jit = off` forces the interpreter.
-  Only **applet + GPU + JIT** is known to crash (jitCreate starves Mesa) — that
-  combo (an explicit `[renderer] gpu` in applet) is warned about but attempted.
+- **JIT default is regime-gated** (`jit = auto` → full JIT in application
+  mode, jitless/Ignition in applet mode). JIT in applet *runs*, but its 64 MiB
+  code-range minimum is dual-mapped by libnx jitCreate to ~128 MiB REAL — a
+  third of the ~380 MiB applet grant — leaving only ~15-19 MiB of slack, so
+  every multi-MiB allocation (raster framebuffers, console font + terminal
+  canvas) sits on a knife edge where kilobytes of runtime growth degrade the
+  console to the PrintConsole fallback (or worse without the display-funding
+  hardening). Jitless frees that ~128 MiB so the full canvas-terminal
+  experience reliably fits. `jit = on` opts in to applet JIT (accepting those
+  margins); `jit = off` forces the interpreter everywhere. Applet mode also
+  uses CPU raster rendering (chosen independently of JIT). Only **applet +
+  GPU + JIT** is known to crash (jitCreate starves Mesa) — that combo (an
+  explicit `[renderer] gpu` in applet) is warned about but attempted.
 - **WASM needs JIT code-arena headroom** beyond V8's 64 MiB code-range floor.
   The libnx jit_* arena is dual-mapped (rx+rw → ~2× real), so the headroom is
   regime-gated: application mode reserves 64 MiB (WASM works out of the box),

--- a/source/main.cc
+++ b/source/main.cc
@@ -1293,18 +1293,30 @@ int main(int argc, char *argv[]) {
 		break;
 	case NX_JIT_AUTO:
 	default:
-		// Full JIT in BOTH memory regimes by default. This is safe now that the
-		// JIT code-arena headroom is regime-gated (applet mode reserves 0 WASM
-		// headroom -> the 64 MiB code-range minimum, which fits): verified
-		// across the example apps on-device in applet mode (canvas, snake, svg,
-		// fonts, react, audio, http/websocket servers, repl — all stable with
-		// clean exit). Applet mode still defaults to CPU raster rendering
-		// (chosen independently of JIT; an explicit `[renderer] gpu` can opt in
-		// to GPU even in applet — the known-unstable combo handled below) and
-		// keeps WASM opt-in (no code headroom by default; see the code-arena
-		// budget below). Apps can force the jitless interpreter with
-		// `[v8] jit = off`.
-		can_jit = true;
+		// Regime-gated default: full JIT in the application regime, jitless
+		// (Ignition interpreter) in the applet regime.
+		//
+		// JIT in applet mode *runs* (the code-arena headroom is regime-gated;
+		// verified across the example apps on-device), but the cost is brutal:
+		// the 64 MiB code-range minimum is dual-mapped by libnx jitCreate to
+		// ~128 MiB REAL memory — a third of the entire ~380 MiB applet grant —
+		// leaving only ~15-19 MiB of slack for everything else. That puts
+		// every multi-MiB allocation (the ~11 MiB raster framebuffer pair, the
+		// console's font + terminal canvas, ...) on a knife edge where mere
+		// kilobytes of runtime growth flip apps into degraded modes (canvas
+		// terminal -> PrintConsole fallback) or, without the display-funding
+		// hardening, outright hangs/crashes (verified on-device). Jitless
+		// frees that ~128 MiB, making the full console/canvas experience
+		// reliably fit with >100 MiB to spare.
+		//
+		// Apps that want JIT performance in applet mode can opt in with
+		// `[v8] jit = on` (accepting the tight margins above); application
+		// mode always gets full JIT. Applet mode also uses CPU raster
+		// rendering (chosen independently of JIT; an explicit `[renderer] gpu`
+		// can opt in to GPU even in applet — the known-unstable combo handled
+		// below), and keeps WASM opt-in (no code headroom by default; see the
+		// code-arena budget below).
+		can_jit = !tight_memory;
 		break;
 	}
 	nx_ctx->config.effective_jit = can_jit;


### PR DESCRIPTION
## Summary

Reverts the applet regime to the **jitless (Ignition) interpreter** by default (`[v8] jit = auto`). Application mode is unchanged — it keeps full JIT.

The JIT's 64 MiB code-range minimum is dual-mapped by libnx `jitCreate` to **~128 MiB of real memory** — a third of the entire ~380 MiB applet grant — leaving only ~15–19 MiB of slack. That puts every multi-MiB allocation (the raster framebuffer pair, the console's font + terminal canvas) on a knife edge where mere kilobytes of runtime growth flip apps into degraded modes (canvas terminal → PrintConsole fallback). Jitless frees that ~128 MiB, so the full canvas-terminal experience reliably fits in applet mode with >100 MiB to spare.

Apps that want JIT performance in applet mode can opt back in with `[v8] jit = on` (accepting the tight margins).

> [!NOTE]
> The applet display-funding hardening this pairs with landed in #388 (now merged); rebased onto `main`.

## Testing

Verified on-device: applet apps boot jitless (`regime=applet -> mode=jitless` in the debug log) and the console renders in the GeistMono canvas terminal rather than the PrintConsole fallback; application-mode apps are unaffected.