### PR TITLE
runtime: defer scheme resolution to globalThis.fetch in Image/Audio/Video

### DIFF
--- a/.changeset/fetch-late-binding.md
+++ b/.changeset/fetch-late-binding.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+feat: `Image`, `Audio`, and `Video` now resolve `globalThis.fetch` at call time, so embedder-installed `fetch` wrappers (e.g. custom URL schemes) are honored for `src` loads

--- a/packages/runtime/src/audio.ts
+++ b/packages/runtime/src/audio.ts
@@ -4,12 +4,24 @@ import type { AudioBufferSourceNode } from './audio/audio-buffer-source-node';
 import { AudioContext } from './audio/audio-context';
 import type { GainNode } from './audio/gain-node';
 import { DOMException } from './dom-exception';
-import { fetch } from './fetch/fetch';
 import { ErrorEvent, Event } from './polyfills/event';
 import { EventTarget } from './polyfills/event-target';
 import { URL } from './polyfills/url';
 import { clearInterval, setInterval } from './timers';
 import { def } from './utils';
+
+// Late-bound (call-time) `globalThis.fetch` wrapper. Same rationale as
+// `image.ts`: embedders extend the scheme registry via a
+// `globalThis.fetch` override installed after the runtime bundle has
+// evaluated. Import-time capture of `./fetch/fetch` would freeze the
+// pre-wrapper engine fetch and any extended scheme would silently fail
+// on `<audio src>`.
+function fetch(
+	input: string | URL | Request,
+	init?: RequestInit,
+): Promise<Response> {
+	return globalThis.fetch(input, init);
+}
 
 const HAVE_NOTHING = 0;
 const HAVE_METADATA = 1;

--- a/packages/runtime/src/audio.ts
+++ b/packages/runtime/src/audio.ts
@@ -10,19 +10,6 @@ import { URL } from './polyfills/url';
 import { clearInterval, setInterval } from './timers';
 import { def } from './utils';
 
-// Late-bound (call-time) `globalThis.fetch` wrapper. Same rationale as
-// `image.ts`: embedders extend the scheme registry via a
-// `globalThis.fetch` override installed after the runtime bundle has
-// evaluated. Import-time capture of `./fetch/fetch` would freeze the
-// pre-wrapper engine fetch and any extended scheme would silently fail
-// on `<audio src>`.
-function fetch(
-	input: string | URL | Request,
-	init?: RequestInit,
-): Promise<Response> {
-	return globalThis.fetch(input, init);
-}
-
 const HAVE_NOTHING = 0;
 const HAVE_METADATA = 1;
 const HAVE_CURRENT_DATA = 2;
