### PR TITLE
feat: add WebUSB support

### DIFF
--- a/.changeset/webusb.md
+++ b/.changeset/webusb.md
@@ -1,0 +1,10 @@
+---
+"@nx.js/runtime": minor
+---
+
+feat: implement initial WebUSB support (`navigator.usb`) backed by libnx `usb:hs`
+
+Includes USB device discovery by descriptor filters, opening/closing devices,
+claiming interfaces, bulk `transferIn()` / `transferOut()`, control
+`controlTransferIn()`, and device reset. Adds a `webusb-rcm` example that sends
+fusee/hekate-style RCM payloads to a v1 Nintendo Switch in RCM mode.

--- a/apps/webusb-rcm/.gitignore
+++ b/apps/webusb-rcm/.gitignore
@@ -1,0 +1,3 @@
+romfs
+*.nro
+*.nsp

--- a/apps/webusb-rcm/package.json
+++ b/apps/webusb-rcm/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "webusb-rcm",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Send a fusee/hekate payload to a Switch in RCM mode over WebUSB",
+  "scripts": {
+    "build": "esbuild --bundle --sourcemap --sources-content=false --target=es2022 --format=esm --outdir=romfs src/main.ts",
+    "nro": "nxjs-nro",
+    "nsp": "nxjs-nsp"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@nx.js/nro": "workspace:^",
+    "@nx.js/nsp": "workspace:^",
+    "@nx.js/runtime": "workspace:^",
+    "esbuild": "catalog:"
+  }
+}

--- a/apps/webusb-rcm/src/main.ts
+++ b/apps/webusb-rcm/src/main.ts
@@ -77,16 +77,20 @@ async function main() {
 	}
 
 	console.log('Triggering RCM vulnerability...');
-	await device.controlTransferIn(
-		{
-			requestType: 'standard',
-			recipient: 'interface',
-			request: 0,
-			value: 0,
-			index: 0,
-		},
-		0x7000,
-	);
+	try {
+		await device.controlTransferIn(
+			{
+				requestType: 'standard',
+				recipient: 'interface',
+				request: 0,
+				value: 0,
+				index: 0,
+			},
+			0x7000,
+		);
+	} catch (err) {
+		console.log('Target disconnected during smash; this is expected if Hekate booted.');
+	}
 	console.log('Done.');
 }
 

--- a/apps/webusb-rcm/src/main.ts
+++ b/apps/webusb-rcm/src/main.ts
@@ -1,0 +1,95 @@
+const intermezzo = new Uint8Array([
+	0x44, 0x00, 0x9f, 0xe5, 0x01, 0x11, 0xa0, 0xe3, 0x40, 0x20, 0x9f, 0xe5,
+	0x00, 0x20, 0x42, 0xe0, 0x08, 0x00, 0x00, 0xeb, 0x01, 0x01, 0xa0, 0xe3,
+	0x10, 0xff, 0x2f, 0xe1, 0x00, 0x00, 0xa0, 0xe1, 0x2c, 0x00, 0x9f, 0xe5,
+	0x2c, 0x10, 0x9f, 0xe5, 0x02, 0x28, 0xa0, 0xe3, 0x01, 0x00, 0x00, 0xeb,
+	0x20, 0x00, 0x9f, 0xe5, 0x10, 0xff, 0x2f, 0xe1, 0x04, 0x30, 0x90, 0xe4,
+	0x04, 0x30, 0x81, 0xe4, 0x04, 0x20, 0x52, 0xe2, 0xfb, 0xff, 0xff, 0x1a,
+	0x1e, 0xff, 0x2f, 0xe1, 0x20, 0xf0, 0x01, 0x40, 0x5c, 0xf0, 0x01, 0x40,
+	0x00, 0x00, 0x02, 0x40, 0x00, 0x00, 0x01, 0x40,
+]);
+
+const RCM_PAYLOAD_ADDRESS = 0x40010000;
+const INTERMEZZO_LOCATION = 0x4001f000;
+const PACKET_SIZE = 0x1000;
+
+function createRCMPayload(payload: Uint8Array) {
+	const rcmLength = 0x30298;
+	const repeatCount = (INTERMEZZO_LOCATION - RCM_PAYLOAD_ADDRESS) / 4;
+	const size = Math.ceil(
+		(0x2a8 + repeatCount * 4 + PACKET_SIZE + payload.byteLength) / PACKET_SIZE,
+	) * PACKET_SIZE;
+	const rcm = new Uint8Array(size);
+	const view = new DataView(rcm.buffer);
+	view.setUint32(0, rcmLength, true);
+	for (let i = 0; i < repeatCount; i++) {
+		view.setUint32(0x2a8 + i * 4, INTERMEZZO_LOCATION, true);
+	}
+	rcm.set(intermezzo, 0x2a8 + repeatCount * 4);
+	rcm.set(payload, 0x2a8 + repeatCount * 4 + PACKET_SIZE);
+	return rcm;
+}
+
+async function writePayload(device: USBDevice, data: Uint8Array) {
+	let offset = 0;
+	let writes = 0;
+	while (offset < data.byteLength) {
+		const end = Math.min(offset + PACKET_SIZE, data.byteLength);
+		await device.transferOut(1, data.subarray(offset, end));
+		offset = end;
+		writes++;
+	}
+	return writes;
+}
+
+async function main() {
+	console.log('WebUSB RCM payload sender');
+	console.log('Place hekate/fusee at romfs:/payload.bin before building.');
+
+	const payloadBuffer = Switch.readFileSync('romfs:/payload.bin');
+	if (!payloadBuffer) {
+		throw new Error('Missing romfs:/payload.bin');
+	}
+	const payload = new Uint8Array(payloadBuffer);
+	console.log(`Payload: ${payload.byteLength} bytes`);
+	console.log('Connect the target Switch in RCM mode over USB-C...');
+
+	const device = await navigator.usb.requestDevice({
+		filters: [{ vendorId: 0x0955, productId: 0x7321 }],
+	});
+	console.log(`Found USB device ${device.vendorId.toString(16)}:${device.productId.toString(16)}`);
+
+	await device.open();
+	await device.claimInterface(0);
+
+	const deviceId = await device.transferIn(1, 16);
+	console.log(
+		`Device ID: ${[...new Uint8Array(deviceId.data!.buffer)]
+			.map((v) => v.toString(16).padStart(2, '0'))
+			.join('')}`,
+	);
+
+	console.log('Sending RCM payload...');
+	const writes = await writePayload(device, createRCMPayload(payload));
+	if (writes % 2 !== 1) {
+		console.log('Sending padding packet...');
+		await device.transferOut(1, new ArrayBuffer(PACKET_SIZE));
+	}
+
+	console.log('Triggering RCM vulnerability...');
+	await device.controlTransferIn(
+		{
+			requestType: 'standard',
+			recipient: 'interface',
+			request: 0,
+			value: 0,
+			index: 0,
+		},
+		0x7000,
+	);
+	console.log('Done.');
+}
+
+main().catch((err) => {
+	console.error(err?.stack || err);
+});

