### PR TITLE
docs: update for the v1 V8 + libuv + Skia runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <img align="right" width="200" height="200" src="./assets/logo.png">
 
 **nx.js** is a framework that enables the development of Nintendo Switch
-homebrew applications using JavaScript. Powered by the [QuickJS][QuickJS]
-engine, nx.js provides a streamlined environment for writing homebrew
-applications for the Nintendo Switch console.
+homebrew applications using JavaScript. Powered by the [V8][] JavaScript engine
+(the same engine as Chrome and Node.js), nx.js provides a streamlined
+environment for writing homebrew applications for the Nintendo Switch console.
 
 With nx.js, developers can leverage their JavaScript skills and tools to create
 engaging and interactive experiences for the Nintendo Switch platform. The
@@ -13,13 +13,15 @@ framework abstracts the underlying low-level details and provides a high-level
 JavaScript API that simplifies the development process.
 
 nx.js is designed with Web standards in mind, so familiar APIs like
-`setTimeout()`, `fetch()`, `new URL()`, `Canvas` and much more are supported. If
-you are familar with web development then you should feel right at home.
+`setTimeout()`, `fetch()`, `new URL()`, `Canvas`, `WebGL2`, Web Audio, Web
+Bluetooth and much more are supported. If you are familiar with web development
+then you should feel right at home.
 
 ## Features
 
 - **JavaScript Development**: Write homebrew applications for the Nintendo
-  Switch using JavaScript, a popular and widely supported programming language.
+  Switch using JavaScript or TypeScript, a popular and widely supported
+  programming language.
 - **High-Level API**: Benefit from a high-level JavaScript API designed
   specifically for the Nintendo Switch platform, providing easy access to
   console-specific features and functionality.
@@ -28,11 +30,19 @@ you are familar with web development then you should feel right at home.
   experiences.
 - **Graphics and UI**: Create visually appealing and interactive user interfaces
   using the web
