### PR TITLE
feat(install-title): add NSZ, XCI, and XCZ support

### DIFF
--- a/.changeset/install-title-nsz-xci-xcz.md
+++ b/.changeset/install-title-nsz-xci-xcz.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/install-title": patch
+---
+
+feat: add NSZ, XCI, and XCZ format support with new unified `install()` function

--- a/docs/app/[...slug]/page.tsx
+++ b/docs/app/[...slug]/page.tsx
@@ -35,6 +35,11 @@ const sidebarTabs = [
 		url: '/inspect',
 	},
 	{
+		title: '@nx.js/install-title',
+		description: 'Title installer for nx.js',
+		url: '/install-title',
+	},
+	{
 		title: '@nx.js/ncm',
 		description: 'Content manager API',
 		url: '/ncm',

--- a/docs/app/source.ts
+++ b/docs/app/source.ts
@@ -4,6 +4,7 @@ import {
 	constantsDocs,
 	httpDocs,
 	inspectDocs,
+	installTitleDocs,
 	ncmDocs,
 	replDocs,
 	runtimeDocs,
@@ -31,6 +32,13 @@ export const loaders = new Map([
 		loader({
 			baseUrl: '/http',
 			source: httpDocs.toFumadocsSource(),
+		}),
+	],
+	[
+		'install-title',
+		loader({
+			baseUrl: '/install-title',
+			source: installTitleDocs.toFumadocsSource(),
 		}),
 	],
 	[

--- a/docs/content/install-title/index.mdx
+++ b/docs/content/install-title/index.mdx
@@ -1,0 +1,127 @@
+---
+title: Usage
+---
+
+## Installation
+
+<InstallTabs items={['npm', 'pnpm', 'yarn', 'bun']}>
+    <Tab value='npm'>
+
+```bash
+npm install @nx.js/install-title
+```
+
+    </Tab>
+    <Tab value="pnpm">
+
+```bash
+pnpm add @nx.js/install-title
+```
+
+    </Tab>
+    <Tab value='yarn'>
+
+```bash
+yarn add @nx.js/install-title
+```
+
+    </Tab>
+    <Tab value='bun'>
+
+```bash
+bun add @nx.js/install-title
+```
+
+    </Tab>
+
+</InstallTabs>
+
+## Supported Formats
+
+| Format | Description                                    |
+| ------ | ---------------------------------------------- |
+| NSP    | Nintendo Submission Package (PFS0)             |
+| NSZ    | Compressed NSP (contains NCZ-compressed NCAs)  |
+| XCI    | GameCard Image (HFS0 partitions)               |
+| XCZ    | Compressed XCI (contains NCZ-compressed NCAs)  |
+
+## Example
+
+```typescript title="src/main.ts"
+import { install } from '@nx.js/install-title';
+import { NcmStorageId } from '@nx.js/ncm';
+
+// Open a file from the SD card
+const file = Switch.file('sdmc:/game.nsp');
+
+// Install to SD card — format is auto-detected from magic bytes
+for await (const step of install(file, NcmStorageId.SdCard)) {
+    switch (step.type) {
+        case 'start':
+            console.log(`Starting: ${step.name}`);
+            break;
+        case 'end':
+            console.log(
+                `Done: ${step.name} (${(step.timeEnd - step.timeStart).toFixed(0)}ms)`,
+            );
+            break;
+        case 'progress':
+            console.log(`${step.name}: ${step.processed}/${step.total}`);
+            break;
+    }
+}
+
+console.log('Installation complete!');
+```
+
+All four formats work the same way — just point at the file:
+
+```typescript title="src/main.ts"
+// NSP, NSZ, XCI, and XCZ are all auto-detected
+const nsz = Switch.file('sdmc:/game.nsz');
+const xci = Switch.file('sdmc:/game.xci');
+const xcz = Switch.file('sdmc:/game.xcz');
+
+for await (const step of install(nsz, NcmStorageId.SdCard)) {
+    // ...
+}
+```
+
+You can also specify the format explicitly:
+
+```typescript title="src/main.ts"
+for await (const step of install(blob, NcmStorageId.SdCard, { format: 'xci' })) {
+    // ...
+}
+```
+
+## Validation Warnings
+
+The installer performs validation checks and emits warnings via the `onWarning` callback.
+If no callback is provided, warnings are treated as fatal errors and abort the installation.
+
+```typescript title="src/main.ts"
+for await (const step of install(file, NcmStorageId.SdCard, {
+    onWarning: async (warning) => {
+        console.warn(`Warning: ${warning.message}`);
+        // Return true to continue, false to abort
+        return true;
+    },
+})) {
+    // ...
+}
+```
+
+| Warning Code | Description |
+| --- | --- |
+| `already-installed` | The exact title ID + version is already installed |
+| `nca-already-registered` | A specific NCA is already in content storage |
+| `missing-ticket` | A `.tik` file is missing its corresponding `.cert` |
+
+## How It Works
+
+1. **Parse container** — NSP/NSZ uses PFS0, XCI/XCZ uses HFS0
+2. **Install content meta** — Installs `.cnmt.nca` files, mounts them to read CNMT metadata
+3. **Import tickets** — Imports `.tik` and `.cert` files via the ES service
+4. **Install NCAs** — Writes NCA files to content storage via NCM placeholders. NCZ files (in NSZ/XCZ) are transparently decompressed and re-encrypted on the fly
+5. **Push application records** — Registers the title with the NS service

--- a/docs/content/install-title/meta.json
+++ b/docs/content/install-title/meta.json
@@ -1,0 +1,10 @@
+{
+  "root": true,
+  "pages": [
+    "--- Documentation ---",
+    "index",
+    "...",
+    "--- API Reference ---",
+    "...api"
+  ]
+}

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -12,6 +12,10 @@ export const httpDocs = defineDocs({
 	dir: 'content/http',
 });
 
+export const installTitleDocs = defineDocs({
+	dir: 'content/install-title',
+});
+
 export const inspectDocs = defineDocs({
 	dir: 'content/inspect',
 });

--- a/packages/install-title/README.md
+++ b/packages/install-title/README.md
@@ -1,0 +1,102 @@
+# `@nx.js/install-title`
+
+Title installer for [nx.js](https://nxjs.n8.io). Supports installing Nintendo Switch titles from NSP, NSZ, XCI, and XCZ files.
+
+## Usage
+
+```typescript
+import { install } from '@nx.js/install-title';
+import { NcmStorageId } from '@nx.js/ncm';
+
+const file = Switch.file('sdmc:/game.nsp');
+
+for await (const step of install(file, NcmStorageId.SdCard)) {
+  switch (step.type) {
+    case 'start':
+      console.log(`Starting: ${step.name}`);
+      break;
+    case 'end':
+      console.log(
+        `Done: ${step.name} (${(step.timeEnd - step.timeStart).toFixed(0)}ms)`,
+      );
+      break;
+    case 'progress':
+      console.log(`${step.name}: ${step.processed}/${step.total}`);
+      break;
+  }
+}
+
+console.log('Installation complete!');
+```
+
+## Supported Formats
+
+| Format | Description                                |
+| ------ | ------------------------------------------ |
+| NSP    | Nintendo Submission Package (PFS0)         |
+| NSZ    | Compressed NSP (contains NCZ-compressed NCAs) |
+| XCI    | GameCard Image (HFS0 partitions)           |
+| XCZ    | Compressed XCI (contains NCZ-compressed NCAs) |
+
+The format is auto-detected from magic bytes. You can also specify it explicitly:
+
+```typescript
+for await (const step of install(file, NcmStorageId.SdCard, { format: 'xci' })) {
+  // ...
+}
+```
+
+## API
+
+### `install(data, storageId, options?)`
+
+Install a title from a `Blob` containing an NSP, NSZ, XCI, or XCZ file. The format is auto-detected from magic bytes unless `options.format` is specified. Yields `Step` progress events as the installation proceeds.
+
+- **`data`** — The file data as a `Blob` (e.g. `Switch.File`).
+- **`storageId`** — Target storage (e.g. `NcmStorageId.SdCard`).
+- **`options.format`** — Optional format hint: `'nsp'`, `'nsz'`, `'xci'`, or `'xcz'`.
+- **`options.onWarning`** — Callback invoked when a validation warning is encountered. Return `true` to continue or `false` to abort. If not provided, warnings are treated as fatal errors.
+
+Returns an `AsyncIterable<Step>`.
+
+### `installNsp(data, storageId)`
+
+Convenience wrapper around `install()` that explicitly sets the format to `'nsp'`.
+
+### Step Events
+
+The `install()` generator yields progress events:
+
+- **`StepStart`** — `{ type: 'start', name, timeStart }`
+- **`StepEnd`** — `{ type: 'end', name, timeStart, timeEnd }`
+- **`StepProgress`** — `{ type: 'progress', name, processed, total }`
+
+## Validation Warnings
+
+The installer performs validation checks during installation and emits warnings via the `onWarning` callback. If no callback is provided, warnings abort the install.
+
+```typescript
+for await (const step of install(file, NcmStorageId.SdCard, {
+  onWarning: async (warning) => {
+    console.warn(`Warning: ${warning.message}`);
+    // Return true to continue, false to abort
+    return true;
+  },
+})) {
+  // ...
+}
+```
+
+| Warning Code | Description |
+| --- | --- |
+| `already-installed` | The exact title ID + version is already installed (on SD or NAND) |
+| `nca-already-registered` | A specific NCA file is already registered in content storage |
+| `missing-ticket` | A `.tik` file is missing its corresponding `.cert` file |
+
+## How It Works
+
+1. **Parse container** — NSP/NSZ uses PFS0 (`@tootallnate/nsp`), XCI/XCZ uses HFS0 (`@tootallnate/xci`)
+2. **Install content meta** — Installs `.cnmt.nca` files, mounts them to read CNMT metadata
+3. **Import tickets** — Imports `.tik` and `.cert` files via the ES service
+4. **Install NCAs** — Writes NCA files to content storage via NCM placeholders. NCZ files are transparently decompressed and re-encrypted on the fly via `@tootallnate/ncz`
+5. **Push application records** — Registers the title with the NS service

--- a/packages/install-title/package.json
+++ b/packages/install-title/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nx.js/install-title",
   "version": "0.0.3",
-  "description": "Install a title from an NSP file",
+  "description": "Install a title from an NSP, NSZ, XCI, or XCZ file",
   "repository": {
     "type": "git",
     "url": "https://github.com/TooTallNate/nx.js.git",
@@ -20,11 +20,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@nx.js/constants": "workspace:^",
-    "@nx.js/ncm": "workspace:^",
-    "@nx.js/ns": "workspace:^",
-    "@nx.js/util": "workspace:^",
-    "@tootallnate/nsp": "^0.0.2"
+    "@nx.js/constants": "^0.4.0",
+    "@nx.js/ncm": "^1.2.0",
+    "@nx.js/ns": "^1.0.0",
+    "@nx.js/util": "^1.1.0",
+    "@tootallnate/ncz": "^0.0.2",
+    "@tootallnate/nsp": "^0.0.3",
+    "@tootallnate/xci": "^0.0.2"
   },
   "devDependencies": {
     "@nx.js/runtime": "workspace:*"
@@ -33,7 +35,11 @@
     "nx.js",
     "switch",
     "install",
-    "nsp"
+    "nsp",
+    "nsz",
+    "xci",
+    "xcz",
+    "ncz"
   ],
   "author": "Nathan Rajlich <n@n8.io>",
   "license": "MIT"

--- a/packages/install-title/src/index.ts
+++ b/packages/install-title/src/index.ts
@@ -1,20 +1,19 @@
-import { u8 } from '@nx.js/util';
 import { FsFileSystemType } from '@nx.js/constants';
 import {
-	NcmContentId,
-	NcmStorageId,
-	NcmContentStorage,
-	NcmContentMetaDatabase,
-	NcmContentMetaKey,
-	NcmContentInstallType,
-	NcmContentType,
-	NcmContentMetaHeader,
-	NcmContentInfo,
-	NcmContentStorageRecord,
-	NcmContentMetaType,
-	NcmPatchMetaExtendedHeader,
-	NcmPackagedContentInfo,
 	NcmApplicationMetaExtendedHeader,
+	NcmContentId,
+	NcmContentInfo,
+	NcmContentInstallType,
+	NcmContentMetaDatabase,
+	NcmContentMetaHeader,
+	NcmContentMetaKey,
+	NcmContentMetaType,
+	NcmContentStorage,
+	NcmContentStorageRecord,
+	NcmContentType,
+	NcmPackagedContentInfo,
+	NcmPatchMetaExtendedHeader,
+	NcmStorageId,
 } from '@nx.js/ncm';
 import {
 	NsApplicationRecordType,
@@ -23,7 +22,10 @@ import {
 	nsListApplicationRecordContentMeta,
 	nsPushApplicationRecord,
 } from '@nx.js/ns';
-import { parseNsp, type FileEntry } from '@tootallnate/nsp';
+import { u8 } from '@nx.js/util';
+import { decompressNcz } from '@tootallnate/ncz';
+import { parseNsp } from '@tootallnate/nsp';
+import { parseXci } from '@tootallnate/xci';
 import { esImportTicket } from './ipc/es';
 import { PackagedContentMetaHeader } from './types';
 
@@ -49,6 +51,90 @@ export interface StepProgress {
 
 export type Step = StepStart | StepEnd | StepProgress;
 
+/**
+ * Unified file entry that works for both PFS0 (NSP/NSZ) and HFS0 (XCI/XCZ) files.
+ */
+interface FileEntry {
+	data: Blob;
+	size: bigint;
+}
+
+export type ContainerFormat = 'nsp' | 'nsz' | 'xci' | 'xcz';
+
+/**
+ * Warning codes emitted during installation validation.
+ */
+export type InstallWarningCode =
+	| 'already-installed'
+	| 'nca-already-registered'
+	| 'missing-ticket';
+
+/**
+ * A validation warning encountered during title installation.
+ */
+export interface InstallWarning {
+	/** Machine-readable warning code. */
+	code: InstallWarningCode;
+	/** Human-readable description of the warning. */
+	message: string;
+	/** Additional context about the warning. */
+	details: Record<string, unknown>;
+}
+
+/**
+ * Callback invoked when a validation warning is encountered during installation.
+ *
+ * Return `true` to continue installation despite the warning, or `false` to abort.
+ * If this callback is not provided, all warnings are treated as fatal errors.
+ */
+export type OnWarningCallback = (
+	warning: InstallWarning,
+) => Promise<boolean> | boolean;
+
+export interface InstallOptions {
+	/**
+	 * Hint for the container format. If not provided, the format will be
+	 * auto-detected from the magic bytes of the data.
+	 */
+	format?: ContainerFormat;
+
+	/**
+	 * Called when a validation warning is encountered during installation.
+	 *
+	 * Return `true` to continue, `false` to abort. If not provided,
+	 * warnings are treated as fatal errors and abort the installation.
+	 *
+	 * @example
+	 * ```typescript
+	 * install(file, storageId, {
+	 *   onWarning: async (warning) => {
+	 *     console.warn(warning.message);
+	 *     return confirm('Continue anyway?');
+	 *   },
+	 * });
+	 * ```
+	 */
+	onWarning?: OnWarningCallback;
+}
+
+/**
+ * Emit a warning via the `onWarning` callback. If the callback returns `false`
+ * (or is not provided), throws an error to abort the installation.
+ */
+async function emitWarning(
+	onWarning: OnWarningCallback | undefined,
+	warning: InstallWarning,
+): Promise<void> {
+	if (onWarning) {
+		const shouldContinue = await onWarning(warning);
+		if (!shouldContinue) {
+			throw new Error(`Installation aborted: ${warning.message}`);
+		}
+	} else {
+		throw new Error(warning.message);
+	}
+}
+
 async function* step<T>(
 	name: string,
 	fn: () => AsyncIterable<Step, T>,
@@ -62,71 +148,262 @@ async function* step<T>(
 	}
 }
 
-// Install NSP
-export async function* installNsp(
+/**
+ * Detect the container format by reading magic bytes from the Blob.
+ *
+ * - PFS0 magic `0x50465330` at offset 0 → NSP/NSZ
+ * - "HEAD" magic `0x48454144` at offset 0x100 → XCI/XCZ
+ */
+async function detectFormat(data: Blob): Promise<'pfs0' | 'xci'> {
+	// Check for PFS0 magic at offset 0 ("PFS0" = 0x50465330)
+	const pfs0Buf = await data.slice(0, 4).arrayBuffer();
+	const pfs0Magic = new DataView(pfs0Buf).getUint32(0, false);
+	if (pfs0Magic === 0x50465330) {
+		return 'pfs0';
+	}
+
+	// Check for XCI "HEAD" magic at offset 0x100 (0x48454144)
+	if (data.size >= 0x104) {
+		const xciBuf = await data.slice(0x100, 0x104).arrayBuffer();
+		const xciMagic = new DataView(xciBuf).getUint32(0, false);
+		if (xciMagic === 0x48454144) {
+			return 'xci';
+		}
+	}
+
+	throw new Error('Unrecognized file format (expected NSP/NSZ or XCI/XCZ)');
+}
+
+/**
+ * Parse a container (NSP/NSZ or XCI/XCZ) and return a unified file map.
+ */
+async function parseContainer(
+	data: Blob,
+	format: 'pfs0' | 'xci',
+): Promise<Map<string, FileEntry>> {
+	if (format === 'pfs0') {
+		const nsp = await parseNsp(data);
+		// Convert NspFileEntry to our unified FileEntry
+		const files = new Map<string, FileEntry>();
+		for (const [name, entry] of nsp.files) {
+			files.set(name, { data: entry.data, size: entry.size });
+		}
+		return files;
+	} else {
+		const xci = await parseXci(data);
+		// Convert Hfs0FileEntry to our unified FileEntry
+		const files = new Map<string, FileEntry>();
+		for (const [name, entry] of xci.files) {
+			files.set(name, { data: entry.data, size: entry.size });
+		}
+		return files;
+	}
+}
+
+// Install from any supported format (NSP, NSZ, XCI, XCZ)
+/**
+ * Install a title from a `Blob` containing an NSP, NSZ, XCI, or XCZ file.
+ *
+ * The format is auto-detected from magic bytes unless `options.format` is specified.
+ * Yields `Step` progress events as the installation proceeds.
+ *
+ * NSZ and XCZ files contain NCZ-compressed NCAs, which are transparently
+ * decompressed and re-encrypted during installation.
+ *
+ * @param data The file data as a `Blob`.
+ * @param storageId Target storage (e.g. `NcmStorageId.SdCard`).
+ * @param options Optional configuration.
+ */
+export async function* install(
 	data: Blob,
 	storageId: NcmStorageId,
+	options?: InstallOptions,
 ): AsyncIterable<Step, void> {
+	// Determine format
+	let containerFormat: 'pfs0' | 'xci';
+	if (options?.format) {
+		containerFormat =
+			options.format === 'xci' || options.format === 'xcz' ? 'xci' : 'pfs0';
+	} else {
+		containerFormat = await detectFormat(data);
+	}
+
+	const formatName = containerFormat === 'pfs0' ? 'NSP/NSZ' : 'XCI/XCZ';
+
+	const { onWarning } = options ?? {};
 	const contentStorage = NcmContentStorage.open(storageId);
+	// Clear any orphaned placeholders left behind by a previously aborted
+	// install, so createPlaceHolder() can't collide with stale on-disk state
+	// (FS PathAlreadyExists, 2005-0002).
+	try {
+		contentStorage.cleanupAllPlaceHolder();
+	} catch {}
 	const contentMetaDatabase = NcmContentMetaDatabase.open(storageId);
 
-	// The `.nca` files that will be installed
+	// Also check the other storage for already-installed detection
+	const otherStorageId =
+		storageId === NcmStorageId.SdCard
+			? NcmStorageId.BuiltInUser
+			: NcmStorageId.SdCard;
+	let otherContentMetaDatabase: NcmContentMetaDatabase | null = null;
+	try {
+		otherContentMetaDatabase = NcmContentMetaDatabase.open(otherStorageId);
+	} catch {
+		// May not be available (e.g. no SD card inserted)
+	}
+
+	// The NCA files that will be installed (by name, e.g. "abc123.nca")
 	const ncaFiles = new Set<string>();
 
-	// Map of title IDs found in the `.cnmt.nca` files and the accompanying
-	// `NcmContentMetaKey` instances that will be recorded
+	// Map of title IDs → NcmContentMetaKey instances for application records
 	const titleIdToContentMetaKeysMap = new Map<bigint, NcmContentMetaKey[]>();
 
-	const nsp = yield* step('Parse NSP', async function* () {
-		return parseNsp(data);
+	// Parse the container
+	const files = yield* step(`Parse ${formatName}`, async function* () {
+		return parseContainer(data, containerFormat);
 	});
 
-	// Prepare metadata from the `.cnmt.nca` file(s)
-	const cnmtNcaFiles = nsp.files
+	// Prepare metadata from the `.cnmt.nca` / `.cnmt.ncz` file(s)
+	const cnmtNcaFiles = files
 		.entries()
-		.filter(([name]) => name.endsWith('.cnmt.nca'));
-	for (const [name, entry] of cnmtNcaFiles) {
-		// Install the `.nca` so that we can mount the
-		// filesystem to read the `.cnmt` file inside
-		await installNca(name, entry, contentStorage);
-
-		// Read the decrypted `.cnmt` file
-		const cnmtData = await readContentMeta(name, contentStorage);
-
-		const contentMetaKey = await installContentMetaRecords(
-			contentMetaDatabase,
-			cnmtData,
-			createMetaContentInfo(name, entry),
-			ncaFiles,
+		.filter(
+			([name]) => name.endsWith('.cnmt.nca') || name.endsWith('.cnmt.ncz'),
 		);
+	for (const [name, entry] of cnmtNcaFiles) {
+		yield* step(`Install content meta "${name}"`, async function* () {
+			// Install the NCA so that we can mount the
+			// filesystem to read the `.cnmt` file inside.
+			// Returns the actual installed NCA size (decompressed for NCZ).
+			const installedSize = await installNca(name, entry, contentStorage);
 
-		// Add the content meta key to add to the application record later
-		const cnmtHeader = new PackagedContentMetaHeader(cnmtData);
-		const titleId = getBaseTitleId(cnmtHeader.titleId, cnmtHeader.type);
-		let contentMetaKeys = titleIdToContentMetaKeysMap.get(titleId);
-		if (!contentMetaKeys) {
-			contentMetaKeys = [];
-			titleIdToContentMetaKeysMap.set(titleId, contentMetaKeys);
+			// The name registered in content storage is always `.nca`
+			const ncaName = name.replace(/\.ncz$/, '.nca');
+
+			// Read the decrypted `.cnmt` file
+			const cnmtData = await readContentMeta(ncaName, contentStorage);
+
+			const cnmtHeader = new PackagedContentMetaHeader(cnmtData);
+			const contentMetaKey = createContentMetaKey(cnmtHeader);
+			const titleIdHex = cnmtHeader.titleId.toString(16).padStart(16, '0');
+
+			// --- Validation: already-installed check ---
+			const isInstalledHere = contentMetaDatabase.has(contentMetaKey);
+			const isInstalledOther =
+				otherContentMetaDatabase?.has(contentMetaKey) ?? false;
+			if (isInstalledHere || isInstalledOther) {
+				const where = isInstalledHere
+					? storageId === NcmStorageId.SdCard
+						? 'SD card'
+						: 'NAND'
+					: otherStorageId === NcmStorageId.SdCard
+						? 'SD card'
+						: 'NAND';
+				await emitWarning(onWarning, {
+					code: 'already-installed',
+					message: `Title ${titleIdHex} v${cnmtHeader.version} (${NcmContentMetaType[cnmtHeader.type]}) is already installed on ${where}`,
+					details: {
+						titleId: cnmtHeader.titleId,
+						version: cnmtHeader.version,
+						type: cnmtHeader.type,
+						storage: isInstalledHere ? storageId : otherStorageId,
+					},
+				});
+			}
+
+			// Use the actual installed size (not compressed size) for meta content info
+			const metaEntry = { ...entry, size: installedSize };
+			const installedContentMetaKey = await installContentMetaRecords(
+				contentMetaDatabase,
+				cnmtData,
+				createMetaContentInfo(ncaName, metaEntry),
+				ncaFiles,
+			);
+
+			// Add the content meta key for the application record
+			const titleId = getBaseTitleId(cnmtHeader.titleId, cnmtHeader.type);
+			let contentMetaKeys = titleIdToContentMetaKeysMap.get(titleId);
+			if (!contentMetaKeys) {
+				contentMetaKeys = [];
+				titleIdToContentMetaKeysMap.set(titleId, contentMetaKeys);
+			}
+			contentMetaKeys.push(installedContentMetaKey);
+		});
+	}
+
+	// --- Validation: ticket/certificate consistency check ---
+	// Ensure that for every .tik file in the container there is a
+	// corresponding .cert file with the same base name. This does not
+	// inspect NCA rights_ids or verify that tickets exist for specific
+	// NCAs; it only checks that any shipped tickets have their matching
+	// certificates present.
+	const ticketNames = new Set(
+		files.keys().filter((name) => name.endsWith('.tik')),
+	);
+	for (const tikName of ticketNames) {
+		const certName = `${tikName.slice(0, -4)}.cert`;
+		if (!files.has(certName)) {
+			await emitWarning(onWarning, {
+				code: 'missing-ticket',
+				message: `Ticket "${tikName}" is missing its corresponding certificate "${certName}"`,
+				details: { tikName, certName },
+			});
 		}
-		contentMetaKeys.push(contentMetaKey);
 	}
 
 	// Install Tickets / Certificates
-	yield* importTicketCerts(nsp.files);
+	yield* importTicketCerts(files);
 
-	// Install NCAs files
-	for (const name of ncaFiles) {
-		const entry = nsp.files.get(name);
+	// Install NCA files
+	for (const ncaName of ncaFiles) {
+		// The CNMT references files as `.nca`, but in NSZ/XCZ containers
+		// they may be stored as `.ncz`. Try both.
+		const nczName = ncaName.replace(/\.nca$/, '.ncz');
+		const entry = files.get(ncaName) ?? files.get(nczName);
 		if (!entry) {
-			throw new Error(`Missing "${name}" file`);
+			throw new Error(`Missing "${ncaName}" file`);
 		}
-		await installNca(name, entry, contentStorage);
+		const actualName = files.has(ncaName) ? ncaName : nczName;
+
+		// --- Validation: NCA already-registered check ---
+		const contentId = NcmContentId.from(ncaName);
+		if (contentStorage.has(contentId)) {
+			await emitWarning(onWarning, {
+				code: 'nca-already-registered',
+				message: `NCA "${ncaName}" is already registered in content storage`,
+				details: { ncaName, contentId: contentId.toString() },
+			});
+		}
+
+		yield* step(`Install "${actualName}"`, async function* () {
+			await installNca(actualName, entry, contentStorage);
+		});
 	}
 
 	// Push application records
 	for (const [titleId, contentMetaKeys] of titleIdToContentMetaKeysMap) {
-		await pushApplicationRecord(titleId, contentMetaKeys, storageId);
+		yield* step(
+			`Push record for ${titleId.toString(16).padStart(16, '0')}`,
+			async function* () {
+				await pushApplicationRecord(titleId, contentMetaKeys, storageId);
+			},
+		);
 	}
+}
+
+/**
+ * Install a title from a `Blob` containing an NSP file.
+ *
+ * This is a convenience wrapper around `install()` that explicitly
+ * sets the format to `'nsp'`.
+ *
+ * @param data The NSP file data as a `Blob`.
+ * @param storageId Target storage (e.g. `NcmStorageId.SdCard`).
+ */
+export async function* installNsp(
+	data: Blob,
+	storageId: NcmStorageId,
+): AsyncIterable<Step, void> {
+	yield* install(data, storageId, { format: 'nsp' });
 }
 
 class ContentStoragePlaceholderWriteStream extends WritableStream<Uint8Array> {
@@ -138,9 +415,12 @@ class ContentStoragePlaceholderWriteStream extends WritableStream<Uint8Array> {
 		size: bigint,
 	) {
 		const placeholderId = contentStorage.generatePlaceHolderId();
-		try {
-			contentStorage.deletePlaceHolder(placeholderId);
-		} catch {}
+		// NOTE: do NOT deletePlaceHolder(placeholderId) here first. The ID was
+		// just generated (a fresh random UUID) so it cannot pre-exist, and on
+		// hardware that delete severs the NCM session (KernelError
+		// ConnectionClosed, 2001-0123), poisoning the handle so the subsequent
+		// createPlaceHolder fails. If a stale placeholder ever needs clearing,
+		// use contentStorage.cleanupAllPlaceHolder() once before installing.
 		contentStorage.createPlaceHolder(contentId, placeholderId, BigInt(size));
 
 		super({
@@ -181,22 +461,68 @@ function createMetaContentInfo(name: string, entry: FileEntry): NcmContentInfo {
 	return info;
 }
 
+/**
+ * Install an NCA (or NCZ) file into content storage.
+ *
+ * If the file is an NCZ (detected by `.ncz` extension), it is decompressed
+ * and re-encrypted on the fly via `@tootallnate/ncz`, then written as a
+ * standard NCA to the content storage placeholder.
+ */
 async function installNca(
 	name: string,
 	entry: FileEntry,
 	contentStorage: NcmContentStorage,
-) {
-	console.debug(`Installing "${name}" (${entry.size} bytes)`);
-	const contentId = NcmContentId.from(name);
-	await entry.data
-		.stream()
-		.pipeTo(
-			new ContentStoragePlaceholderWriteStream(
-				contentStorage,
-				contentId,
-				entry.size,
-			),
+): Promise<bigint> {
+	const isNcz = name.endsWith('.ncz');
+	const ncaName = isNcz ? name.replace(/\.ncz$/, '.nca') : name;
+	const contentId = NcmContentId.from(ncaName);
+
+	if (isNcz) {
+		console.debug(`Decompressing and installing NCZ "${name}" as "${ncaName}"`);
+		const { ncaSize } = await decompressNcz(
+			entry.data,
+			(ncaSize) => {
+				console.debug(`NCZ decompressed NCA size: ${ncaSize}`);
+				return new ContentStoragePlaceholderWriteStream(
+					contentStorage,
+					contentId,
+					ncaSize,
+				);
+			},
+			{
+				// Stream-mode NCZ: the whole body is one zstd stream. Routed
+				// transparently to the fused native read+decompress fast path
+				// when `input` is a native file source (see compression).
+				decompressStream: (input) =>
+					input.pipeThrough(
+						new DecompressionStream('zstd' as CompressionFormat),
+					),
+				// Block-mode NCZ: each block is an independent zstd buffer,
+				// decompressed in one shot.
+				decompressBytes: async (compressed: Uint8Array) => {
+					const ds = new DecompressionStream('zstd' as CompressionFormat);
+					const decompressed = new Blob([compressed])
+						.stream()
+						.pipeThrough<Uint8Array>(ds);
+					const response = new Response(decompressed);
+					return new Uint8Array(await response.arrayBuffer());
+				},
+			},
 		);
+		return ncaSize;
+	} else {
+		console.debug(`Installing "${name}" (${entry.size} bytes)`);
+		await entry.data
+			.stream()
+			.pipeTo(
+				new ContentStoragePlaceholderWriteStream(
+					contentStorage,
+					contentId,
+					entry.size,
+				),
+			);
+		return entry.size;
+	}
 }
 
 async function* importTicketCerts(
@@ -291,6 +617,7 @@ async function installContentMetaRecords(
 		}
 
 		contentInfos.push(contentInfo);
+		// Always reference as `.nca` — NCZ lookup happens at install time
 		ncaFilesToInstall.add(`${contentInfo.contentId}.nca`);
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,18 +781,24 @@ importers:
   packages/install-title:
     dependencies:
       '@nx.js/constants':
-        specifier: workspace:^
-        version: link:../constants
+        specifier: ^0.4.0
+        version: 0.4.1
       '@nx.js/ncm':
-        specifier: workspace:^
-        version: link:../ncm
+        specifier: ^1.2.0
+        version: 1.2.0
       '@nx.js/ns':
-        specifier: workspace:^
-        version: link:../ns
+        specifier: ^1.0.0
+        version: 1.0.0
       '@nx.js/util':
-        specifier: workspace:^
-        version: link:../util
+        specifier: ^1.1.0
+        version: 1.1.0
+      '@tootallnate/ncz':
+        specifier: ^0.0.2
+        version: 0.0.2
       '@tootallnate/nsp':
+        specifier: ^0.0.3
+        version: 0.0.3
+      '@tootallnate/xci':
         specifier: ^0.0.2
         version: 0.0.2
     devDependencies:
@@ -2041,6 +2047,18 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@nx.js/constants@0.4.1':
+    resolution: {integrity: sha512-JNsHS7YpSLlkIAWwumOujc9e0N98KliZ8IitXPEILY2NKZ88s+i+R8w4pwI+pWFT6pM/b3+cxP+3Ik+JhkiZow==}
+
+  '@nx.js/ncm@1.2.0':
+    resolution: {integrity: sha512-azxdrFxu6BnRcpydU2aoipwGHONnLtk4q8kg44aZ+GKe3fHsiEqNYvG5f/Y80OTFScTiLor5d53t7l0gbb65Nw==}
+
+  '@nx.js/ns@1.0.0':
+    resolution: {integrity: sha512-9l9OM/VP9jfnp8zJ78SDKVqRbD4nOGXvFgfmex5B8njM+9CZy6+R0R8KXrRnkShI/+8zeZYjgPjzDFyg4YUeoA==}
+
+  '@nx.js/util@1.1.0':
+    resolution: {integrity: sha512-UUWJCFpFSKHhp3HYrKk+BVmUpS2JxD55Dqhw6TJTmOaTI3HKOqQJJlIOwK/GRRW3VTXAOO13x+k4BHxFy7jnPg==}
+
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
@@ -2793,6 +2811,9 @@ packages:
   '@tootallnate/hacbrewpack@0.0.1':
     resolution: {integrity: sha512-vsVc9iO+6vI81TjxEb35FdSaK2gaL++LjgipntfPaIiaM7S+Z5CloB45L+Ih5tMNrXHwRMj74BYpzepDI+xxiA==}
 
+  '@tootallnate/hfs0@0.0.1':
+    resolution: {integrity: sha512-Ad67C0DdMgq3WoBxs/tlxRTm8T/kbqEx7KkOnFDvul8ToRJtThRnbmRUeSF8K6iOU+7Z0ZOFtbihGtnRmPN8FA==}
+
   '@tootallnate/ivfc@0.0.1':
     resolution: {integrity: sha512-ftsCuHRDLQVlCBg2pTAi8aY/vH8G2mB1tFb6urWJyTQ39CUFbwgYOCvCx2xX3rXaNLSqSamQyIpDibcn0D0H+Q==}
 
@@ -2802,14 +2823,20 @@ packages:
   '@tootallnate/nca@0.0.1':
     resolution: {integrity: sha512-dMLMjfBd2puXmQU+SiSX4rcnc50RA05hxhRaKIwxOz3m82AA7pu10MYCJqnNCuxdTLdhRnKwaLAaA5oKVm3FLg==}
 
+  '@tootallnate/ncz@0.0.2':
+    resolution: {integrity: sha512-Ug8Co9uybHJzUE/s3/atSVjGXHnbdnq5u0Wt0aGqX5ksBQQfEEDsCRL0Xel6U4mGRlMZlkPObTFrUjO+o5CQJw==}
+
   '@tootallnate/nro@0.1.3':
     resolution: {integrity: sha512-X3OcYXv5qcZZ7dGPmab4jQzXRR2+9ObCnoHOkfnSlKAFsMYx7kzkx/W1mobFbNQOm0oJYdSr12ldqib+EfhDsA==}
 
-  '@tootallnate/nsp@0.0.2':
-    resolution: {integrity: sha512-z5rPb6sMFwidTpLw05VHX/Hu1yUGvKXhQd+990nbcAPwGOzMkdSToETQ/4jSzyDoke1FsPyLdpSYlUuXWIEuDg==}
+  '@tootallnate/nsp@0.0.3':
+    resolution: {integrity: sha512-IcuPQIMw3hh/kZvHl737cQPhTqri3m/QlGPpFVdbM02L0F9sj4g0jb7sx7N5R4OtUUzHlEOFc0suAU4pMUdnzA==}
 
   '@tootallnate/romfs@0.1.1':
     resolution: {integrity: sha512-dd0435f0hPfOV5KGKMxS0NAgruaukQ4MoOdLcZr36HQMNee23qVEsEiYZyxvJZ0ixwoXYMr65ZrzdFOjpNp29w==}
+
+  '@tootallnate/xci@0.0.2':
+    resolution: {integrity: sha512-ioGHnoLFFHHXurYPtG4jAFQ3WDq7M6/yZf+e+LPFFK36JCB/ieY6BgXt4hhHxyt/ZVm/HfjHj5PxSDt7WreRpA==}
 
   '@types/bytes@3.1.5':
     resolution: {integrity: sha512-VgZkrJckypj85YxEsEavcMmmSOIzkUHqWmM4CCyia5dc54YwsXzJ5uT4fYxBQNEXx+oF1krlhgCbvfubXqZYsQ==}
@@ -6298,6 +6325,19 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@nx.js/constants@0.4.1': {}
+
+  '@nx.js/ncm@1.2.0':
+    dependencies:
+      '@nx.js/constants': 0.4.1
+      '@nx.js/util': 1.1.0
+
+  '@nx.js/ns@1.0.0':
+    dependencies:
+      '@nx.js/constants': 0.4.1
+
+  '@nx.js/util@1.1.0': {}
+
   '@orama/orama@3.1.18': {}
 
   '@oven/bun-darwin-aarch64@1.3.10':
@@ -6963,6 +7003,8 @@ snapshots:
       '@tootallnate/nca': 0.0.1
       '@tootallnate/romfs': 0.1.1
 
+  '@tootallnate/hfs0@0.0.1': {}
+
   '@tootallnate/ivfc@0.0.1': {}
 
   '@tootallnate/nacp@0.2.1': {}
@@ -6973,13 +7015,19 @@ snapshots:
       '@tootallnate/cnmt': 0.0.1
       '@tootallnate/ivfc': 0.0.1
 
+  '@tootallnate/ncz@0.0.2': {}
+
   '@tootallnate/nro@0.1.3':
     dependencies:
       '@tootallnate/nacp': 0.2.1
 
-  '@tootallnate/nsp@0.0.2': {}
+  '@tootallnate/nsp@0.0.3': {}
 
   '@tootallnate/romfs@0.1.1': {}
+
+  '@tootallnate/xci@0.0.2':
+    dependencies:
+      '@tootallnate/hfs0': 0.0.1
 
   '@types/bytes@3.1.5': {}
 


### PR DESCRIPTION
## Summary

Adds NSZ (compressed NSP), XCI (gamecard image), and XCZ (compressed XCI) support to `@nx.js/install-title`, with a unified `install()` that auto-detects the container format from magic bytes and handles all four (NSP, NSZ, XCI, XCZ). NCZ-compressed NCAs are transparently zstd-decompressed and AES-128-CTR re-encrypted, **streaming directly into the NCM placeholder** (no full in-memory buffering) via `@tootallnate/ncz`'s `createSink`/`WritableStream` API.

```ts
import { install } from '@nx.js/install-title';
import { NcmStorageId } from '@nx.js/ncm';

for await (const step of install(Switch.file('sdmc:/game.nsz'), NcmStorageId.SdCard)) {
  // step.type: 'start' | 'progress' | 'end'
}
```

The zstd stream path goes through `file.stream().pipeThrough(new DecompressionStream('zstd'))`, so it automatically benefits from the runtime's fused native read+decompress fast path (#392).

## New deps
`@tootallnate/ncz` (NCZ decompressor), `@tootallnate/xci` (XCI parser), `@tootallnate/nsp` (already used). Plus README + docs-site content.

## Relationship to #291
This supersedes #291 (`install-title-xci-nsz`), which had drifted: it carried QuickJS-era `source/compression.c` / `source/main.c` / `test/compression/` changes (early attempts at the streaming-decompression memory problem) that are now obsolete — that problem is solved on `main` by the V8 migration + #386 + #392. This branch is **pruned to only the install-title feature + docs**, rebased onto current `main`, and uses the now-published `@tootallnate/*` packages (no local links).

## On-device verification

A full **NSZ install completes end-to-end** and the title appears on the HOME menu:
```
Parse NSP/NSZ ✓ → Install content meta ✓ → Import ticket ✓
→ Install .ncz (decompress + AES-CTR + NCM placeholder write + register) ✓ (34.6s, ~17 MB/s)
→ Install remaining NCAs ✓ → Push application record ✓
INSTALL COMPLETE in 36.7s
```

## Depends on
- **#393** (runtime: `NX_GetBufferSource` duck-typed `ArrayBufferStruct` fix) — required for the NCM IPC commands (`register`, `deletePlaceHolder`, …) to work on-device. Without it the install fails at the first NCM struct command with `2001-0123` (ConnectionClosed). Code builds without it; **runtime install requires it**.
- Benefits from **#392** (fused decompress) for speed, but works without it.

Also includes two NCM-usage hardenings in install-title: drop a redundant `deletePlaceHolder(freshId)` before `createPlaceHolder`, and `cleanupAllPlaceHolder()` at install start to clear orphaned placeholders from aborted runs.