--- a/apps/webusb-rcm/tsconfig.json
+++ b/apps/webusb-rcm/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@nx.js/runtime"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/runtime/src/$.ts
+++ b/packages/runtime/src/$.ts
@@ -128,6 +128,7 @@ type DecompressHandle = Opaque<'DecompressHandle'>;
 type DecompressFileHandle = Opaque<'DecompressFileHandle'>;
 type SaveDataIterator = Opaque<'SaveDataIterator'>;
 type URLSearchParamsIterator = Opaque<'URLSearchParamsIterator'>;
+export type USBNativeDevice = Opaque<'USBNativeDevice'>;
 
 /** Effective socket (libnx SocketInitConfig) values, after nxjs.ini overrides. */
 export interface NxSocketConfig {
@@ -803,6 +804,45 @@ export interface Init {
 	/** Request an ATT MTU for the connection (browsers negotiate ~517). */
 	btleConfigureMtu(conn: number, mtu: number): void;
 	btleGetMtu(conn: number): number;
+
+	// usb.cc — WebUSB over libnx usb:hs (USB host mode)
+	usbInit(): void;
+	usbExit(): void;
+	usbGetDevices(filter?: {
+		vendorId?: number;
+		productId?: number;
+		classCode?: number;
+		subclassCode?: number;
+		protocolCode?: number;
+		interfaceClass?: number;
+		interfaceSubclass?: number;
+		interfaceProtocol?: number;
+	}): USBNativeDevice[];
+	usbDeviceOpen(device: USBNativeDevice): void;
+	usbDeviceClose(device: USBNativeDevice): void;
+	usbClaimInterface(device: USBNativeDevice, interfaceNumber: number): void;
+	usbTransferIn(
+		device: USBNativeDevice,
+		endpointNumber: number,
+		length: number,
+	): ArrayBuffer;
+	usbTransferOut(
+		device: USBNativeDevice,
+		endpointNumber: number,
+		data: BufferSource,
+	): number;
+	usbControlTransferIn(
+		device: USBNativeDevice,
+		setup: {
+			requestType: string;
+			recipient: string;
+			request: number;
+			value: number;
+			index: number;
+		},
+		length: number,
+	): ArrayBuffer;
+	usbResetDevice(device: USBNativeDevice): void;
 
 	// video.cc — Video element (ffmpeg media pipeline)
 	videoNew(): VideoHandle;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -33,6 +33,7 @@ export type * from './image';
 export type * from './navigator';
 export type * from './navigator/battery';
 export type * from './navigator/bluetooth';
+export type * from './navigator/usb';
 export type {
 	Gamepad,
 	GamepadButton,

--- a/packages/runtime/src/navigator.ts
+++ b/packages/runtime/src/navigator.ts
@@ -10,6 +10,7 @@ import {
 } from './navigator/virtual-keyboard';
 import { Application, type Vibration } from './switch';
 import { bluetooth } from './navigator/bluetooth';
+import { usb } from './navigator/usb';
 
 interface NavigatorState {
 	batt?: Promise<BatteryManager>;
@@ -232,6 +233,16 @@ export class Navigator {
 	 */
 	get bluetooth() {
 		return bluetooth;
+	}
+
+	/**
+	 * Entry point to the WebUSB API, for communicating with USB devices attached
+	 * to the Switch's USB-C port while the host Switch is in USB host mode.
+	 *
+	 * @see https://developer.mozilla.org/docs/Web/API/Navigator/usb
+	 */
+	get usb() {
+		return usb;
 	}
 }
 def(Navigator);

--- a/packages/runtime/src/navigator/usb.ts
+++ b/packages/runtime/src/navigator/usb.ts
@@ -3,6 +3,7 @@ import { DOMException } from '../dom-exception';
 import { INTERNAL_SYMBOL } from '../internal';
 import type { BufferSource } from '../types';
 import { assertInternalConstructor, def } from '../utils';
+import { setTimeout } from '../timers';
 
 type USBControlTransferType = 'standard' | 'class' | 'vendor';
 type USBRequestType = USBControlTransferType | 'reserved';
@@ -106,6 +107,10 @@ function ensureInit() {
 		$.usbExit();
 		initialized = false;
 	});
+}
+
+function yieldToLoop() {
+	return new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 function validateByte(name: string, value: number) {
@@ -265,6 +270,7 @@ export class USBDevice {
 	async open(): Promise<void> {
 		const state = _device.get(this)!;
 		if (!state.opened) {
+			await yieldToLoop();
 			$.usbDeviceOpen(state.native);
 			state.opened = true;
 		}
@@ -273,6 +279,7 @@ export class USBDevice {
 	async close(): Promise<void> {
 		const state = _device.get(this)!;
 		if (state.opened) {
+			await yieldToLoop();
 			$.usbDeviceClose(state.native);
 			state.opened = false;
 			for (const config of this.configurations) {
@@ -297,6 +304,7 @@ export class USBDevice {
 		if (!state.opened) {
 			throw new DOMException('The device must be opened first.', 'InvalidStateError');
 		}
+		await yieldToLoop();
 		$.usbClaimInterface(state.native, interfaceNumber);
 		const iface = state.configuration?.interfaces.find(
 			(i) => i.interfaceNumber === interfaceNumber,
@@ -334,6 +342,7 @@ export class USBDevice {
 		validateByte('endpointNumber', endpointNumber);
 		validateWord('length', length);
 		const state = _device.get(this)!;
+		await yieldToLoop();
 		const buffer = $.usbTransferIn(state.native, endpointNumber, length);
 		return { data: new DataView(buffer), status: 'ok' };
 	}
@@ -344,6 +353,7 @@ export class USBDevice {
 	): Promise<USBOutTransferResult> {
 		validateByte('endpointNumber', endpointNumber);
 		const state = _device.get(this)!;
+		await yieldToLoop();
 		return {
 			bytesWritten: $.usbTransferOut(state.native, endpointNumber, data),
 			status: 'ok',
@@ -365,12 +375,14 @@ export class USBDevice {
 		validateWord('index', setup.index);
 		validateWord('length', length);
 		const state = _device.get(this)!;
+		await yieldToLoop();
 		const buffer = $.usbControlTransferIn(state.native, setup, length);
 		return { data: new DataView(buffer), status: 'ok' };
 	}
 
 	async reset(): Promise<void> {
 		const state = _device.get(this)!;
+		await yieldToLoop();
 		$.usbResetDevice(state.native);
 	}
 }

--- a/packages/runtime/src/navigator/usb.ts
+++ b/packages/runtime/src/navigator/usb.ts
@@ -1,0 +1,412 @@
+import { $, type USBNativeDevice } from '../$';
+import { DOMException } from '../dom-exception';
+import { INTERNAL_SYMBOL } from '../internal';
+import type { BufferSource } from '../types';
+import { assertInternalConstructor, def } from '../utils';
+
+type USBControlTransferType = 'standard' | 'class' | 'vendor';
+type USBRequestType = USBControlTransferType | 'reserved';
+type USBRecipient = 'device' | 'interface' | 'endpoint' | 'other';
+type USBTransferStatus = 'ok' | 'stall' | 'babble';
+type USBDirection = 'in' | 'out';
+type USBEndpointType = 'bulk' | 'interrupt' | 'isochronous';
+
+export interface USBDeviceFilter {
+	vendorId?: number;
+	productId?: number;
+	classCode?: number;
+	subclassCode?: number;
+	protocolCode?: number;
+	interfaceClass?: number;
+	interfaceSubclass?: number;
+	interfaceProtocol?: number;
+}
+
+export interface USBDeviceRequestOptions {
+	filters?: USBDeviceFilter[];
+}
+
+export interface USBControlTransferParameters {
+	requestType: USBRequestType;
+	recipient: USBRecipient;
+	request: number;
+	value: number;
+	index: number;
+}
+
+export interface USBInTransferResult {
+	data?: DataView;
+	status: USBTransferStatus;
+}
+
+export interface USBOutTransferResult {
+	bytesWritten: number;
+	status: USBTransferStatus;
+}
+
+interface USBEndpointDescriptor {
+	endpointNumber: number;
+	direction: USBDirection;
+	type: USBEndpointType;
+	packetSize: number;
+}
+
+interface USBAlternateInterfaceDescriptor {
+	alternateSetting: number;
+	interfaceClass: number;
+	interfaceSubclass: number;
+	interfaceProtocol: number;
+	endpoints: USBEndpointDescriptor[];
+}
+
+interface USBInterfaceDescriptor {
+	interfaceNumber: number;
+	claimed?: boolean | number;
+	alternates: USBAlternateInterfaceDescriptor[];
+}
+
+interface USBConfigurationDescriptor {
+	configurationValue: number;
+	interfaces: USBInterfaceDescriptor[];
+}
+
+interface USBNativeDescriptor extends USBNativeDevice {
+	usbVersionMajor: number;
+	usbVersionMinor: number;
+	usbVersionSubminor: number;
+	deviceClass: number;
+	deviceSubclass: number;
+	deviceProtocol: number;
+	vendorId: number;
+	productId: number;
+	deviceVersionMajor: number;
+	deviceVersionMinor: number;
+	deviceVersionSubminor: number;
+	manufacturerName?: string;
+	productName?: string;
+	serialNumber?: string;
+	configurations: USBConfigurationDescriptor[];
+}
+
+interface USBDeviceState {
+	native: USBNativeDescriptor;
+	opened: boolean;
+	configuration?: USBConfiguration;
+}
+
+const INTERNAL = INTERNAL_SYMBOL;
+const _device = new WeakMap<USBDevice, USBDeviceState>();
+let initialized = false;
+
+function ensureInit() {
+	if (initialized) return;
+	$.usbInit();
+	initialized = true;
+	addEventListener('unload', () => {
+		$.usbExit();
+		initialized = false;
+	});
+}
+
+function validateByte(name: string, value: number) {
+	if (!Number.isInteger(value) || value < 0 || value > 0xff) {
+		throw new TypeError(`${name} must be an integer in the range 0-255`);
+	}
+}
+
+function validateWord(name: string, value: number) {
+	if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
+		throw new TypeError(`${name} must be an integer in the range 0-65535`);
+	}
+}
+
+function validateFilter(filter: USBDeviceFilter) {
+	for (const key of [
+		'vendorId',
+		'productId',
+		'classCode',
+		'subclassCode',
+		'protocolCode',
+		'interfaceClass',
+		'interfaceSubclass',
+		'interfaceProtocol',
+	] as const) {
+		const value = filter[key];
+		if (typeof value !== 'undefined') {
+			validateWord(key, value);
+		}
+	}
+}
+
+function deviceFromNative(native: USBNativeDescriptor): USBDevice {
+	return new USBDevice(INTERNAL, native);
+}
+
+/** A USB endpoint descriptor exposed by {@link USBAlternateInterface}. */
+export class USBEndpoint {
+	readonly endpointNumber: number;
+	readonly direction: USBDirection;
+	readonly type: USBEndpointType;
+	readonly packetSize: number;
+
+	constructor(_internal: symbol, desc: USBEndpointDescriptor) {
+		assertInternalConstructor(arguments);
+		this.endpointNumber = desc.endpointNumber;
+		this.direction = desc.direction;
+		this.type = desc.type;
+		this.packetSize = desc.packetSize;
+	}
+}
+def(USBEndpoint);
+
+/** A USB alternate interface descriptor. */
+export class USBAlternateInterface {
+	readonly alternateSetting: number;
+	readonly interfaceClass: number;
+	readonly interfaceSubclass: number;
+	readonly interfaceProtocol: number;
+	readonly endpoints: USBEndpoint[];
+
+	constructor(_internal: symbol, desc: USBAlternateInterfaceDescriptor) {
+		assertInternalConstructor(arguments);
+		this.alternateSetting = desc.alternateSetting;
+		this.interfaceClass = desc.interfaceClass;
+		this.interfaceSubclass = desc.interfaceSubclass;
+		this.interfaceProtocol = desc.interfaceProtocol;
+		this.endpoints = desc.endpoints.map((e) => new USBEndpoint(INTERNAL, e));
+	}
+}
+def(USBAlternateInterface);
+
+/** A USB interface descriptor. */
+export class USBInterface {
+	readonly interfaceNumber: number;
+	claimed: boolean;
+	readonly alternates: USBAlternateInterface[];
+	alternate: USBAlternateInterface;
+
+	constructor(_internal: symbol, desc: USBInterfaceDescriptor) {
+		assertInternalConstructor(arguments);
+		this.interfaceNumber = desc.interfaceNumber;
+		this.claimed = !!desc.claimed;
+		this.alternates = desc.alternates.map(
+			(a) => new USBAlternateInterface(INTERNAL, a),
+		);
+		this.alternate = this.alternates[0];
+	}
+}
+def(USBInterface);
+
+/** A USB configuration descriptor. */
+export class USBConfiguration {
+	readonly configurationValue: number;
+	readonly interfaces: USBInterface[];
+
+	constructor(_internal: symbol, desc: USBConfigurationDescriptor) {
+		assertInternalConstructor(arguments);
+		this.configurationValue = desc.configurationValue;
+		this.interfaces = desc.interfaces.map((i) => new USBInterface(INTERNAL, i));
+	}
+}
+def(USBConfiguration);
+
+/** A USB device returned from {@link USB.requestDevice}. */
+export class USBDevice {
+	readonly usbVersionMajor: number;
+	readonly usbVersionMinor: number;
+	readonly usbVersionSubminor: number;
+	readonly deviceClass: number;
+	readonly deviceSubclass: number;
+	readonly deviceProtocol: number;
+	readonly vendorId: number;
+	readonly productId: number;
+	readonly deviceVersionMajor: number;
+	readonly deviceVersionMinor: number;
+	readonly deviceVersionSubminor: number;
+	readonly manufacturerName?: string;
+	readonly productName?: string;
+	readonly serialNumber?: string;
+	readonly configurations: USBConfiguration[];
+
+	constructor(_internal: symbol, native: USBNativeDescriptor) {
+		assertInternalConstructor(arguments);
+		this.usbVersionMajor = native.usbVersionMajor;
+		this.usbVersionMinor = native.usbVersionMinor;
+		this.usbVersionSubminor = native.usbVersionSubminor;
+		this.deviceClass = native.deviceClass;
+		this.deviceSubclass = native.deviceSubclass;
+		this.deviceProtocol = native.deviceProtocol;
+		this.vendorId = native.vendorId;
+		this.productId = native.productId;
+		this.deviceVersionMajor = native.deviceVersionMajor;
+		this.deviceVersionMinor = native.deviceVersionMinor;
+		this.deviceVersionSubminor = native.deviceVersionSubminor;
+		this.manufacturerName = native.manufacturerName;
+		this.productName = native.productName;
+		this.serialNumber = native.serialNumber;
+		this.configurations = native.configurations.map(
+			(c) => new USBConfiguration(INTERNAL, c),
+		);
+		_device.set(this, {
+			native,
+			opened: false,
+			configuration: this.configurations[0],
+		});
+	}
+
+	get opened() {
+		return _device.get(this)?.opened ?? false;
+	}
+
+	get configuration() {
+		return _device.get(this)?.configuration;
+	}
+
+	async open(): Promise<void> {
+		const state = _device.get(this)!;
+		if (!state.opened) {
+			$.usbDeviceOpen(state.native);
+			state.opened = true;
+		}
+	}
+
+	async close(): Promise<void> {
+		const state = _device.get(this)!;
+		if (state.opened) {
+			$.usbDeviceClose(state.native);
+			state.opened = false;
+			for (const config of this.configurations) {
+				for (const iface of config.interfaces) iface.claimed = false;
+			}
+		}
+	}
+
+	async selectConfiguration(configurationValue: number): Promise<void> {
+		const state = _device.get(this)!;
+		const config = this.configurations.find(
+			(c) => c.configurationValue === configurationValue,
+		);
+		if (!config) {
+			throw new DOMException('The selected configuration does not exist.', 'NotFoundError');
+		}
+		state.configuration = config;
+	}
+
+	async claimInterface(interfaceNumber: number): Promise<void> {
+		const state = _device.get(this)!;
+		if (!state.opened) {
+			throw new DOMException('The device must be opened first.', 'InvalidStateError');
+		}
+		$.usbClaimInterface(state.native, interfaceNumber);
+		const iface = state.configuration?.interfaces.find(
+			(i) => i.interfaceNumber === interfaceNumber,
+		);
+		if (iface) iface.claimed = true;
+	}
+
+	async releaseInterface(interfaceNumber: number): Promise<void> {
+		const iface = this.configuration?.interfaces.find(
+			(i) => i.interfaceNumber === interfaceNumber,
+		);
+		if (iface) iface.claimed = false;
+	}
+
+	async selectAlternateInterface(
+		interfaceNumber: number,
+		alternateSetting: number,
+	): Promise<void> {
+		const iface = this.configuration?.interfaces.find(
+			(i) => i.interfaceNumber === interfaceNumber,
+		);
+		const alternate = iface?.alternates.find(
+			(a) => a.alternateSetting === alternateSetting,
+		);
+		if (!iface || !alternate) {
+			throw new DOMException('The selected alternate interface does not exist.', 'NotFoundError');
+		}
+		iface.alternate = alternate;
+	}
+
+	async transferIn(
+		endpointNumber: number,
+		length: number,
+	): Promise<USBInTransferResult> {
+		validateByte('endpointNumber', endpointNumber);
+		validateWord('length', length);
+		const state = _device.get(this)!;
+		const buffer = $.usbTransferIn(state.native, endpointNumber, length);
+		return { data: new DataView(buffer), status: 'ok' };
+	}
+
+	async transferOut(
+		endpointNumber: number,
+		data: BufferSource,
+	): Promise<USBOutTransferResult> {
+		validateByte('endpointNumber', endpointNumber);
+		const state = _device.get(this)!;
+		return {
+			bytesWritten: $.usbTransferOut(state.native, endpointNumber, data),
+			status: 'ok',
+		};
+	}
+
+	async controlTransferIn(
+		setup: USBControlTransferParameters,
+		length: number,
+	): Promise<USBInTransferResult> {
+		if (!['standard', 'class', 'vendor', 'reserved'].includes(setup.requestType)) {
+			throw new TypeError('Invalid USB requestType');
+		}
+		if (!['device', 'interface', 'endpoint', 'other'].includes(setup.recipient)) {
+			throw new TypeError('Invalid USB recipient');
+		}
+		validateByte('request', setup.request);
+		validateWord('value', setup.value);
+		validateWord('index', setup.index);
+		validateWord('length', length);
+		const state = _device.get(this)!;
+		const buffer = $.usbControlTransferIn(state.native, setup, length);
+		return { data: new DataView(buffer), status: 'ok' };
+	}
+
+	async reset(): Promise<void> {
+		const state = _device.get(this)!;
+		$.usbResetDevice(state.native);
+	}
+}
+def(USBDevice);
+
+/** Entry point for WebUSB functionality, available as `navigator.usb`. */
+export class USB {
+	constructor() {
+		assertInternalConstructor(arguments);
+	}
+
+	async getDevices(): Promise<USBDevice[]> {
+		ensureInit();
+		return $.usbGetDevices().map((native) =>
+			deviceFromNative(native as USBNativeDescriptor),
+		);
+	}
+
+	async requestDevice(options: USBDeviceRequestOptions = {}): Promise<USBDevice> {
+		ensureInit();
+		const filters = options.filters ?? [{}];
+		if (!Array.isArray(filters)) {
+			throw new TypeError('USB device filters must be an array');
+		}
+		for (const filter of filters) {
+			validateFilter(filter);
+			const devices = $.usbGetDevices(filter).map((native) =>
+				deviceFromNative(native as USBNativeDescriptor),
+			);
+			if (devices.length > 0) return devices[0];
+		}
+		throw new DOMException('No USB devices matching the filters were found.', 'NotFoundError');
+	}
+}
+def(USB);
+
+/** The shared USB instance, also exposed as `navigator.usb`. */
+// @ts-expect-error internal constructor
+export const usb = new USB(INTERNAL);

--- a/packages/runtime/test/src/main.cc
+++ b/packages/runtime/test/src/main.cc
@@ -58,7 +58,7 @@ NX_MOD(dommatrix); NX_MOD(error); NX_MOD(font); NX_MOD(fs); NX_MOD(fsdev);
 NX_MOD(gamepad); NX_MOD(hidsys); NX_MOD(image); NX_MOD(irs); NX_MOD(memory);
 NX_MOD(nifm);
 NX_MOD(ns); NX_MOD(path2d); NX_MOD(service); NX_MOD(swkbd); NX_MOD(tcp);
-NX_MOD(tls); NX_MOD(udp); NX_MOD(url); NX_MOD(video); NX_MOD(web);
+NX_MOD(tls); NX_MOD(udp); NX_MOD(url); NX_MOD(usb); NX_MOD(video); NX_MOD(web);
 NX_MOD(webgl); NX_MOD(window);
 #undef NX_MOD
 
@@ -329,6 +329,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	nx_init_tls(iso, init_obj);
 	nx_init_udp(iso, init_obj);
 	nx_init_url(iso, init_obj);
+	nx_init_usb(iso, init_obj);
 	nx_init_video(iso, init_obj);
 	nx_init_web(iso, init_obj);
 	nx_init_webgl(iso, init_obj);

--- a/packages/runtime/test/src/stubs.cc
+++ b/packages/runtime/test/src/stubs.cc
@@ -60,6 +60,10 @@ static void nx_stub_zero(const FunctionCallbackInfo<Value> &info) {
 	info.GetReturnValue().Set(v8::Integer::New(info.GetIsolate(), 0));
 }
 
+static void nx_stub_empty_array(const FunctionCallbackInfo<Value> &info) {
+	info.GetReturnValue().Set(v8::Array::New(info.GetIsolate()));
+}
+
 // Register a list of names on init_obj, all bound to `fn`.
 static void nx_stub_register(Isolate *iso, Local<Object> init_obj,
                              const char *const *names, size_t count,
@@ -160,6 +164,15 @@ NX_STUB_FN(service) {
 NX_STUB_FN(swkbd) {
 	(void)iso;
 	(void)init_obj;
+}
+
+NX_STUB_FN(usb) {
+	NX_STUB_NAMES("usbInit", "usbExit", "usbDeviceOpen", "usbDeviceClose",
+	              "usbClaimInterface", "usbTransferIn", "usbTransferOut",
+	              "usbControlTransferIn", "usbResetDevice")
+	static const char *const array_names[] = {"usbGetDevices"};
+	nx_stub_register(iso, init_obj, array_names, countof(array_names),
+	                 nx_stub_empty_array);
 }
 
 // WebGL2 is EGL/Mesa over the Switch GPU — Switch-only. webglContextNew

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,21 @@ importers:
         specifier: 'catalog:'
         version: 0.27.3
 
+  apps/webusb-rcm:
+    devDependencies:
+      '@nx.js/nro':
+        specifier: workspace:^
+        version: link:../../packages/nro
+      '@nx.js/nsp':
+        specifier: workspace:^
+        version: link:../../packages/nsp
+      '@nx.js/runtime':
+        specifier: workspace:^
+        version: link:../../packages/runtime
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.27.3
+
   docs:
     dependencies:
       '@vercel/analytics':

--- a/source/main.cc
+++ b/source/main.cc
@@ -74,6 +74,7 @@ NX_MODULE(tcp);
 NX_MODULE(tls);
 NX_MODULE(udp);
 NX_MODULE(url);
+NX_MODULE(usb);
 NX_MODULE(video);
 NX_MODULE(web);
 NX_MODULE(window);
@@ -862,6 +863,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	nx_init_tls(iso, init_obj);
 	nx_init_udp(iso, init_obj);
 	nx_init_url(iso, init_obj);
+	nx_init_usb(iso, init_obj);
 	nx_init_video(iso, init_obj);
 	nx_init_web(iso, init_obj);
 	nx_init_webgl(iso, init_obj);

--- a/source/usb.cc
+++ b/source/usb.cc
@@ -1,0 +1,549 @@
+#include "error.h"
+#include "types.h"
+#include "util.h"
+#include "wrap.h"
+#include <malloc.h>
+#include <memory>
+#include <stdio.h>
+#include <string.h>
+#include <switch.h>
+
+using namespace v8;
+
+namespace {
+
+struct nx_usb_device_t {
+	UsbHsInterface inf;
+	UsbHsClientIfSession if_session;
+	bool opened;
+	UsbHsClientEpSession in_eps[16];
+	UsbHsClientEpSession out_eps[16];
+	bool in_open[16];
+	bool out_open[16];
+};
+
+bool g_initialized = false;
+
+uint32_t get_u32_prop(Isolate *iso, Local<Object> obj, const char *name,
+	                    bool *has) {
+	Local<Context> ctx = iso->GetCurrentContext();
+	Local<Value> v;
+	*has = false;
+	if (!obj->Get(ctx, nx_str(iso, name)).ToLocal(&v) || v->IsUndefined() ||
+	    v->IsNull()) {
+		return 0;
+	}
+	*has = true;
+	return v->Uint32Value(ctx).FromMaybe(0);
+}
+
+bool get_string_prop(Isolate *iso, Local<Object> obj, const char *name,
+	                    Local<Value> *out) {
+	Local<Context> ctx = iso->GetCurrentContext();
+	Local<Value> v;
+	if (!obj->Get(ctx, nx_str(iso, name)).ToLocal(&v) || !v->IsString()) {
+		char message[128];
+		snprintf(message, sizeof(message), "USB control transfer setup.%s must be a string", name);
+		nx_throw(iso, message);
+		return false;
+	}
+	*out = v;
+	return true;
+}
+
+void usb_device_close(nx_usb_device_t *dev) {
+	if (!dev)
+		return;
+	for (int i = 0; i < 16; i++) {
+		if (dev->in_open[i]) {
+			usbHsEpClose(&dev->in_eps[i]);
+			dev->in_open[i] = false;
+		}
+		if (dev->out_open[i]) {
+			usbHsEpClose(&dev->out_eps[i]);
+			dev->out_open[i] = false;
+		}
+	}
+	if (dev->opened) {
+		usbHsIfClose(&dev->if_session);
+		dev->opened = false;
+	}
+}
+
+void usb_device_free(nx_usb_device_t *dev) {
+	usb_device_close(dev);
+	free(dev);
+}
+
+bool ensure_usb(Isolate *iso) {
+	if (g_initialized)
+		return true;
+	Result rc = usbHsInitialize();
+	if (R_FAILED(rc)) {
+		nx_throw_libnx_error(iso, rc, "usbHsInitialize");
+		return false;
+	}
+	g_initialized = true;
+	return true;
+}
+
+nx_usb_device_t *unwrap_device(Isolate *iso, Local<Value> v) {
+	nx_usb_device_t *dev = nx::Unwrap<nx_usb_device_t>(v);
+	if (!dev) {
+		nx_throw(iso, "Invalid USBDevice native handle");
+		return nullptr;
+	}
+	return dev;
+}
+
+void set_u32(Isolate *iso, Local<Object> obj, const char *name, uint32_t value) {
+	Local<Context> ctx = iso->GetCurrentContext();
+	obj->Set(ctx, nx_str(iso, name), Integer::NewFromUnsigned(iso, value)).Check();
+}
+
+Local<Object> endpoint_to_object(Isolate *iso,
+	                               const struct usb_endpoint_descriptor *desc) {
+	Local<Object> obj = Object::New(iso);
+	set_u32(iso, obj, "endpointNumber",
+	        desc->bEndpointAddress & USB_ENDPOINT_ADDRESS_MASK);
+	obj->Set(iso->GetCurrentContext(), nx_str(iso, "direction"),
+	         nx_str(iso, (desc->bEndpointAddress & USB_ENDPOINT_IN) ? "in" : "out"))
+	    .Check();
+	const char *type = "bulk";
+	switch (desc->bmAttributes & USB_TRANSFER_TYPE_MASK) {
+	case USB_TRANSFER_TYPE_ISOCHRONOUS:
+		type = "isochronous";
+		break;
+	case USB_TRANSFER_TYPE_INTERRUPT:
+		type = "interrupt";
+		break;
+	}
+	obj->Set(iso->GetCurrentContext(), nx_str(iso, "type"), nx_str(iso, type))
+	    .Check();
+	set_u32(iso, obj, "packetSize", desc->wMaxPacketSize);
+	return obj;
+}
+
+Local<Object> interface_to_object(Isolate *iso, const UsbHsInterface *inf) {
+	Local<Context> ctx = iso->GetCurrentContext();
+	Local<Object> alt = Object::New(iso);
+	const struct usb_interface_descriptor *desc = &inf->inf.interface_desc;
+	set_u32(iso, alt, "alternateSetting", desc->bAlternateSetting);
+	set_u32(iso, alt, "interfaceClass", desc->bInterfaceClass);
+	set_u32(iso, alt, "interfaceSubclass", desc->bInterfaceSubClass);
+	set_u32(iso, alt, "interfaceProtocol", desc->bInterfaceProtocol);
+	Local<Array> eps = Array::New(iso);
+	uint32_t ep_idx = 0;
+	for (int i = 0; i < 15; i++) {
+		const struct usb_endpoint_descriptor *in = &inf->inf.input_endpoint_descs[i];
+		if (in->bLength == USB_DT_ENDPOINT_SIZE) {
+			eps->Set(ctx, ep_idx++, endpoint_to_object(iso, in)).Check();
+		}
+		const struct usb_endpoint_descriptor *out = &inf->inf.output_endpoint_descs[i];
+		if (out->bLength == USB_DT_ENDPOINT_SIZE) {
+			eps->Set(ctx, ep_idx++, endpoint_to_object(iso, out)).Check();
+		}
+	}
+	alt->Set(ctx, nx_str(iso, "endpoints"), eps).Check();
+
+	Local<Object> iface = Object::New(iso);
+	set_u32(iso, iface, "interfaceNumber", desc->bInterfaceNumber);
+	set_u32(iso, iface, "claimed", 0);
+	Local<Array> alternates = Array::New(iso, 1);
+	alternates->Set(ctx, 0, alt).Check();
+	iface->Set(ctx, nx_str(iso, "alternates"), alternates).Check();
+	return iface;
+}
+
+void set_device_descriptor(Isolate *iso, Local<Object> obj,
+	                         const UsbHsInterface *inf) {
+	Local<Context> ctx = iso->GetCurrentContext();
+	struct usb_device_descriptor dev;
+	memcpy(&dev, &inf->device_desc, sizeof(dev));
+	set_u32(iso, obj, "usbVersionMajor", (dev.bcdUSB >> 8) & 0xff);
+	set_u32(iso, obj, "usbVersionMinor", (dev.bcdUSB >> 4) & 0x0f);
+	set_u32(iso, obj, "usbVersionSubminor", dev.bcdUSB & 0x0f);
+	set_u32(iso, obj, "deviceClass", dev.bDeviceClass);
+	set_u32(iso, obj, "deviceSubclass", dev.bDeviceSubClass);
+	set_u32(iso, obj, "deviceProtocol", dev.bDeviceProtocol);
+	set_u32(iso, obj, "vendorId", dev.idVendor);
+	set_u32(iso, obj, "productId", dev.idProduct);
+	set_u32(iso, obj, "deviceVersionMajor", (dev.bcdDevice >> 8) & 0xff);
+	set_u32(iso, obj, "deviceVersionMinor", (dev.bcdDevice >> 4) & 0x0f);
+	set_u32(iso, obj, "deviceVersionSubminor", dev.bcdDevice & 0x0f);
+
+	Local<Object> config = Object::New(iso);
+	set_u32(iso, config, "configurationValue", inf->config_desc.bConfigurationValue);
+	Local<Array> interfaces = Array::New(iso, 1);
+	interfaces->Set(ctx, 0, interface_to_object(iso, inf)).Check();
+	config->Set(ctx, nx_str(iso, "interfaces"), interfaces).Check();
+	Local<Array> configurations = Array::New(iso, 1);
+	configurations->Set(ctx, 0, config).Check();
+	obj->Set(ctx, nx_str(iso, "configurations"), configurations).Check();
+}
+
+struct usb_endpoint_descriptor *find_endpoint(nx_usb_device_t *dev,
+	                                            uint8_t endpoint,
+	                                            bool in) {
+	struct usb_endpoint_descriptor *descs = in
+	    ? dev->inf.inf.input_endpoint_descs
+	    : dev->inf.inf.output_endpoint_descs;
+	for (int i = 0; i < 15; i++) {
+		struct usb_endpoint_descriptor *desc = &descs[i];
+		if (desc->bLength != USB_DT_ENDPOINT_SIZE)
+			continue;
+		if ((desc->bEndpointAddress & USB_ENDPOINT_ADDRESS_MASK) == endpoint)
+			return desc;
+	}
+	return nullptr;
+}
+
+UsbHsClientEpSession *open_endpoint(Isolate *iso, nx_usb_device_t *dev,
+	                                  uint8_t endpoint, bool in,
+	                                  uint32_t xfer_size) {
+	if (!dev->opened) {
+		nx_throw(iso, "USB device is not open");
+		return nullptr;
+	}
+	if (endpoint >= 16) {
+		nx_throw(iso, "Invalid USB endpoint number");
+		return nullptr;
+	}
+	bool *open = in ? dev->in_open : dev->out_open;
+	UsbHsClientEpSession *eps = in ? dev->in_eps : dev->out_eps;
+	if (open[endpoint])
+		return &eps[endpoint];
+	struct usb_endpoint_descriptor *desc = find_endpoint(dev, endpoint, in);
+	if (!desc) {
+		nx_throw(iso, "USB endpoint not found");
+		return nullptr;
+	}
+	uint32_t max_xfer = xfer_size;
+	if (max_xfer < desc->wMaxPacketSize)
+		max_xfer = desc->wMaxPacketSize;
+	if (max_xfer < 0x1000)
+		max_xfer = 0x1000;
+	Result rc = usbHsIfOpenUsbEp(&dev->if_session, &eps[endpoint], 4, max_xfer,
+	                             desc);
+	if (R_FAILED(rc)) {
+		nx_throw_libnx_error(iso, rc, "usbHsIfOpenUsbEp");
+		return nullptr;
+	}
+	open[endpoint] = true;
+	return &eps[endpoint];
+}
+
+void nx_usb_init(const FunctionCallbackInfo<Value> &info) {
+	ensure_usb(info.GetIsolate());
+}
+
+void nx_usb_exit(const FunctionCallbackInfo<Value> &info) {
+	(void)info;
+	if (g_initialized) {
+		usbHsExit();
+		g_initialized = false;
+	}
+}
+
+void nx_usb_get_devices(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> ctx = iso->GetCurrentContext();
+	if (!ensure_usb(iso))
+		return;
+
+	UsbHsInterfaceFilter filter = {0};
+	if (info[0]->IsObject()) {
+		Local<Object> f = info[0].As<Object>();
+		bool has = false;
+		uint32_t v = get_u32_prop(iso, f, "vendorId", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_idVendor;
+			filter.idVendor = (u16)v;
+		}
+		v = get_u32_prop(iso, f, "productId", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_idProduct;
+			filter.idProduct = (u16)v;
+		}
+		v = get_u32_prop(iso, f, "classCode", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_bDeviceClass;
+			filter.bDeviceClass = (u8)v;
+		}
+		v = get_u32_prop(iso, f, "subclassCode", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_bDeviceSubClass;
+			filter.bDeviceSubClass = (u8)v;
+		}
+		v = get_u32_prop(iso, f, "protocolCode", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_bDeviceProtocol;
+			filter.bDeviceProtocol = (u8)v;
+		}
+		v = get_u32_prop(iso, f, "interfaceClass", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_bInterfaceClass;
+			filter.bInterfaceClass = (u8)v;
+		}
+		v = get_u32_prop(iso, f, "interfaceSubclass", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_bInterfaceSubClass;
+			filter.bInterfaceSubClass = (u8)v;
+		}
+		v = get_u32_prop(iso, f, "interfaceProtocol", &has);
+		if (has) {
+			filter.Flags |= UsbHsInterfaceFilterFlags_bInterfaceProtocol;
+			filter.bInterfaceProtocol = (u8)v;
+		}
+	}
+
+	UsbHsInterface interfaces[32];
+	s32 total = 0;
+	Result rc = usbHsQueryAvailableInterfaces(&filter, interfaces,
+	                                         sizeof(interfaces), &total);
+	if (R_FAILED(rc)) {
+		nx_throw_libnx_error(iso, rc, "usbHsQueryAvailableInterfaces");
+		return;
+	}
+	if (total > 32)
+		total = 32;
+	Local<Array> arr = Array::New(iso, total);
+	for (s32 i = 0; i < total; i++) {
+		nx_usb_device_t *dev = (nx_usb_device_t *)calloc(1, sizeof(*dev));
+		if (!dev) {
+			nx_throw_oom(iso, sizeof(*dev));
+			return;
+		}
+		dev->inf = interfaces[i];
+		Local<Object> obj = nx::NewWrapped(iso);
+		nx::Wrap(iso, obj, dev, usb_device_free);
+		set_device_descriptor(iso, obj, &interfaces[i]);
+		arr->Set(ctx, i, obj).Check();
+	}
+	info.GetReturnValue().Set(arr);
+}
+
+void nx_usb_device_open(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_usb_device_t *dev = unwrap_device(iso, info[0]);
+	if (!dev)
+		return;
+	if (dev->opened)
+		return;
+	Result rc = usbHsAcquireUsbIf(&dev->if_session, &dev->inf);
+	if (R_FAILED(rc)) {
+		nx_throw_libnx_error(iso, rc, "usbHsAcquireUsbIf");
+		return;
+	}
+	dev->opened = true;
+}
+
+void nx_usb_device_close(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_usb_device_t *dev = unwrap_device(iso, info[0]);
+	if (!dev)
+		return;
+	usb_device_close(dev);
+}
+
+void nx_usb_claim_interface(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> ctx = iso->GetCurrentContext();
+	nx_usb_device_t *dev = unwrap_device(iso, info[0]);
+	if (!dev)
+		return;
+	if (!dev->opened) {
+		nx_throw(iso, "USB device is not open");
+		return;
+	}
+	uint32_t iface = info[1]->Uint32Value(ctx).FromMaybe(0);
+	if (iface != dev->inf.inf.interface_desc.bInterfaceNumber) {
+		nx_throw(iso, "USB interface not found on this device handle");
+	}
+}
+
+void nx_usb_transfer_out(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> ctx = iso->GetCurrentContext();
+	nx_usb_device_t *dev = unwrap_device(iso, info[0]);
+	if (!dev)
+		return;
+	uint32_t endpoint = info[1]->Uint32Value(ctx).FromMaybe(0);
+	size_t len = 0;
+	uint8_t *src = NX_GetBufferSource(iso, &len, info[2]);
+	if (!src) {
+		nx_throw(iso, "transferOut data must be a BufferSource");
+		return;
+	}
+	UsbHsClientEpSession *ep = open_endpoint(iso, dev, (uint8_t)endpoint, false,
+	                                        (uint32_t)len);
+	if (!ep)
+		return;
+	if (len > 0xff0000) {
+		nx_throw(iso, "USB transfer is too large");
+		return;
+	}
+	size_t alloc_size = (len + 0xfff) & ~((size_t)0xfff);
+	if (alloc_size == 0)
+		alloc_size = 0x1000;
+	void *buf = memalign(0x1000, alloc_size);
+	if (!buf) {
+		nx_throw_oom(iso, alloc_size);
+		return;
+	}
+	memset(buf, 0, alloc_size);
+	memcpy(buf, src, len);
+	u32 transferred = 0;
+	Result rc = usbHsEpPostBuffer(ep, buf, (u32)len, &transferred);
+	free(buf);
+	if (R_FAILED(rc)) {
+		nx_throw_libnx_error(iso, rc, "usbHsEpPostBuffer");
+		return;
+	}
+	info.GetReturnValue().Set(Integer::NewFromUnsigned(iso, transferred));
+}
+
+void nx_usb_transfer_in(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> ctx = iso->GetCurrentContext();
+	nx_usb_device_t *dev = unwrap_device(iso, info[0]);
+	if (!dev)
+		return;
+	uint32_t endpoint = info[1]->Uint32Value(ctx).FromMaybe(0);
+	uint32_t len = info[2]->Uint32Value(ctx).FromMaybe(0);
+	UsbHsClientEpSession *ep = open_endpoint(iso, dev, (uint8_t)endpoint, true,
+	                                        len);
+	if (!ep)
+		return;
+	if (len > 0xff0000) {
+		nx_throw(iso, "USB transfer is too large");
+		return;
+	}
+	size_t alloc_size = (len + 0xfff) & ~((size_t)0xfff);
+	if (alloc_size == 0)
+		alloc_size = 0x1000;
+	void *buf = memalign(0x1000, alloc_size);
+	if (!buf) {
+		nx_throw_oom(iso, alloc_size);
+		return;
+	}
+	memset(buf, 0, alloc_size);
+	u32 transferred = 0;
+	Result rc = usbHsEpPostBuffer(ep, buf, len, &transferred);
+	if (R_FAILED(rc)) {
+		free(buf);
+		nx_throw_libnx_error(iso, rc, "usbHsEpPostBuffer");
+		return;
+	}
+	std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+	    buf, transferred, [](void *p, size_t, void *) { free(p); }, nullptr);
+	info.GetReturnValue().Set(ArrayBuffer::New(iso, std::move(bs)));
+}
+
+uint8_t request_type_bits(const char *s) {
+	if (strcmp(s, "class") == 0)
+		return USB_REQUEST_TYPE_CLASS;
+	if (strcmp(s, "vendor") == 0)
+		return USB_REQUEST_TYPE_VENDOR;
+	if (strcmp(s, "reserved") == 0)
+		return USB_REQUEST_TYPE_RESERVED;
+	return USB_REQUEST_TYPE_STANDARD;
+}
+
+uint8_t recipient_bits(const char *s) {
+	if (strcmp(s, "interface") == 0)
+		return USB_RECIPIENT_INTERFACE;
+	if (strcmp(s, "endpoint") == 0)
+		return USB_RECIPIENT_ENDPOINT;
+	if (strcmp(s, "other") == 0)
+		return USB_RECIPIENT_OTHER;
+	return USB_RECIPIENT_DEVICE;
+}
+
+void nx_usb_control_transfer_in(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> ctx = iso->GetCurrentContext();
+	nx_usb_device_t *dev = unwrap_device(iso, info[0]);
+	if (!dev)
+		return;
+	if (!dev->opened) {
+		nx_throw(iso, "USB device is not open");
+		return;
+	}
+	if (!info[1]->IsObject()) {
+		nx_throw(iso, "controlTransferIn setup must be an object");
+		return;
+	}
+	Local<Object> setup = info[1].As<Object>();
+	Local<Value> request_type_val;
+	Local<Value> recipient_val;
+	if (!get_string_prop(iso, setup, "requestType", &request_type_val) ||
+	    !get_string_prop(iso, setup, "recipient", &recipient_val)) {
+		return;
+	}
+	String::Utf8Value request_type(iso, request_type_val);
+	String::Utf8Value recipient(iso, recipient_val);
+	bool has = false;
+	uint32_t request = get_u32_prop(iso, setup, "request", &has);
+	uint32_t value = get_u32_prop(iso, setup, "value", &has);
+	uint32_t index = get_u32_prop(iso, setup, "index", &has);
+	uint32_t len = info[2]->Uint32Value(ctx).FromMaybe(0);
+	if (len > 0xffff) {
+		nx_throw(iso, "USB control transfer length is too large");
+		return;
+	}
+	size_t alloc_size = (len + 0xfff) & ~((size_t)0xfff);
+	if (alloc_size == 0)
+		alloc_size = 0x1000;
+	void *buf = memalign(0x1000, alloc_size);
+	if (!buf) {
+		nx_throw_oom(iso, alloc_size);
+		return;
+	}
+	memset(buf, 0, alloc_size);
+	u8 bmRequestType = USB_ENDPOINT_IN |
+	    request_type_bits(*request_type ? *request_type : "standard") |
+	    recipient_bits(*recipient ? *recipient : "device");
+	u32 transferred = 0;
+	Result rc = usbHsIfCtrlXfer(&dev->if_session, bmRequestType, (u8)request,
+	                            (u16)value, (u16)index, (u16)len, buf,
+	                            &transferred);
+	if (R_FAILED(rc)) {
+		free(buf);
+		nx_throw_libnx_error(iso, rc, "usbHsIfCtrlXfer");
+		return;
+	}
+	std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+	    buf, transferred, [](void *p, size_t, void *) { free(p); }, nullptr);
+	info.GetReturnValue().Set(ArrayBuffer::New(iso, std::move(bs)));
+}
+
+void nx_usb_reset_device(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	nx_usb_device_t *dev = unwrap_device(iso, info[0]);
+	if (!dev)
+		return;
+	if (!dev->opened) {
+		nx_throw(iso, "USB device is not open");
+		return;
+	}
+	Result rc = usbHsIfResetDevice(&dev->if_session);
+	if (R_FAILED(rc)) {
+		nx_throw_libnx_error(iso, rc, "usbHsIfResetDevice");
+	}
+}
+
+} // namespace
+
+void nx_init_usb(Isolate *iso, Local<Object> init_obj) {
+	NX_SET_FUNC(init_obj, "usbInit", nx_usb_init);
+	NX_SET_FUNC(init_obj, "usbExit", nx_usb_exit);
+	NX_SET_FUNC(init_obj, "usbGetDevices", nx_usb_get_devices);
+	NX_SET_FUNC(init_obj, "usbDeviceOpen", nx_usb_device_open);
+	NX_SET_FUNC(init_obj, "usbDeviceClose", nx_usb_device_close);
+	NX_SET_FUNC(init_obj, "usbClaimInterface", nx_usb_claim_interface);
+	NX_SET_FUNC(init_obj, "usbTransferIn", nx_usb_transfer_in);
+	NX_SET_FUNC(init_obj, "usbTransferOut", nx_usb_transfer_out);
+	NX_SET_FUNC(init_obj, "usbControlTransferIn", nx_usb_control_transfer_in);
+	NX_SET_FUNC(init_obj, "usbResetDevice", nx_usb_reset_device);
+}


### PR DESCRIPTION
## Summary
- Adds initial `navigator.usb` WebUSB support backed by libnx `usb:hs` host APIs.
- Implements device discovery, open/close, interface claiming, bulk transfers, control transfer-in, and reset.
- Adds a `webusb-rcm` example app for sending fusee/hekate-style RCM payloads to a v1 Switch in RCM mode.

Closes https://github.com/TooTallNate/nx.js/issues/132

## Verification
- `pnpm --filter @nx.js/runtime build`
- `pnpm --filter @nx.js/runtime bundle`
- `DEVKITPRO=/opt/devkitpro make -j4`
- `pnpm --filter webusb-rcm build`
- `git diff --check`
- On-device: built a fat `webusb-rcm.nro` with `hekate_ctcaer_6.5.2.bin`, launched it from the host Switch, detected target RCM Switch `0955:7321`, read the device ID, sent the payload, triggered the RCM vulnerability, handled the expected disconnect, and confirmed the target booted Hekate.