-  [`Canvas`](https://developer.mozilla.org/docs/Web/API/Canvas_API) API.
-- **Audio Support**: Integrate audio playback and sound effects into your
-  applications using the web
+  [`Canvas`](https://developer.mozilla.org/docs/Web/API/Canvas_API) API,
+  GPU-accelerated by the [Skia](https://skia.org/) 2D graphics library.
+- **3D Graphics**: Render hardware-accelerated 3D graphics with the
+  [`WebGL2`](https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext)
+  API, backed by a real OpenGL ES 3 context on the Switch GPU.
+- **Audio & Video**: Play audio and video files with the web
   [`Audio`](https://developer.mozilla.org/docs/Web/API/HTMLAudioElement/Audio)
-  API.
+  and `Video` elements, plus the full
+  [Web Audio API](https://developer.mozilla.org/docs/Web/API/Web_Audio_API),
+  backed by an [FFmpeg](https://ffmpeg.org/) media pipeline.
+- **Bluetooth**: Communicate with Bluetooth Low Energy peripherals using the
+  [Web Bluetooth](https://developer.mozilla.org/docs/Web/API/Web_Bluetooth_API)
+  GATT client API.
 - **WebAssembly**: Support for executing code compiled to
   [WebAssembly (WASM)](https://developer.mozilla.org/docs/WebAssembly).
 
@@ -50,33 +60,46 @@ for improvements, please open an issue or submit a pull request in the
 
 ### Building from Source
 
+> [!NOTE]
+> nx.js is cross-compiled for the Switch's `aarch64` CPU using the
+> [devkitPro](https://devkitpro.org/) toolchain, so a full build can only be
+> done on a machine with devkitPro installed (Linux, macOS, or WSL). You do
+> **not** need to build from source to develop apps — see the
+> [Getting Started](https://nxjs.n8.io/runtime) guide, which uses the published
+> runtime.
+
 1. Node.js needs to be installed
-   (`curl -sfLS install-node.vercel.app/20 | bash`)
+   (`curl -sfLS install-node.vercel.app/22 | bash`)
 1. `pnpm` needs to be installed (`npm i -g pnpm`)
 1. `jq` needs to be installed (`brew install jq`)
 1. The [devkitPro](https://devkitpro.org/) compiler toolchain needs to be
    installed
 1. Install required packages from the official registry:
    ```bash
-   sudo dkp-pacman -S switch-dev switch-freetype switch-libjpeg-turbo switch-libpng switch-harfbuzz switch-libwebp switch-libzstd switch-mbedtls
+   sudo dkp-pacman -S switch-dev switch-freetype switch-libjpeg-turbo switch-libpng switch-harfbuzz switch-libwebp switch-libzstd switch-mbedtls switch-ffmpeg
    ```
-1. Install additional packages which are not in the official registry (cairo,
-   pixman, wasm3, harfbuzz, quickjs-ng):
+1. Install the additional custom packages which are **not** in the official
+   devkitPro registry (`switch-v8`, `switch-skia`, `switch-libuv`,
+   `switch-ada`, `switch-dav1d`, and others). These are distributed via a
+   Docker image:
    ```bash
    docker pull ghcr.io/tootallnate/pacman-packages:nxjs
    docker run -it --rm --platform linux/amd64 --mount type=bind,source="$(pwd)",target=/host ghcr.io/tootallnate/pacman-packages:nxjs sh -c 'cp packages/*/*.pkg.tar.zst /host'
    sudo dkp-pacman -U *.pkg.tar.zst
    ```
-1. `qjsc` needs to be installed (**note**: must match the version of the QuickJS
-   dkp package installed in the previous step, see [here](https://github.com/TooTallNate/pacman-packages/blob/nxjs/Dockerfile#L80))
 1. Now you can compile one of the example apps into a self-contained `.nro`:
    ```bash
    ./build.sh hello-world
    ```
+
+> [!TIP]
+> The `build.sh` script bundles the TypeScript runtime, compiles the native
+> `nxjs.nro` runtime via `make`, and packages the selected example app from the
+> [`apps/`](./apps) directory into a standalone `.nro`.
 
 ## License
 
 nx.js is released under the MIT License. Please see the [`LICENSE`](./LICENSE)
 file for more details.
 
-[QuickJS]: https://bellard.org/quickjs/
+[V8]: https://v8.dev/

--- a/docs/content/runtime/concepts/audio.mdx
+++ b/docs/content/runtime/concepts/audio.mdx
@@ -3,17 +3,36 @@ title: Audio
 description: Playing audio files in your nx.js application
 ---
 
-nx.js provides audio playback through the [`Audio`](/runtime/api/classes/Audio) class,
-which implements a subset of the web
-[`HTMLAudioElement`](https://developer.mozilla.org/docs/Web/API/HTMLAudioElement) API.
+nx.js provides two complementary ways to play audio:
+
+- The [`Audio`](/runtime/api/classes/Audio) element — a simple way to play back
+  an audio file, implementing a subset of the web
+  [`HTMLAudioElement`](https://developer.mozilla.org/docs/Web/API/HTMLAudioElement)
+  API. Covered in the first half of this page.
+- The [**Web Audio API**](#web-audio-api) — a node-graph engine for low-latency
+  playback, synthesis, mixing, panning, and real-time processing. Covered in the
+  [second half](#web-audio-api).
+
+Both are backed by the same [FFmpeg](https://ffmpeg.org/) decoder, so they
+support the same set of file formats.
 
 ## Supported Formats
 
-| Format | Library | MIME Type |
-|--------|---------|-----------|
-| MP3 | [dr_mp3](https://github.com/mackron/dr_libs) | `audio/mpeg` |
-| WAV | [dr_wav](https://github.com/mackron/dr_libs) | `audio/wav` |
-| OGG Vorbis | [stb_vorbis](https://github.com/nothings/stb) | `audio/ogg` |
+Audio decoding is backed by [FFmpeg](https://ffmpeg.org/), so essentially every
+common audio format is supported, including:
+
+| Format | MIME Type |
+|--------|-----------|
+| MP3 | `audio/mpeg` |
+| WAV | `audio/wav` |
+| OGG Vorbis | `audio/ogg` |
+| Opus | `audio/opus` |
+| FLAC | `audio/flac` |
+| AAC / M4A | `audio/aac` |
+
+> [!NOTE]
+> The same FFmpeg pipeline backs the [Web Audio API](#web-audio-api)'s
+> `decodeAudioData()` and the [`Video`](/runtime/concepts/video) element.
 
 ## Basic Playback
 
@@ -165,3 +184,108 @@ update();
 > [!TIP]
 > For sound effects that need to be played rapidly or overlapping, create
 > multiple `Audio` instances from the same source.
+
+## Web Audio API
+
+For low-latency playback, synthesis, mixing, and real-time processing, nx.js
+implements the [Web Audio API](https://developer.mozilla.org/docs/Web/API/Web_Audio_API),
+which builds an audio processing graph out of connected nodes.
+
+Audio is processed by a native graph engine running on a dedicated real-time
+render thread (in 128-frame quanta, like browsers), and streamed to the Switch's
+`audren` audio service.
+
+### Implemented Interfaces
+
+| Interface | Description |
+|-----------|-------------|
+| [`AudioContext`](https://developer.mozilla.org/docs/Web/API/AudioContext) | The main real-time audio graph |
+| [`OfflineAudioContext`](https://developer.mozilla.org/docs/Web/API/OfflineAudioContext) | Renders a graph to an `AudioBuffer` faster than real-time |
+| [`AudioBuffer`](https://developer.mozilla.org/docs/Web/API/AudioBuffer) | In-memory PCM audio data |
+| [`AudioBufferSourceNode`](https://developer.mozilla.org/docs/Web/API/AudioBufferSourceNode) | Plays back an `AudioBuffer` |
+| [`GainNode`](https://developer.mozilla.org/docs/Web/API/GainNode) | Volume control |
+| [`StereoPannerNode`](https://developer.mozilla.org/docs/Web/API/StereoPannerNode) | Left/right stereo panning |
+| [`AudioParam`](https://developer.mozilla.org/docs/Web/API/AudioParam) | Automatable parameter (with scheduling) |
+
+### Playing an `AudioBuffer`
+
+Decode an audio file with [`decodeAudioData()`](https://developer.mozilla.org/docs/Web/API/BaseAudioContext/decodeAudioData),
+then play it through an `AudioBufferSourceNode`:
+
+```typescript title="src/main.ts"
+const ctx = new AudioContext();
+
+const data = await fetch('romfs:/sound.mp3').then((r) => r.arrayBuffer());
+const buffer = await ctx.decodeAudioData(data);
+
+const source = ctx.createBufferSource();
+source.buffer = buffer;
+source.connect(ctx.destination);
+source.start();
+```
+
+### Synthesizing audio
+
+You don't need any asset files — you can fill an `AudioBuffer` with samples you
+compute yourself. Here's a simple sine-wave beep:
+
+```typescript title="src/main.ts"
+const ctx = new AudioContext();
+
+// 0.5 seconds of a 440 Hz sine wave
+const length = Math.floor(0.5 * ctx.sampleRate);
+const buffer = ctx.createBuffer(1, length, ctx.sampleRate);
+const data = buffer.getChannelData(0);
+for (let i = 0; i < length; i++) {
+  const t = i / ctx.sampleRate;
+  data[i] = Math.sin(2 * Math.PI * 440 * t) * 0.3;
+}
+
+const source = ctx.createBufferSource();
+source.buffer = buffer;
+source.connect(ctx.destination);
+source.start();
+```
+
+### Building a graph
+
+Nodes can be chained with `connect()` to build a processing graph. Here a source
+is routed through a gain (volume) node and a stereo panner before reaching the
+destination:
+
+```typescript
+const ctx = new AudioContext();
+
+const gain = ctx.createGain();
+gain.gain.value = 0.5; // 50% volume
+
+const panner = ctx.createStereoPanner();
+panner.pan.value = -1; // hard left
+
+source.connect(gain).connect(panner).connect(ctx.destination);
+source.start();
+```
+
+### Parameter automation
+
+[`AudioParam`](https://developer.mozilla.org/docs/Web/API/AudioParam) values can
+be scheduled to change over time — for example, a fade-out:
+
+```typescript
+const gain = ctx.createGain();
+gain.connect(ctx.destination);
+
+// Fade from full volume to silence over 1 second
+gain.gain.setValueAtTime(1, ctx.currentTime);
+gain.gain.linearRampToValueAtTime(0, ctx.currentTime + 1);
+```
+
+> See the [`apps/web-audio`](https://github.com/TooTallNate/nx.js/tree/main/apps/web-audio)
+> example for a complete demo that synthesizes sound effects and music
+> procedurally.
+
+## Learn more
+
+<Cards>
+  <Card title="Video playback" href="/runtime/concepts/video" />
+</Cards>

--- a/docs/content/runtime/concepts/bluetooth.mdx
+++ b/docs/content/runtime/concepts/bluetooth.mdx
@@ -1,0 +1,119 @@
+---
+title: Bluetooth
+description: Communicating with BLE peripherals using the Web Bluetooth API
+---
+
+nx.js implements the [Web Bluetooth API](https://developer.mozilla.org/docs/Web/API/Web_Bluetooth_API)
+for communicating with **Bluetooth Low Energy (BLE)** peripherals as a GATT
+client. It is exposed via the global
+[`navigator.bluetooth`](https://developer.mozilla.org/docs/Web/API/Navigator/bluetooth)
+object, and is backed by the Switch's application-facing `btm.u` + `bt`
+services.
+
+This means the same Web Bluetooth code that runs in a Chrome web app can run on
+the Switch.
+
+## Implemented Interfaces
+
+| Interface | Description |
+|-----------|-------------|
+| [`Bluetooth`](https://developer.mozilla.org/docs/Web/API/Bluetooth) (`navigator.bluetooth`) | Entry point: availability + device requests |
+| [`BluetoothDevice`](https://developer.mozilla.org/docs/Web/API/BluetoothDevice) | A discovered/known device |
+| [`BluetoothRemoteGATTServer`](https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTServer) | The connection to a device's GATT server |
+| [`BluetoothRemoteGATTService`](https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTService) | A GATT service |
+| [`BluetoothRemoteGATTCharacteristic`](https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic) | A characteristic (read/write/notify) |
+| [`BluetoothUUID`](https://developer.mozilla.org/docs/Web/API/BluetoothUUID) | UUID helpers |
+
+## Finding a device
+
+On the Switch, the application BLE scanner is **filter-based**: devices are
+discovered by an **advertised 128-bit service UUID**. Pass the service UUIDs you
+care about in the `filters` of
+[`requestDevice()`](https://developer.mozilla.org/docs/Web/API/Bluetooth/requestDevice):
+
+```typescript title="src/main.ts"
+const device = await navigator.bluetooth.requestDevice({
+  filters: [
+    // Nordic UART service (common on Arduino/ESP32/Adafruit boards)
+    { services: ['6e400001-b5a3-f393-e0a9-e50e24dcca9e'] },
+  ],
+});
+
+console.log(`Found: ${device.name ?? '(unnamed)'} [${device.id}]`);
+```
+
+> [!NOTE]
+> Consumer devices that advertise only manufacturer data (e.g. AirPods) cannot
+> be discovered by scanning. See [Connecting by address](#connecting-by-address)
+> below.
+
+## Connecting by address
+
+nx.js adds a `deviceId` extension to `requestDevice()` so you can connect to a
+device by its known Bluetooth address — bypassing the scan entirely. This is
+useful for devices that advertise no usable service UUID:
+
+```typescript
+const device = await navigator.bluetooth.requestDevice({
+  deviceId: 'aa:bb:cc:dd:ee:ff',
+  optionalServices: ['6e400001-b5a3-f393-e0a9-e50e24dcca9e'],
+});
+```
+
+> [!TIP]
+> Use a phone app like **nRF Connect** to discover a device's address and the
+> service UUIDs it advertises.
+
+## Reading and writing
+
+Connect to the GATT server, look up a service and characteristic, then read or
+write its value:
+
+```typescript
+const server = await device.gatt.connect();
+const service = await server.getPrimaryService(
+  '6e400001-b5a3-f393-e0a9-e50e24dcca9e',
+);
+const characteristic = await service.getCharacteristic(
+  '6e400002-b5a3-f393-e0a9-e50e24dcca9e',
+);
+
+// Read
+const value = await characteristic.readValue(); // DataView
+
+// Write
+await characteristic.writeValueWithResponse(new Uint8Array([0x01, 0x02]));
+```
+
+## Notifications
+
+Subscribe to characteristic notifications (the CCCD write is handled
+automatically) and listen for `characteristicvaluechanged` events:
+
+```typescript
+await characteristic.startNotifications();
+characteristic.addEventListener('characteristicvaluechanged', (event) => {
+  const value = event.target.value; // DataView
+  console.log('notified:', new Uint8Array(value.buffer));
+});
+```
+
+## Disconnection
+
+Listen for the `gattserverdisconnected` event to know when the device drops:
+
+```typescript
+device.addEventListener('gattserverdisconnected', () => {
+  console.log('Device disconnected.');
+});
+```
+
+## Other features
+
+- Browser-style ATT MTU negotiation
+- Writes with and without response
+- GATT service/characteristic discovery
+- `navigator.bluetooth.getAvailability()`
+
+> See the [`apps/bluetooth`](https://github.com/TooTallNate/nx.js/tree/main/apps/bluetooth)
+> example for a complete GATT explorer that dumps a device's full GATT table.

--- a/docs/content/runtime/concepts/event-loop.mdx
+++ b/docs/content/runtime/concepts/event-loop.mdx
@@ -3,9 +3,17 @@ title: Event Loop
 description: Callback-based animation frame request
 ---
 
+nx.js runs an event loop driven by [libuv](https://libuv.org/) (the same library
+that powers Node.js), which services timers, async I/O, and the render loop.
+
 To hook into each frame of the event loop in nx.js, use the
 [`requestAnimationFrame()`](/runtime/api/functions/requestAnimationFrame)
 function. This allows your app to update its state at a fixed frame rate (60 FPS).
+
+The familiar timer functions ([`setTimeout()`](/runtime/api/functions/setTimeout),
+[`setInterval()`](/runtime/api/functions/setInterval),
+[`queueMicrotask()`](https://developer.mozilla.org/docs/Web/API/Window/queueMicrotask),
+and Promises) are also available.
 
 ## Example
 

--- a/docs/content/runtime/concepts/index.mdx
+++ b/docs/content/runtime/concepts/index.mdx
@@ -32,6 +32,8 @@ reference for the full surface.
   <Card title="Images" href="/runtime/concepts/images" />
   <Card title="Fonts" href="/runtime/concepts/fonts" />
   <Card title="Albums" href="/runtime/concepts/albums" />
+  <Card title="Audio" href="/runtime/concepts/audio" />
+  <Card title="Video" href="/runtime/concepts/video" />
 </Cards>
 
 ## System
@@ -42,11 +44,18 @@ reference for the full surface.
   <Card title="Web Browser" href="/runtime/concepts/web-browser" />
 </Cards>
 
+## Connectivity
+
+<Cards>
+  <Card title="Networking" href="/runtime/concepts/networking" />
+  <Card title="Bluetooth" href="/runtime/concepts/bluetooth" />
+</Cards>
+
 ## Runtime
 
 <Cards>
   <Card title="Event Loop" href="/runtime/concepts/event-loop" />
-  <Card title="Networking" href="/runtime/concepts/networking" />
+  <Card title="ES Modules" href="/runtime/concepts/modules" />
   <Card title="Cryptography" href="/runtime/concepts/crypto" />
   <Card title="Compression" href="/runtime/concepts/compression" />
 </Cards>

--- a/docs/content/runtime/concepts/modules.mdx
+++ b/docs/content/runtime/concepts/modules.mdx
@@ -1,0 +1,80 @@
+---
+title: ES Modules
+description: Loading multiple files with native import resolution
+---
+
+nx.js resolves native ES module
+[`import`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import)
+statements at runtime, so you can ship an **unbundled, multi-file app** or
+**lazy-load** modules on demand with dynamic `import()`.
+
+> [!TIP]
+> For distribution, [bundling](/runtime#bundle-the-source-code) your app into a
+> single file with [`esbuild`][] is still recommended. Native imports are
+> additive — they enable unbundled multi-file apps, the REPL, and app-level lazy
+> loading.
+
+## Static imports
+
+Both static `import` and top-level `await` are supported. Specifiers are
+resolved as URLs relative to the importing module:
+
+```typescript title="romfs/main.js"
+import { greet } from './greet.js';
+import { CONFIG } from '/config.js'; // absolute path
+
+greet(CONFIG.name);
+```
+
+```typescript title="romfs/greet.js"
+export function greet(name) {
+  console.log(`Hello, ${name}!`);
+}
+```
+
+## Dynamic imports
+
+`await import()` works too, for lazy-loading code only when needed:
+
+```typescript
+async function onLevelStart() {
+  const { loadLevel } = await import('./levels/level1.js');
+  loadLevel();
+}
+```
+
+## Resolution rules
+
+Module specifiers are resolved against the importing module's URL:
+
+| Specifier | Example | Supported |
+|-----------|---------|-----------|
+| Relative | `./util.js`, `../lib/x.js` | ✅ |
+| Absolute path | `/config.js` | ✅ |
+| Absolute URL | `romfs:/x.js`, `sdmc:/x.js`, `nxjs:/x.js`, `file:/x.js` | ✅ |
+| Bare specifier | `react`, `lodash` | ❌ (throws) |
+| Remote URL | `https://…`, `data:…` | ❌ (not yet supported) |
+
+- There is **no** `node_modules` resolution or import maps — bare specifiers
+  (like `react`) throw. Use a bundler if you depend on npm packages.
+- Resolution is **synchronous**, so only mounted filesystem schemes work
+  (`romfs:`, `sdmc:`, `nxjs:`, `file:`). Remote `http(s):`/`data:` imports are
+  not supported.
+- JSON and other asset module types are not yet supported.
+
+## `import.meta`
+
+Each module has an accurate `import.meta`:
+
+```typescript
+console.log(import.meta.url);  // the module's resolved URL
+console.log(import.meta.main); // true only for the entrypoint
+```
+
+## Module cache & cycles
+
+Modules are cached by their resolved URL, so a shared dependency imported through
+multiple paths resolves to a single instance (giving referential stability), and
+import cycles are handled correctly.
+
+[`esbuild`]: https://esbuild.github.io

--- a/docs/content/runtime/concepts/video.mdx
+++ b/docs/content/runtime/concepts/video.mdx
@@ -1,0 +1,106 @@
+---
+title: Video
+description: Playing video files in your nx.js application
+---
+
+nx.js provides video playback through the [`Video`](/runtime/api/classes/Video)
+class, which implements an API similar to the web
+[`HTMLVideoElement`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement).
+
+Because nx.js has no DOM, there is no `<video>` element that draws itself to the
+page. Instead, your app explicitly draws each frame onto the screen with
+[`ctx.drawImage(video, …)`](/runtime/concepts/images) — exactly like rendering a
+`<video>` onto a `<canvas>` on the web.
+
+Video decoding is powered by an [FFmpeg](https://ffmpeg.org/) media pipeline, so
+a wide range of containers and codecs are supported (WebM VP8/VP9, MP4/MKV
+H.264/H.265, AV1, …). Audio tracks are played through the
+[Web Audio](/runtime/concepts/audio#web-audio-api) engine, with A/V sync slaved to the
+audio clock.
+
+## Basic Playback
+
+Create a `Video`, set its `src`, and draw it every frame in your render loop:
+
+```typescript title="src/main.ts"
+const ctx = screen.getContext('2d');
+
+const video = new Video();
+video.src = 'romfs:/video.webm';
+
+// Start playing once enough data is buffered
+video.addEventListener('canplay', () => {
+  video.play();
+});
+
+function update() {
+  requestAnimationFrame(update);
+  ctx.clearRect(0, 0, screen.width, screen.height);
+
+  // Draw the current video frame, scaled to fill the screen
+  ctx.drawImage(video, 0, 0, screen.width, screen.height);
+}
+update();
+```
+
+> [!IMPORTANT]
+> Like the [`Audio`](/runtime/concepts/audio) element, video data loads and
+> decodes asynchronously. Wait for the `canplay` (or `loadedmetadata`) event
+> before calling `play()`.
+
+## Loading Video
+
+The `src` property accepts any URL supported by [`fetch()`](/runtime/api/functions/fetch),
+including `romfs:/` paths for bundled assets, `sdmc:/` paths on the SD card, and
+remote `http(s)://` URLs.
+
+## Playback Controls
+
+The familiar media controls are available:
+
+```typescript
+await video.play();
+video.pause();
+
+video.loop = true;          // gapless looping
+video.volume = 0.5;         // 0..1
+video.currentTime = 30;     // seek to 30 seconds (keyframe seeking)
+console.log(video.duration);
+```
+
+## Dimensions
+
+Use `videoWidth` and `videoHeight` (available after `loadedmetadata`) to size or
+letterbox the frame correctly:
+
+```typescript
+video.addEventListener('loadedmetadata', () => {
+  console.log(`${video.videoWidth} x ${video.videoHeight}`);
+});
+```
+
+## Playback Quality
+
+[`getVideoPlaybackQuality()`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/getVideoPlaybackQuality)
+reports decode statistics, useful for diagnostics:
+
+```typescript
+const q = video.getVideoPlaybackQuality();
+console.log(`dropped: ${q.droppedVideoFrames} / ${q.totalVideoFrames}`);
+```
+
+## Events
+
+The `Video` class dispatches standard media events, including `loadedmetadata`,
+`canplay`, `canplaythrough`, `play`, `pause`, `ended`, `timeupdate`, and
+`error`.
+
+> See the [`apps/video`](https://github.com/TooTallNate/nx.js/tree/main/apps/video)
+> example for a complete player with seeking, looping, and volume controls.
+
+## Learn more
+
+<Cards>
+  <Card title="Drawing images and frames with drawImage()" href="/runtime/concepts/images" />
+  <Card title="Audio &amp; Web Audio" href="/runtime/concepts/audio" />
+</Cards>

--- a/docs/content/runtime/configuration.mdx
+++ b/docs/content/runtime/configuration.mdx
@@ -1,0 +1,191 @@
+---
+title: Configuration
+description: Tuning the runtime with an nxjs.ini file
+---
+
+nx.js apps can be configured with an optional **`nxjs.ini`** file placed next to
+the application's entrypoint (i.e. in the root of the `romfs` directory,
+alongside `main.js`).
+
+This file is read **very early during startup** — before the V8 engine is even
+initialized — because some of its settings (the JIT mode and heap limit) must be
+applied before the JavaScript engine starts. It uses the standard INI format
+with `[section]` headers and `key = value` pairs. Lines beginning with `;` are
+comments.
+
+```ini title="romfs/nxjs.ini"
+[v8]
+jit = auto
+
+[memory]
+heap_limit = 256MiB
+
+[renderer]
+mode = auto
+```
+
+> [!NOTE]
+> The file is entirely optional. If it is missing, the runtime uses its
+> regime-aware defaults (see below). Any value that can't be honored (a clamped
+> heap, an invalid setting, a renderer fallback, etc.) is logged to
+> `sdmc:/switch/nxjs-debug.log` with the reason — a missing file is silent.
+
+## Memory regimes
+
+Many defaults depend on the **memory regime** the app is launched in:
+
+- **Application mode** — the full memory grant (~3 GiB). This is what you get
+  when launching hbmenu via the title override (hold R while opening a game), or
+  when running an installed `.nsp`. Defaults to full V8 JIT and GPU canvas
+  rendering.
+- **Applet mode** — a much smaller grant (~380 MiB). This is what you get when
+  launching from the Album. Defaults to a more conservative configuration: the
+  jitless interpreter, CPU raster rendering, and smaller buffers. (The jitless
+  default keeps enough memory free for the canvas terminal and other large
+  allocations; you can opt into JIT with `[v8] jit = on`.)
+
+Any setting whose requested value can't be honored in the current regime (a
+clamped heap, a GPU fallback, an oversized socket reservation, etc.) is logged to
+`sdmc:/switch/nxjs-debug.log` so you can see what the runtime actually applied.
+
+## `[v8]`
+
+Controls the V8 JavaScript engine.
+
+| Key | Values | Description |
+|-----|--------|-------------|
+| `jit` | `auto` (default), `on`, `off` | JIT compilation mode. `auto` enables full JIT in **application** mode and the jitless interpreter in **applet** mode; `on` forces full JIT everywhere; `off` forces the jitless interpreter everywhere. |
+| `flags` | string | Extra V8 flags, appended **after** the runtime's defaults (e.g. `--max-old-space-size=256`). |
+| `wasm` | `on` / `off` | Sugar for `code_headroom_mb = 64`. Reserves the extra JIT code-arena headroom that [WebAssembly](https://developer.mozilla.org/docs/WebAssembly) needs. |
+| `code_headroom_mb` | number | Explicit JIT code-arena headroom (MiB) for WebAssembly, beyond V8's 64 MiB code-range floor. |
+
+```ini
+[v8]
+jit   = auto
+flags = --max-old-space-size=256
+```
+
+> [!IMPORTANT]
+> **WebAssembly requires JIT** and extra code-arena headroom. It works out of
+> the box in **application mode**. In **applet mode** the headroom can't be
+> afforded by default, so WASM is opt-in there via `[v8] wasm = on` (or
+> `code_headroom_mb`). When WASM is unavailable, `WebAssembly.compile()` /
+> `instantiate()` throw a clear nx.js error pointing at this fix.
+
+## `[memory]`
+
+| Key | Values | Description |
+|-----|--------|-------------|
+| `heap_limit` | size | The V8 max heap size. Accepts `KiB`/`MiB`/`GiB` suffixes or raw bytes. Clamped to what actually fits in the current regime. |
+
+```ini
+[memory]
+heap_limit = 256MiB
+```
+
+## `[renderer]`
+
+| Key | Values | Description |
+|-----|--------|-------------|
+| `mode` | `auto` (default), `cpu`, `gpu` | The canvas renderer. `auto` picks GPU in application mode and CPU raster in applet mode. `gpu` falls back to raster if GPU init fails. |
+| `gpu_cache` | `auto` (default), `default`, number | The [Skia](https://skia.org/) Ganesh GPU resource-cache budget in MiB. `auto` uses 512 MiB in application mode and the Skia default in applet mode. Useful for texture-heavy apps that thrash the cache. |
+
+```ini
+[renderer]
+mode      = auto
+gpu_cache = auto
+```
+
+> [!NOTE]
+> [WebGL2](/runtime/rendering#webgl2) always requires the GPU path and is
+> therefore only available in application mode.
+
+## `[console]`
+
+Styles the on-screen [console](/runtime/rendering/console) terminal
+declaratively. All keys are optional; an explicit `console.options =` assignment
+at runtime overrides them.
+
+| Key | Description |
+|-----|-------------|
+| `font_size` | Terminal font size in pixels |
+| `cursor_style` | `block`, `underline`, or `bar` |
+| `background` / `foreground` / `cursor` | Base terminal colors (hex) |
+| `black`..`bright_white` | The full 16-color ANSI palette (hex) |
+
+```ini
+[console]
+font_size    = 22
+cursor_style = bar
+background   = #002b36
+foreground   = #839496
+
+black        = #073642
+red          = #dc322f
+green        = #859900
+; ...through bright_white
+```
+
+> See [`apps/console-theme`](https://github.com/TooTallNate/nx.js/tree/main/apps/console-theme)
+> for a complete Solarized Dark theme.
+
+## `[threadpool]`
+
+Configures the [libuv](https://libuv.org/) worker thread pool, which services
+**every** async native operation (file I/O, crypto, compression, image decode,
+DNS, …).
+
+| Key | Description |
+|-----|-------------|
+| `size` | Number of worker threads. Default: `2` in applet mode, `4` in application mode. |
+| `stack_size` | Per-worker stack size (256 KiB floor, 32 MiB cap). Default: `1MiB`. |
+
+```ini
+[threadpool]
+size       = 4
+stack_size = 1MiB
+```
+
+> [!CAUTION]
+> The defaults exist for a reason. libuv's upstream defaults (4 workers × 8 MiB
+> stacks) cannot be satisfied in applet mode, where exceeding the budget hard-
+> aborts the process. Raise these values with care, and test in applet mode.
+
+## `[socket]`
+
+Field-level overrides for the libnx socket configuration. All values are clamped
+so a bad value can't prevent the network stack from initializing.
+
+| Key | Description |
+|-----|-------------|
+| `tcp_tx_buf_size` / `tcp_rx_buf_size` | Initial TCP send/receive buffer sizes |
+| `tcp_tx_buf_max_size` / `tcp_rx_buf_max_size` | Maximum TCP send/receive buffer sizes |
+| `udp_tx_buf_size` / `udp_rx_buf_size` | UDP send/receive buffer sizes |
+| `sb_efficiency` | Socket buffer efficiency multiplier |
+| `num_bsd_sessions` | Number of BSD sessions |
+| `service_type` | `auto` (default), `user`, or `system` |
+
+```ini
+[socket]
+tcp_tx_buf_size = 256KiB
+tcp_rx_buf_size = 256KiB
+```
+
+## `[runtime]`
+
+This section is read by the [slim bootstrap launcher](/runtime/packaging),
+**not** by the runtime itself.
+
+| Key | Description |
+|-----|-------------|
+| `version` | A [semver](https://semver.org/) requirement for the shared runtime NRO (e.g. `^1.0.0-beta.2`). |
+
+```ini
+[runtime]
+version = ^1.0.0-beta.2
+```
+
+> [!NOTE]
+> When packaging a slim app, this section is generated for you (baked to
+> `^<the full runtime version the app was built against>`). You normally won't
+> edit it by hand.

--- a/docs/content/runtime/index.mdx
+++ b/docs/content/runtime/index.mdx
@@ -63,19 +63,26 @@ In the end, you will have a new directory which contains the cloned template for
 
 ## Bundle the source code
 
-nx.js evaluates a single JavaScript file at runtime. It does _not_ implement a module loader. Therefore,
-when separating your application code into multiple files, it is the responsibility of a _bundler_ to
-combine the source files into a singular "bundle", which is the code that nx.js runs.
+The example templates are pre-configured to bundle your application into a single
+`romfs/main.js` file (the entrypoint that nx.js runs) using [`esbuild`][]. This
+is the recommended workflow: the bundler resolves your imports and npm
+dependencies at build time, and outputs a single optimized file.
 
-All of the example templates are pre-configured to use [`esbuild`][], but you can use a different bundler
-if you prefer, such as Parcel or Rollup.
-
-Run the `build` script to bundle the application into the `romfs/main.js` file, which is the entrypoint
-of the nx.js app:
+Run the `build` script to produce `romfs/main.js`:
 
 ```bash
 npm run build
 ```
+
+You can use a different bundler if you prefer, such as Parcel or Rollup.
+
+> [!NOTE]
+> nx.js also supports native ES module
+> [`import`](/runtime/concepts/modules) at runtime, so you _can_ ship an
+> unbundled multi-file app or lazy-load modules with dynamic `import()`. Bundling
+> is still recommended for distribution, since runtime import resolution is
+> synchronous and limited to local files (`romfs:`/`sdmc:`/`nxjs:` — no bare npm
+> specifiers or remote URLs).
 
 > [!TIP]
 > You may place other files within the `romfs` directory, and they will become embedded within the RomFS
@@ -94,10 +101,17 @@ npm run nro
 This will result in a `<your app name>.nro` file in the root directory of your project. You can then upload
 this file to Switch via FTP or directly copy it to the SD card, and then launch the app from the homebrew menu.
 
+> [!NOTE]
+> By default this produces a **slim** NRO — a tiny launcher that shares one nx.js
+> runtime installed on the SD card. See [Packaging](/runtime/packaging) for the
+> slim vs. fat tradeoff and how the shared runtime is installed.
+
 ## Learn more
 
 <Cards>
   <Card title="Customizing package metadata and icon" href="/runtime/metadata" />
+  <Card title="Slim vs. fat packaging" href="/runtime/packaging" />
+  <Card title="Configure the runtime with nxjs.ini" href="/runtime/configuration" />
   <Card title="Learn about the available rendering mode APIs" href="/runtime/rendering" />
 </Cards>
 

--- a/docs/content/runtime/meta.json
+++ b/docs/content/runtime/meta.json
@@ -4,6 +4,8 @@
     "--- Documentation ---",
     "index",
     "metadata",
+    "configuration",
+    "packaging",
     "...",
     "--- API Reference ---",
     "...api"

--- a/docs/content/runtime/packaging.mdx
+++ b/docs/content/runtime/packaging.mdx
@@ -1,0 +1,81 @@
+---
+title: Packaging
+description: Slim vs. fat packaging for distributing your nx.js app
+---
+
+When you package an nx.js app into a `.nro` (homebrew menu) or `.nsp` (installed
+title), you choose how the **runtime** is bundled. There are two modes: **slim**
+(the default) and **fat**.
+
+## Slim vs. fat
+
+| | **Slim** (default) | **Fat** |
+|---|---|---|
+| App file size | A few hundred KB | ~40 MB (NRO) / ~21 MB (NSP) |
+| Runtime | Shared, installed once at `sdmc:/nx.js/` | Embedded in every app |
+| Best for | Most apps; multiple nx.js apps on one console | Self-contained distribution |
+
+A **slim** app is a tiny launcher. At boot it _chainloads_ a shared nx.js
+runtime NRO installed at `sdmc:/nx.js/nxjs-v<version>.nro`, selected by the
+[`[runtime] version`](/runtime/configuration#runtime) semver requirement baked
+into the app's `nxjs.ini`. Many slim apps can share a single runtime, so you
+don't pay the ~40 MB cost per app.
+
+A **fat** app embeds the entire runtime, so it is fully self-contained and runs
+without anything else installed.
+
+> [!NOTE]
+> Slim became the default in `@nx.js/nro` v1 (previously every NRO was fat).
+
+## Building
+
+The packaging scripts produced by the templates are
+[`nxjs-nro`](https://www.npmjs.com/package/@nx.js/nro) and
+[`nxjs-nsp`](https://www.npmjs.com/package/@nx.js/nsp). They build slim by
+default; pass `--fat` (or set the `NXJS_FAT=1` environment variable) for a
+self-contained build:
+
+```bash
+# Slim (default)
+npm run nro
+
+# Fat (self-contained)
+npx nxjs-nro --fat
+```
+
+> [!TIP]
+> When scaffolding with [`create-nxjs-app`](/runtime#clone-a-template), you're
+> prompted to choose slim or fat. Choosing fat adds the `--fat` flag to the
+> generated `nro`/`nsp` scripts.
+
+## Installing the shared runtime (slim)
+
+A slim app needs a compatible shared runtime present on the SD card under
+`sdmc:/nx.js/`. There are two ways this happens:
+
+1. **Automatic download.** If no compatible runtime is installed, the slim
+   bootstrap launcher downloads one automatically from the nx.js GitHub releases
+   over the network, shows an on-screen progress indicator, saves it to
+   `sdmc:/nx.js/nxjs-v<version>.nro`, and continues launching. A freshly-
+   installed slim app "just works" on a network-connected console.
+2. **Manual.** Download a runtime `nxjs.nro` from the
+   [releases](https://github.com/TooTallNate/nx.js/releases) and place it at
+   `sdmc:/nx.js/nxjs-v<version>.nro`. (If the automatic download can't proceed,
+   the launcher shows these instructions on-screen.)
+
+Multiple runtime versions can coexist under `sdmc:/nx.js/`; each slim app picks
+the highest installed version that satisfies its requirement.
+
+## NSP packaging
+
+The same slim/fat choice applies to `.nsp` (installed-title) builds via
+`nxjs-nsp`. A slim NSP uses a tiny forwarder as its executable, which chainloads
+the shared runtime and mounts the installed title's own files as `romfs:`. Pass
+`--fat` for a self-contained NSP.
+
+## Learn more
+
+<Cards>
+  <Card title="Configure the [runtime] version requirement" href="/runtime/configuration#runtime" />
+  <Card title="Customize metadata and icon" href="/runtime/metadata" />
+</Cards>

--- a/docs/content/runtime/rendering/console.mdx
+++ b/docs/content/runtime/rendering/console.mdx
@@ -13,8 +13,7 @@ nx.js renders the console output using a **canvas-backed terminal**: a headless
 [xterm.js](https://xtermjs.org) instance drawn to the screen with the Canvas 2D
 API in the bundled [Geist Mono](https://vercel.com/font) font. This means the
 console supports full ANSI colors, UTF-8 text, scrollback, and customizable
-styling — a major upgrade over the fixed `libnx` terminal that earlier versions
-of nx.js used.
+styling.
 
 > [!TIP]
 > To draw more intricate graphics, your application should use [__canvas rendering__](/runtime/rendering/canvas) mode.

--- a/docs/content/runtime/rendering/console.mdx
+++ b/docs/content/runtime/rendering/console.mdx
@@ -1,13 +1,20 @@
 ---
 title: Console
-description: Logging to the Console for text based applications
+description: Logging to the screen for text based applications
 ---
 
 import HelloWorldScreenshot from '@/screenshots/hello-world.jpg';
 
 If your application is purely text-based, you can use the familiar
-global [`console`](/runtime/api/variables/console) object to write textual data to the screen of the application
-in the terminal-like interface that [`libnx`](https://github.com/switchbrew/libnx) provides.
+global [`console`](/runtime/api/variables/console) object to write textual data
+to the screen.
+
+nx.js renders the console output using a **canvas-backed terminal**: a headless
+[xterm.js](https://xtermjs.org) instance drawn to the screen with the Canvas 2D
+API in the bundled [Geist Mono](https://vercel.com/font) font. This means the
+console supports full ANSI colors, UTF-8 text, scrollback, and customizable
+styling — a major upgrade over the fixed `libnx` terminal that earlier versions
+of nx.js used.
 
 > [!TIP]
 > To draw more intricate graphics, your application should use [__canvas rendering__](/runtime/rendering/canvas) mode.
@@ -25,18 +32,107 @@ console.log('Press the + button to exit...');
 
 ## ANSI Escape Codes
 
+The canvas terminal honors the full xterm ANSI palette (the 16 base colors plus
+truecolor `38;2;…`/`48;2;…` sequences), so colored output and cursor movement
+work as you would expect from a real terminal.
+
 Listed below is a (non-exhaustive) list of npm modules known to work well with nx.js when using console rendering mode:
 
 * [`kleur`](https://github.com/lukeed/kleur) - Output colored text with ANSI escape codes
 * [`sisteransi`](https://github.com/terkelg/sisteransi) - ANSI escape sequences for moving the cursor
 
-## Limitations
+## Scrollback
 
-It is worth noting that the terminal interface that `libnx` provides
-has dimensions of 80 x 45 characters, supports a limited set of unicode characters,
-and provides no customization options for the appearance of the text.
+Output that scrolls off the top of the screen is retained in a scrollback
+buffer. Use [`console.scrollUp()`](/runtime/api/classes/Console#scrollup) and
+[`console.scrollDown()`](/runtime/api/classes/Console#scrolldown) to navigate it
+(you can also drag with the touchscreen):
 
-> There is a work-in-progress `@nx.js/terminal` package
-> (see [#112](https://github.com/TooTallNate/nx.js/pull/112)), which will provide
-> a more full-featured terminal interface powered by [`xterm.js`](https://xtermjs.org),
-> which will allow for more control over the visual appearance of your application.
+```typescript
+console.scrollUp(5);   // scroll up 5 rows into the scrollback
+console.scrollDown(5); // scroll back down
+```
+
+## Theming
+
+The console is fully themeable. You can configure it programmatically by
+assigning [`console.options`](/runtime/api/classes/Console#options), or
+declaratively via the [`[console]` section of `nxjs.ini`](/runtime/configuration#console).
+
+> [!IMPORTANT]
+> The terminal is created _lazily_, on the first log. Assign `console.options`
+> **before** your first `console.*` call so the options take effect on the
+> initial render. Re-assigning `options` rebuilds the terminal (and resets the
+> scrollback buffer).
+
+```typescript title="src/main.ts"
+console.options = {
+  fontSize: 24,
+  cursorStyle: 'bar', // 'block' | 'underline' | 'bar'
+  theme: {
+    background: '#002b36',
+    foreground: '#839496',
+    // ...the full `black`..`brightWhite` ANSI palette is supported
+  },
+};
+
+console.log('Now with a Solarized Dark theme!');
+```
+
+Available options (from [`TerminalOptions`](/runtime/api/interfaces/TerminalOptions)):
+
+| Option | Description |
+|--------|-------------|
+| `theme` | Terminal colors (`background`, `foreground`, `cursor`, and the `black`..`brightWhite` ANSI palette) |
+| `fontSize` | Font size in pixels |
+| `lineHeight` | Line height multiplier |
+| `scrollback` | Number of scrollback rows to retain |
+| `cursorStyle` | `'block'`, `'underline'`, or `'bar'` |
+| `cursorOpacity` | Cursor opacity (`0`–`1`) |
+
+> See the [`apps/console-theme`](https://github.com/TooTallNate/nx.js/tree/main/apps/console-theme)
+> example for a complete Solarized Dark theme configured via `nxjs.ini`.
+
+## Compositing the console canvas
+
+The console renders to an offscreen canvas, accessible via
+[`console.canvas`](/runtime/api/classes/Console#canvas). This lets a
+[canvas-rendering](/runtime/rendering/canvas) app composite the console output
+into its own scene — for example, an in-game debug overlay:
+
+```typescript
+const ctx = screen.getContext('2d');
+
+function update() {
+  requestAnimationFrame(update);
+  // ...draw your scene...
+
+  // Composite the live console output in the top-left corner
+  ctx.drawImage(console.canvas, 0, 0);
+}
+update();
+```
+
+The console keeps updating its canvas as long as you read `console.canvas`, even
+after an app has taken over the screen with `screen.getContext('2d')`.
+
+## Isolated `Console` instances
+
+In addition to the global `console`, you can create isolated
+[`Console`](/runtime/api/classes/Console) instances. Each renders to its own
+`canvas` (it does not auto-present to the screen), which is useful for
+multiple independent terminal surfaces:
+
+```typescript
+const term = new Console({ fontSize: 18, scrollback: 500 });
+term.log('Output for this terminal only');
+ctx.drawImage(term.canvas, 100, 100);
+```
+
+## Fallback behavior
+
+When no font or display is available (for example, when the canvas terminal
+can't be allocated in the memory-constrained applet regime), the console
+gracefully falls back to the native `libnx` terminal so output is never lost.
+The underlying error and stack are also written to
+`sdmc:/switch/nxjs-debug.log`.

--- a/docs/content/runtime/rendering/console.mdx
+++ b/docs/content/runtime/rendering/console.mdx
@@ -54,15 +54,38 @@ console.scrollDown(5); // scroll back down
 
 ## Theming
 
-The console is fully themeable. You can configure it programmatically by
-assigning [`console.options`](/runtime/api/classes/Console#options), or
-declaratively via the [`[console]` section of `nxjs.ini`](/runtime/configuration#console).
+The console is fully themeable. The recommended way is declaratively, via the
+[`[console]` section of `nxjs.ini`](/runtime/configuration#console) — the runtime
+reads it at startup and styles the global `console` for you, with no app code:
 
-> [!IMPORTANT]
-> The terminal is created _lazily_, on the first log. Assign `console.options`
-> **before** your first `console.*` call so the options take effect on the
-> initial render. Re-assigning `options` rebuilds the terminal (and resets the
-> scrollback buffer).
+```ini title="romfs/nxjs.ini"
+[console]
+font_size    = 22
+cursor_style = bar              ; block | underline | bar
+
+background   = #002b36
+foreground   = #839496
+cursor       = #93a1a1
+
+; The full 16-color ANSI palette (black..bright_white) is supported
+black        = #073642
+red          = #dc322f
+green        = #859900
+yellow       = #b58900
+blue         = #268bd2
+magenta      = #d33682
+cyan         = #2aa198
+white        = #eee8d5
+```
+
+> See the [`apps/console-theme`](https://github.com/TooTallNate/nx.js/tree/main/apps/console-theme)
+> example for a complete Solarized Dark theme configured this way.
+
+### Programmatic theming
+
+You can also configure the console at runtime by assigning
+[`console.options`](/runtime/api/classes/Console#options) (this overrides any
+`nxjs.ini` styling):
 
 ```typescript title="src/main.ts"
 console.options = {
@@ -78,6 +101,12 @@ console.options = {
 console.log('Now with a Solarized Dark theme!');
 ```
 
+> [!IMPORTANT]
+> The terminal is created _lazily_, on the first log. Assign `console.options`
+> **before** your first `console.*` call so the options take effect on the
+> initial render. Re-assigning `options` rebuilds the terminal (and resets the
+> scrollback buffer).
+
 Available options (from [`TerminalOptions`](/runtime/api/interfaces/TerminalOptions)):
 
 | Option | Description |
@@ -88,9 +117,6 @@ Available options (from [`TerminalOptions`](/runtime/api/interfaces/TerminalOpti
 | `scrollback` | Number of scrollback rows to retain |
 | `cursorStyle` | `'block'`, `'underline'`, or `'bar'` |
 | `cursorOpacity` | Cursor opacity (`0`–`1`) |
-
-> See the [`apps/console-theme`](https://github.com/TooTallNate/nx.js/tree/main/apps/console-theme)
-> example for a complete Solarized Dark theme configured via `nxjs.ini`.
 
 ## Compositing the console canvas
 

--- a/docs/content/runtime/rendering/index.mdx
+++ b/docs/content/runtime/rendering/index.mdx
@@ -15,6 +15,9 @@ To use console rendering mode, use the functions available on the global [`conso
 console.log('Hello World');
 ```
 
+The console is rendered as a fully-featured, themeable terminal (ANSI colors,
+UTF-8, and scrollback) drawn with the Canvas API.
+
 ## Canvas Rendering
 
 [__Canvas rendering__](/runtime/rendering/canvas) mode is useful for graphical user interfaces and games.


### PR DESCRIPTION
## Summary

The documentation had gone essentially untouched since the `1.0.0-beta` rewrite (V8 + libuv, Cairo → Skia, #340). This audits the user-facing changes since then (via the changesets) and brings the docs site + `README.md` back in sync.

### README
- QuickJS → **V8**; add Skia, WebGL2, Web Audio/Video (FFmpeg), and Web Bluetooth to the feature list.
- Rewrote **Building from Source** for the current toolchain — the old steps referenced `qjsc`, cairo, pixman, wasm3, and quickjs-ng (all removed). Custom packages (`switch-v8`/`switch-skia`/`switch-libuv`/`switch-ada`/`switch-dav1d`) come from the Docker image; the rest from the registry. Points at `build.sh`.

### New pages
- **Configuration** — the `nxjs.ini` file (`[v8]`, `[memory]`, `[renderer]`, `[console]`, `[threadpool]`, `[socket]`, `[runtime]`).
- **Packaging** — slim (the new default) vs. fat, the shared runtime + auto-download, and slim/fat NSP.
- **concepts/Video** — the `Video` element (FFmpeg pipeline; draw each frame with `ctx.drawImage`).
- **concepts/Bluetooth** — Web Bluetooth / BLE GATT client.
- **concepts/ES Modules** — native `import` resolution for unbundled multi-file apps + dynamic `import()`.

### Updated
- **rendering/Console** — rewrote the stale libnx-PrintConsole content (80×45, no customization) to the canvas-backed, themeable xterm.js terminal (ANSI, scrollback, theming, `console.canvas`, isolated `Console` instances).
- **concepts/Audio** — FFmpeg-backed formats; folded the **Web Audio API** in as a section of this page.
- **Getting Started** — corrected the "no module loader" claim; noted slim/fat packaging.
- **Event Loop** — mention the libuv-driven loop + timer/microtask functions.
- Concepts & rendering indexes, `meta.json` ordering.

## Notes
- Docs-only / `README` change — no `source/` or runtime changes, so no changeset.
- Validated locally by regenerating the Fumadocs content (`fumadocs-mdx`) — all pages compile, with no broken internal links/anchors.
- Applet mode correctly documented as **jitless by default** (`jit = auto`), with JIT opt-in via `[v8] jit = on`.