### PR TITLE
fix: `fetch(new Request(url))` throws "Body not allowed for GET or HEAD requests"

### DIFF
--- a/.changeset/fetch-request-get-body.md
+++ b/.changeset/fetch-request-get-body.md
@@ -1,0 +1,11 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: `fetch(new Request(url))` no longer throws "Body not allowed for GET or HEAD requests"
+
+When a bodyless `GET`/`HEAD` `Request` was passed back into the `Request`
+constructor (as `fetch()` does internally), the input `Request` object was
+treated as the body before extraction, so the GET/HEAD body guard saw the
+(always-truthy) wrapper object and wrongly threw. The guard now unwraps the
+real body from an input `Request`/`Body` before checking it.

--- a/packages/runtime/src/fetch/request.ts
+++ b/packages/runtime/src/fetch/request.ts
@@ -149,7 +149,16 @@ export class Request extends Body implements globalThis.Request {
 		}
 		if (!method) method = 'GET';
 
-		if ((method === 'GET' || method === 'HEAD') && body) {
+		// When `body` is another `Request` (or `Body`) instance, the actual
+		// payload lives on its `.body` property — which may be `null` for a
+		// bodyless request. Unwrap it here so the GET/HEAD guard below tests
+		// the real body rather than the (always-truthy) wrapper object.
+		const actualBody =
+			body && typeof body === 'object' && 'body' in body
+				? body.body
+				: body;
+
+		if ((method === 'GET' || method === 'HEAD') && actualBody) {
 			throw new TypeError('Body not allowed for GET or HEAD requests');
 		}
 		super(body, headers);

--- a/packages/runtime/test/fixtures/request.ts
+++ b/packages/runtime/test/fixtures/request.ts
@@ -12,6 +12,51 @@ test('Request constructor with init overriding credentials', (t) => {
 	t.equal(original.credentials, 'omit', 'original unchanged');
 });
 
+// --- Request constructor: bodyless input Request (regression) ---
+
+test('Request from bodyless GET input Request does not throw', (t) => {
+	// Regression: `fetch(new Request(url))` re-wraps the input Request via
+	// `new Request(input)`. With no `init.body`, the input Request was used as
+	// the body, and the GET/HEAD guard saw the (truthy) wrapper object and
+	// wrongly threw "Body not allowed for GET or HEAD requests".
+	const input = new Request('https://example.com/data');
+	let derived: Request | undefined;
+	t.doesNotThrow(() => {
+		derived = new Request(input);
+	}, 'no throw re-wrapping a bodyless GET Request');
+	t.equal(derived!.method, 'GET', 'method is GET');
+	t.equal(derived!.url, input.url, 'url copied');
+	t.equal(derived!.body, null, 'body is null');
+});
+
+test('Request from bodyless HEAD input Request does not throw', (t) => {
+	const input = new Request('https://example.com/data', { method: 'HEAD' });
+	let derived: Request | undefined;
+	t.doesNotThrow(() => {
+		derived = new Request(input);
+	}, 'no throw re-wrapping a bodyless HEAD Request');
+	t.equal(derived!.method, 'HEAD', 'method is HEAD');
+});
+
+test('Request still rejects an actual body on GET', (t) => {
+	// The error message text is implementation-defined (nx.js and Chrome word
+	// it differently), so only assert that a TypeError is thrown.
+	let err: unknown;
+	t.throws(
+		() => {
+			try {
+				new Request('https://example.com', { method: 'GET', body: 'x' });
+			} catch (e) {
+				err = e;
+				throw e;
+			}
+		},
+		undefined,
+		'GET with a real body still throws',
+	);
+	t.ok(err instanceof TypeError, 'thrown error is a TypeError');
+});
+
 // --- Request constructor: referrer ---
 
 test('Request constructor copies referrer from input Request', (t) => {


### PR DESCRIPTION
## Summary

`fetch(new Request("https://api.example.com/data"))` throws:

```
Uncaught TypeError: Body not allowed for GET or HEAD requests
    at Request (nxjs:src/fetch/request.ts:153:9)
    at fetch (nxjs:src/fetch/fetch.ts:479:13)
```

`fetch()` internally re-wraps its `input` via `new Request(input, init)`. When `input` is a bodyless `GET`/`HEAD` `Request` and `init` has no `body`, the constructor does `if (!body) body = input` — so `body` becomes the **input `Request` object itself**. The GET/HEAD guard at `request.ts:152` then runs *before* `super()` (where `Body` would extract the real `.body`, which is `null`), so it sees the always-truthy wrapper object and wrongly throws.

`Body`'s constructor already handles being passed a `Request` (it reads `init.body`, which is `null` here), so the body extraction was never the problem — only the guard's ordering.

## Fix

Unwrap the real body from an input `Request`/`Body` before the GET/HEAD guard runs, so the guard tests the actual payload (`null` for a bodyless request) rather than the wrapper object. A real body on a GET/HEAD request still throws.

## Testing

Added regression fixtures in `packages/runtime/test/fixtures/request.ts`:
- `Request` from a bodyless `GET` input `Request` does not throw (the reported bug)
- same for `HEAD`
- a real body on `GET` still throws a `TypeError`

Verified with the host conformance harness (`nxjs-test` vs Chrome via Playwright) on the `nxdbg` container — all 26 assertions pass in **both** engines:

```
✓ test/conformance.test.ts > nxjs-test conformance > request: nxjs-test vs Chrome
```