### PR TITLE
Clean up failed content meta staging

### DIFF
--- a/.changeset/install-title-meta-cleanup.md
+++ b/.changeset/install-title-meta-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/install-title": patch
+---
+
+Clean up staged content meta NCAs and placeholders when metadata mounting fails during title installation.

--- a/packages/install-title/src/index.ts
+++ b/packages/install-title/src/index.ts
@@ -271,16 +271,36 @@ export async function* install(
 		);
 	for (const [name, entry] of cnmtNcaFiles) {
 		yield* step(`Install content meta "${name}"`, async function* () {
+			// The name registered in content storage is always `.nca`.
+			const ncaName = name.replace(/\.ncz$/, '.nca');
+			const contentId = NcmContentId.from(ncaName);
+			let installedContentMeta = false;
+
 			// Install the NCA so that we can mount the
 			// filesystem to read the `.cnmt` file inside.
 			// Returns the actual installed NCA size (decompressed for NCZ).
-			const installedSize = await installNca(name, entry, contentStorage);
+			let installedSize: bigint;
+			let cnmtData: ArrayBuffer;
+			try {
+				installedSize = await installNca(name, entry, contentStorage);
+				installedContentMeta = true;
 
-			// The name registered in content storage is always `.nca`
-			const ncaName = name.replace(/\.ncz$/, '.nca');
-
-			// Read the decrypted `.cnmt` file
-			const cnmtData = await readContentMeta(ncaName, contentStorage);
+				// Read the decrypted `.cnmt` file.
+				cnmtData = await readContentMeta(ncaName, contentStorage);
+			} catch (err) {
+				// If the newly-registered content meta cannot be mounted/read, remove it
+				// immediately. Leaving a malformed or rejected meta NCA in content storage
+				// can poison later FS/NCM operations until reboot.
+				if (installedContentMeta) {
+					try {
+						contentStorage.delete(contentId);
+					} catch {}
+				}
+				try {
+					contentStorage.cleanupAllPlaceHolder();
+				} catch {}
+				throw err;
+			}
 
 			const cnmtHeader = new PackagedContentMetaHeader(cnmtData);
 			const contentMetaKey = createContentMetaKey(cnmtHeader);


### PR DESCRIPTION
## Summary

- Remove newly-registered content meta NCAs when mounting/reading their CNMT fails during install.
- Clean all content-storage placeholders on that failure path before rethrowing the original error.
- Prevent malformed/rejected content meta staging from poisoning later FS/NCM operations.

## Verification

- `pnpm --filter @nx.js/inspect build`
- `pnpm --filter @nx.js/runtime build`
- `pnpm --filter @nx.js/constants build`
- `pnpm --filter @nx.js/ncm build`
- `pnpm --filter @nx.js/ns build`
- `pnpm --filter @nx.js/install-title build`
- On-device applet-mode install succeeded after generator fixes (`Daybreak` forwarder, ~4.4s)