@@ -226,7 +213,9 @@ export class Audio extends EventTarget {
 		const url = new URL(this.#src, $.entrypoint);
 		this.#currentSrc = url.href;
 
-		fetch(url)
+		// Call-time `globalThis.fetch` so embedder-installed wrappers
+		// (e.g. extended URL schemes) are honored — see note in `image.ts`.
+		globalThis.fetch(url)
 			.then((res) => {
 				if (!res.ok) {
 					throw new Error(`Failed to load audio: ${res.status}`);

--- a/packages/runtime/src/image.ts
+++ b/packages/runtime/src/image.ts
@@ -5,19 +5,6 @@ import { Event, ErrorEvent } from './polyfills/event';
 import { EventTarget } from './polyfills/event-target';
 import type { CanvasRenderingContext2D } from './canvas/canvas-rendering-context-2d';
 
-// Late-bound (call-time) `globalThis.fetch` wrapper. Embedders extend
-// the scheme registry by installing a `globalThis.fetch` wrapper at
-// session start; capturing `./fetch/fetch` at import time would freeze
-// the pre-wrapper engine fetch and any embedder-registered schemes
-// would silently fail on `<img src>`. The function body below resolves
-// `globalThis.fetch` per-call, so the embedder's wrapper always wins.
-function fetch(
-	input: string | URL | Request,
-	init?: RequestInit,
-): Promise<Response> {
-	return globalThis.fetch(input, init);
-}
-
 interface ImageInternal {
 	complete: boolean;
 	src?: URL;
@@ -100,7 +87,13 @@ export class Image extends EventTarget {
 		const internal = _(this);
 		internal.src = url;
 		internal.complete = false;
-		fetch(url)
+		// `globalThis.fetch` is resolved at call time (NOT imported from
+		// `./fetch/fetch`) so that an embedder-installed `fetch` wrapper —
+		// e.g. one extending the URL scheme registry — is honored for
+		// `<img src>` loads. A bare `fetch` identifier is also not an
+		// option: esbuild would rename the bundled `fetch` declaration to
+		// `fetch2`, breaking `def(fetch)`'s global registration.
+		globalThis.fetch(url)
 			.then((res) => {
 				if (!res.ok) {
 					throw new Error(`Failed to load image: ${res.status}`);

--- a/packages/runtime/src/image.ts
+++ b/packages/runtime/src/image.ts
@@ -1,10 +1,22 @@
 import { $ } from './$';
 import { createInternal, def, proto } from './utils';
-import { fetch } from './fetch/fetch';
 import { URL } from './polyfills/url';
 import { Event, ErrorEvent } from './polyfills/event';
 import { EventTarget } from './polyfills/event-target';
 import type { CanvasRenderingContext2D } from './canvas/canvas-rendering-context-2d';
+
+// Late-bound (call-time) `globalThis.fetch` wrapper. Embedders extend
+// the scheme registry by installing a `globalThis.fetch` wrapper at
+// session start; capturing `./fetch/fetch` at import time would freeze
+// the pre-wrapper engine fetch and any embedder-registered schemes
+// would silently fail on `<img src>`. The function body below resolves
+// `globalThis.fetch` per-call, so the embedder's wrapper always wins.
+function fetch(
+	input: string | URL | Request,
+	init?: RequestInit,
+): Promise<Response> {
+	return globalThis.fetch(input, init);
+}
 
 interface ImageInternal {
 	complete: boolean;

--- a/packages/runtime/src/video.ts
+++ b/packages/runtime/src/video.ts
@@ -2,13 +2,26 @@ import { $, type AudioNodeHandle, type VideoHandle, type VideoMetadata } from '.
 import { getSharedAudioContext } from './audio';
 import { ctxInternal, nodeInternal } from './audio/internal';
 import { DOMException } from './dom-exception';
-import { fetch } from './fetch/fetch';
 import { ErrorEvent, Event } from './polyfills/event';
 import { EventTarget } from './polyfills/event-target';
 import { URL } from './polyfills/url';
 import { clearInterval, setInterval } from './timers';
 import { createInternal, def, proto } from './utils';
 import type { GainNode } from './audio/gain-node';
+
+// Late-bound (call-time) `globalThis.fetch` wrapper. Same rationale as
+// `image.ts`: embedders extend the scheme registry via a
+// `globalThis.fetch` override installed after the runtime bundle has
+// evaluated. `video.ts` already short-circuits its own FILE_SCHEMES
+// set to a direct native decoder and bypasses fetch entirely; the
+// wrapper only affects the http/https/blob/data branch and any
+// embedder-registered scheme.
+function fetch(
+	input: string | URL | Request,
+	init?: RequestInit,
+): Promise<Response> {
+	return globalThis.fetch(input, init);
+}
 
 const HAVE_NOTHING = 0;
 const HAVE_METADATA = 1;

--- a/packages/runtime/src/video.ts
+++ b/packages/runtime/src/video.ts
@@ -9,20 +9,6 @@ import { clearInterval, setInterval } from './timers';
 import { createInternal, def, proto } from './utils';
 import type { GainNode } from './audio/gain-node';
 
-// Late-bound (call-time) `globalThis.fetch` wrapper. Same rationale as
-// `image.ts`: embedders extend the scheme registry via a
-// `globalThis.fetch` override installed after the runtime bundle has
-// evaluated. `video.ts` already short-circuits its own FILE_SCHEMES
-// set to a direct native decoder and bypasses fetch entirely; the
-// wrapper only affects the http/https/blob/data branch and any
-// embedder-registered scheme.
-function fetch(
-	input: string | URL | Request,
-	init?: RequestInit,
-): Promise<Response> {
-	return globalThis.fetch(input, init);
-}
-
 const HAVE_NOTHING = 0;
 const HAVE_METADATA = 1;
 const HAVE_CURRENT_DATA = 2;
@@ -384,9 +370,12 @@ export class Video extends EventTarget {
 		const url = new URL(i.src, $.entrypoint);
 		i.currentSrc = url.href;
 
+		// Non-FILE_SCHEMES loads use call-time `globalThis.fetch` so
+		// embedder-installed wrappers (e.g. extended URL schemes) are
+		// honored — see note in `image.ts`.
 		const loadPromise = FILE_SCHEMES.has(url.protocol)
 			? $.videoLoad(handleOf(this), decodeURI(url.href), null)
-			: fetch(url)
+			: globalThis.fetch(url)
 					.then((res) => {
 						if (!res.ok) {
 							throw new Error(`Failed to load video: ${res.status}`);


### PR DESCRIPTION
`Image.src`, `Audio.src`, and `Video.src` setters today do `import { fetch } from './fetch/fetch'` at module init and capture that fetch closure. `./fetch/fetch`'s scheme registry is fixed at `http/https/blob/data/file/sdmc/romfs`.

Embedders that install a session-time `globalThis.fetch` wrapper to extend the scheme registry (e.g. a custom `app://` scheme handler, or a resource-loader that resolves paths against an in-memory package) will find that `<img src="app://foo.png">` still rejects at scheme lookup — the `Image.src` setter is calling the pre-wrapper `./fetch/fetch`, not the embedder's `globalThis.fetch`.

Move the setter's fetch reference to a call-time `globalThis.fetch` lookup. Each of the three modules gets a local:

```ts
function fetch(
    input: string | URL | Request,
    init?: RequestInit,
): Promise<Response> {
    return globalThis.fetch(input, init);
}
```
which replaces the previous `import { fetch } from './fetch/fetch'`. The call sites in the setters are unchanged (`fetch(url).then(...)`).

## Behavior

- No change for embedders that don't override `globalThis.fetch` —  the engine's global fetch is `./fetch/fetch`'s exported fetch by default, so the delegation chain terminates at the same implementation.
- Embedders that DO override `globalThis.fetch` now have their wrapper honored on `Image.src`/`Audio.src`/`Video.src` assignments.

## Gotcha

The lookup MUST be call-time, not import-time. An `import { fetch } from './fetch/fetch'` line captures the export at module init — before any embedder installs its wrapper. Replacing it with `const fetch = globalThis.fetch;` at module top-level would freeze the pre-wrapper fetch and reintroduce the bug in code that looks like it should work. The function-body form guarantees the lookup happens per-call.

## Diff summary

```
 packages/runtime/src/audio.ts | 14 +++++++++++++-
 packages/runtime/src/image.ts | 14 +++++++++++++-
 packages/runtime/src/video.ts | 15 ++++++++++++++-
 3 files changed, 40 insertions(+), 3 deletions(-)
```

Each file: replaces one `import { fetch } from './fetch/fetch';` line with a ~12-line local function definition + explanatory comment.