### PR TITLE
fix: prevent AmbientLightSensor.start() from leaking timers

### DIFF
--- a/.changeset/ambient-light-sensor-timer-leak.md
+++ b/.changeset/ambient-light-sensor-timer-leak.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: prevent `AmbientLightSensor.start()` from leaking timers when called multiple times. `start()` is now a no-op while already active, and `stop()` resets the timeout handle so `activated` correctly returns `false` afterward.

--- a/packages/runtime/src/ambientlightsensor.ts
+++ b/packages/runtime/src/ambientlightsensor.ts
@@ -60,6 +60,8 @@ export class AmbientLightSensor extends Sensor {
 	}
 
 	start(): void {
+		// Already running, so this is a no-op to avoid leaking timers.
+		if (this.#timeout != null) return;
 		this.#timeout = setInterval(() => {
 			const prev = this.#illuminance;
 			this.#illuminance = $.appletIlluminance();
@@ -72,6 +74,7 @@ export class AmbientLightSensor extends Sensor {
 
 	stop(): void {
 		clearInterval(this.#timeout);
+		this.#timeout = undefined;
 	}
 }
 def(AmbientLightSensor);


### PR DESCRIPTION
## Summary
- Fixes #324: `AmbientLightSensor.start()` unconditionally created a new `setInterval`, leaking the previous timer when called more than once (causing duplicate `reading` events at increasing rates).
- `start()` now no-ops while the sensor is already active.
- `stop()` now resets `#timeout` to `undefined` so `activated` correctly returns `false` afterward (and a subsequent `start()` works again).

## Details
`activated` is derived from `typeof this.#timeout === 'number'`, so resetting the handle in `stop()` keeps that getter consistent and re-arms `start()`'s guard.

## Test plan
- `tsc --noEmit` passes for `@nx.js/runtime`.
- Change is pure TS (no native `source/` changes), so the host conformance binary is unaffected.