### PR TITLE
fix(runtime): accept duck-typed BufferSource (ArrayBufferStruct) in NX_GetBufferSource

### DIFF
--- a/.changeset/buffersource-arraybufferstruct.md
+++ b/.changeset/buffersource-arraybufferstruct.md
@@ -1,0 +1,24 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: accept duck-typed `BufferSource` objects (e.g. `ArrayBufferStruct`) in native APIs
+
+`NX_GetBufferSource` — used by every native API that takes a `BufferSource`
+(service IPC dispatch, crypto, compression, fs, image, …) — only handled real
+`ArrayBuffer` / `ArrayBufferView` values after the V8 migration. It dropped the
+QuickJS-era fallback that duck-typed any object exposing
+`{ buffer, byteOffset, byteLength }`.
+
+`@nx.js/util`'s `ArrayBufferStruct` (used pervasively by `@nx.js/ncm`,
+`@nx.js/install-title`, and others to describe IPC structs) is a plain JS class
+that only *implements* the `ArrayBufferView` shape — it is not a real V8
+`ArrayBufferView`. So passing one silently read as a null/empty buffer, which
+produced malformed service requests that the kernel rejected by closing the
+session (`KernelError_ConnectionClosed`, `2001-0123`). This broke, among other
+things, NCM content-storage commands (`deletePlaceHolder`, `register`, `has`,
+…) and therefore title installation.
+
+Restored the duck-typed fallback (honoring `byteOffset`/`byteLength`, clamped to
+the backing buffer). Verified on-device: a full NSZ title install now completes
+and the title appears on the HOME menu.

--- a/packages/runtime/test/fixtures/crypto.ts
+++ b/packages/runtime/test/fixtures/crypto.ts
@@ -120,3 +120,39 @@ test('crypto.subtle.digest empty input', async (t) => {
 		'SHA-256 of empty input',
 	);
 });
+
+// --- duck-typed BufferSource regression (NX_GetBufferSource) ---
+//
+// nx.js's native buffer-source extraction accepts not just ArrayBuffer /
+// ArrayBufferView but also any object shaped like { buffer, byteOffset,
+// byteLength } — the form of `@nx.js/util`'s ArrayBufferStruct, which is a
+// plain JS class (NOT a real ArrayBufferView) used pervasively by @nx.js/ncm
+// and others for IPC structs. The V8 migration dropped this duck-typing, so
+// such objects silently read as a null/empty buffer, producing malformed
+// service IPC requests (kernel ConnectionClosed) — which broke title installs.
+// This verifies a duck-typed struct over a sub-range of a larger buffer hashes
+// identically to the equivalent bytes. On non-nx.js runtimes (Chrome/Bun) the
+// duck-typed shape isn't accepted, so we pass the equivalent real view to keep
+// the observable result — and the TAP — identical across environments.
+test('crypto.subtle.digest accepts duck-typed BufferSource', async (t) => {
+	// Bytes "abc" placed at offset 4 within a 16-byte buffer.
+	const backing = new ArrayBuffer(16);
+	new Uint8Array(backing).set([0, 0, 0, 0, 0x61, 0x62, 0x63], 0);
+	const byteOffset = 4;
+	const byteLength = 3;
+
+	const isNxjs = typeof (globalThis as any).Switch !== 'undefined';
+	const src: ArrayBufferView = isNxjs
+		? // Duck-typed struct (ArrayBufferStruct shape). Exercises the
+		  // NX_GetBufferSource fallback that honors byteOffset/byteLength.
+		  ({ buffer: backing, byteOffset, byteLength } as unknown as ArrayBufferView)
+		: // Real view of the same 3 bytes elsewhere.
+		  new Uint8Array(backing, byteOffset, byteLength);
+
+	const hash = await crypto.subtle.digest('SHA-256', src as BufferSource);
+	t.equal(
+		new Uint8Array(hash).toHex(),
+		'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+		'SHA-256 of the duck-typed sub-range equals SHA-256("abc")',
+	);
+});

--- a/source/util.cc
+++ b/source/util.cc
@@ -34,6 +34,45 @@ uint8_t *NX_GetBufferSource(Isolate *iso, size_t *size, Local<Value> obj) {
 		return data + view->ByteOffset();
 	}
 
+	// Duck-typed buffer source: any object exposing `{ buffer, byteOffset,
+	// byteLength }` where `buffer` is an ArrayBuffer. This is the shape of
+	// `@nx.js/util`'s `ArrayBufferStruct` (used pervasively by @nx.js/ncm and
+	// other packages to describe IPC structs), which is a plain JS class — NOT
+	// a real V8 ArrayBufferView, so it falls through the checks above. The
+	// QuickJS-era NX_GetBufferSource duck-typed these; the V8 rewrite dropped
+	// it, which silently returned nullptr here and produced malformed service
+	// IPC requests (kernel ConnectionClosed) for any command passed such a
+	// struct. Restore the fallback.
+	Local<Context> ctx = iso->GetCurrentContext();
+	Local<Object> o = obj.As<Object>();
+	Local<Value> buffer_val;
+	if (o->Get(ctx, nx_str(iso, "buffer")).ToLocal(&buffer_val) &&
+	    buffer_val->IsArrayBuffer()) {
+		Local<ArrayBuffer> ab = buffer_val.As<ArrayBuffer>();
+		size_t ab_size = ab->ByteLength();
+		uint8_t *base = static_cast<uint8_t *>(ab->Data());
+
+		// byteOffset / byteLength (default to 0 / whole buffer).
+		uint32_t byte_offset = 0, byte_length = (uint32_t)ab_size;
+		Local<Value> v;
+		if (o->Get(ctx, nx_str(iso, "byteOffset")).ToLocal(&v) && v->IsNumber())
+			byte_offset = v->Uint32Value(ctx).FromMaybe(0);
+		if (o->Get(ctx, nx_str(iso, "byteLength")).ToLocal(&v) && v->IsNumber())
+			byte_length = v->Uint32Value(ctx).FromMaybe(byte_length);
+
+		// Clamp to the backing buffer so a bogus offset/length can't escape it.
+		if (byte_offset > ab_size)
+			byte_offset = (uint32_t)ab_size;
+		if ((size_t)byte_offset + byte_length > ab_size)
+			byte_length = (uint32_t)(ab_size - byte_offset);
+
+		*size = byte_length;
+		if (!base || byte_length == 0) {
+			return &NX_EMPTY_BUFFER_SENTINEL;
+		}
+		return base + byte_offset;
+	}
+
 	return nullptr;
 }
 


### PR DESCRIPTION
## Summary

`NX_GetBufferSource` — the helper every native API uses to read a `BufferSource` argument (service IPC dispatch, crypto, compression, fs, image, audio, ns, …) — only handled real `ArrayBuffer` / `ArrayBufferView` values after the V8 migration. It **dropped the QuickJS-era fallback** that duck-typed any object exposing `{ buffer, byteOffset, byteLength }`.

`@nx.js/util`'s `ArrayBufferStruct` (used pervasively by `@nx.js/ncm`, `@nx.js/install-title`, and others to describe IPC structs) is a **plain JS class** that only *implements* the `ArrayBufferView` shape — it is **not** a real V8 `ArrayBufferView`. So passing one silently read as a null/empty buffer, producing a malformed service request that the kernel rejected by **closing the session** (`KernelError_ConnectionClosed`, `2001-0123`).

This broke any NCM content-storage command that takes a struct argument (`deletePlaceHolder`, `register`, `delete`, `has`, …) — and therefore **title installation**.

## Root cause

QuickJS `NX_GetBufferSource` (pre-V8) duck-typed any object with `.buffer`/`.byteOffset`/`.byteLength`. The V8 rewrite only kept `IsArrayBuffer()` / `IsArrayBufferView()`, both of which are `false` for `ArrayBufferStruct`, so the function fell through to `return nullptr` (with `*size` unset).

## Fix

Restore the duck-typed fallback: when the value isn't a real ArrayBuffer/view, read `{ buffer, byteOffset, byteLength }` (defaulting offset/length, clamped to the backing buffer) the same way QuickJS did.

## Verification

- **Unit (nxjs-test):** new `crypto.subtle.digest` regression fixture passes a duck-typed struct over a sub-range of a larger buffer and asserts it hashes to `SHA-256("abc")` — exercises the `byteOffset`/`byteLength` path.
- **Conformance:** crypto fixture matches Chrome (which uses an equivalent real view, so the TAP is identical cross-env).
- **On-device:** a full **NSZ title install** (`@nx.js/install-title`) now completes end-to-end — decompress + AES-CTR re-encrypt + NCM placeholder write + **register** + push application record — and the installed title appears on the HOME menu. Before this fix it failed at the first NCM command passing an `ArrayBufferStruct` with `2001-0123`.

## Impact

This is a general runtime regression fix: any `@nx.js/*` package passing an `ArrayBufferStruct` to a native API was silently sending an empty buffer. It unblocks `@nx.js/ncm` (and the install-title NSZ/XCI/XCZ work).