### PR TITLE
canvas: pin FT_Face char_size at start of fillText/strokeText/measureText

### DIFF
--- a/.changeset/canvas-cross-context-font-size.md
+++ b/.changeset/canvas-cross-context-font-size.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: cross-context canvas font size leakage — re-pin the shared FT_Face char_size at the start of `fillText()`, `strokeText()`, and `measureText()`

--- a/packages/runtime/test/fixtures/canvas-font-cross-context.ts
+++ b/packages/runtime/test/fixtures/canvas-font-cross-context.ts
@@ -1,0 +1,103 @@
+import { test } from '../src/tap';
+
+// Regression tests for cross-context font size leakage (PR #406).
+//
+// In nx.js, all 2D contexts that resolve the same font share one
+// FreeType FT_Face + HarfBuzz hb_font. FT_Face's char_size is
+// device-global, so a save()/restore() on one context (whose restore
+// re-pins the popped state's font_size onto the shared face) used to
+// corrupt the effective font size of every other context sharing the
+// font — until that other context happened to re-assign a *different*
+// font string (same-string assignment short-circuits in the setter).
+//
+// Each test measures/draws on context B at 14px, runs a save/font/
+// restore dance on context A (whose outer state is the default
+// "10px sans-serif"), then measures/draws on B again. The results
+// must be identical.
+
+const TEXT = 'Hello nx.js';
+
+/** Count pixels with non-zero alpha (ink coverage). */
+function inkCoverage(
+	ctx: OffscreenCanvasRenderingContext2D,
+	w: number,
+	h: number,
+): number {
+	const d = ctx.getImageData(0, 0, w, h).data;
+	let n = 0;
+	for (let i = 3; i < d.length; i += 4) {
+		if (d[i] !== 0) n++;
+	}
+	return n;
+}
+
+test('measureText unaffected by save/restore on another context', (t) => {
+	const a = new OffscreenCanvas(200, 50).getContext('2d')!;
+	const b = new OffscreenCanvas(200, 50).getContext('2d')!;
+
+	b.font = '14px sans-serif';
+	const before = b.measureText(TEXT).width;
+	t.ok(before > 0, 'baseline measureText width is positive');
+
+	// Context A: outer state has the default "10px sans-serif";
+	// inner scope sets 20px, draws, and restores back to 10px.
+	a.save();
+	a.font = '20px sans-serif';
+	a.fillText('A', 10, 30);
+	a.restore();
+
+	const after = b.measureText(TEXT).width;
+	t.equal(
+		after,
+		before,
+		'measureText width on context B is unchanged after context A save/restore',
+	);
+});
+
+test('fillText unaffected by save/restore on another context', (t) => {
+	const a = new OffscreenCanvas(200, 50).getContext('2d')!;
+	const b = new OffscreenCanvas(200, 50).getContext('2d')!;
+
+	b.font = '14px sans-serif';
+	b.fillText(TEXT, 10, 30);
+	const before = inkCoverage(b, 200, 50);
+	t.ok(before > 0, 'baseline fillText produced ink');
+
+	a.save();
+	a.font = '20px sans-serif';
+	a.fillText('A', 10, 30);
+	a.restore();
+
+	b.clearRect(0, 0, 200, 50);
+	b.fillText(TEXT, 10, 30);
+	const after = inkCoverage(b, 200, 50);
+	t.equal(
+		after,
+		before,
+		'fillText ink coverage on context B is unchanged after context A save/restore',
+	);
+});
+
+test('strokeText unaffected by save/restore on another context', (t) => {
+	const a = new OffscreenCanvas(200, 50).getContext('2d')!;
+	const b = new OffscreenCanvas(200, 50).getContext('2d')!;
+
+	b.font = '14px sans-serif';
+	b.strokeText(TEXT, 10, 30);
+	const before = inkCoverage(b, 200, 50);
+	t.ok(before > 0, 'baseline strokeText produced ink');
+
+	a.save();
+	a.font = '20px sans-serif';
+	a.fillText('A', 10, 30);
+	a.restore();
+
+	b.clearRect(0, 0, 200, 50);
+	b.strokeText(TEXT, 10, 30);
+	const after = inkCoverage(b, 200, 50);
+	t.equal(
+		after,
+		before,
+		'strokeText ink coverage on context B is unchanged after context A save/restore',
+	);
+});

--- a/source/canvas.cc
+++ b/source/canvas.cc
@@ -1694,6 +1694,14 @@ void nx_canvas_context_2d_fill_text(const FunctionCallbackInfo<Value> &info) {
 	String::Utf8Value text(iso, info[0]);
 	if (!*text)
 		return;
+	// Pin the FreeType/HarfBuzz char_size to this ctx's state.font_size.
+	// Two OffscreenCanvas contexts sharing a FontFace share the underlying
+	// nx_font_face_t (FT_Face + hb_font); a save/restore on one context
+	// mutates the shared FT_Face's device-global char_size in place, so
+	// the next text op on the other context reads glyphs at the wrong
+	// size. Re-pin per call — one FT_Set_Char_Size + one
+	// hb_font_set_scale, sub-microsecond on cached faces.
+	set_font_size(context, context->state->font_size);
 	double scale = 1., font_size = context->state->font_size;
 	if (info.Length() >= 4 && info[3]->IsNumber()) {
 		double max_width;
@@ -1728,6 +1736,8 @@ void nx_canvas_context_2d_stroke_text(
 	String::Utf8Value text(iso, info[0]);
 	if (!*text)
 		return;
+	// Re-pin per call — see fill_text for full rationale.
+	set_font_size(context, context->state->font_size);
 	double scale = 1., font_size = context->state->font_size;
 	if (info.Length() >= 4 && info[3]->IsNumber()) {
 		double max_width;
@@ -1769,6 +1779,9 @@ void nx_canvas_context_2d_measure_text(
 	};
 	double width = 0;
 	if (context->state->hb_font) {
+		// Re-pin per call — see fill_text for full rationale. Measure has
+		// to match render, so the pin fires here too.
+		set_font_size(context, context->state->font_size);
 		String::Utf8Value text(iso, info[0]);
 		hb_buffer_t *buf = hb_buffer_create();
 		hb_buffer_set_direction(buf, HB_DIRECTION_LTR);


### PR DESCRIPTION
`FontFace` construction allocates one `FT_Face` + one `hb_font` per JS `FontFace` object (see `source/font.cc`). All 2D canvas contexts that resolve to the same `FontFace` via `findFont` (in `packages/runtime/src/font/font-face-set.ts`) end up sharing those
FreeType and HarfBuzz instances via their `state->ft_face` / `state->hb_font` pointers.

That sharing has a subtle correctness bug in cross-context save/restore. The `state->font_size` value is per-context (preserved by save/restore); but `FT_Face.char_size` is device-global. Any `set_font_size` call — including the implicit one at the end of `nx_canvas_context_2d_restore` — mutates the shared FT_Face's char_size in place, visible to every other context holding the same FontFace.

Concrete scenario:

1. Context B: `ctx.font = '14px system-ui'`. Setter calls `set_font_size(14)`. FT_Face.char_size = 14 × 64.
2. Context A: `ctx.save()`. Pushes a state copy.
3. Context A: `ctx.font = '20px system-ui'`. Setter finds the same FontFace, calls `set_font_size(20)`. FT_Face.char_size = 20 × 64.
4. Context A: `ctx.fillText(...)`. Draws at 20 px.
5. Context A: `ctx.restore()`. Pops the state; at the bottom, restores `set_font_size(outer.font_size)` — where `outer.font_size = 10` (the canvas-state default). FT_Face.char_size = 10 × 64.
6. Context B: `ctx.font = '14px system-ui'` — the JS-side setter short-circuits because `this.font === '14px system-ui'` (font string unchanged). No `set_font_size` fires.
7. Context B: `ctx.fillText(...)`. Reads glyph metrics from the shared FT_Face with char_size = 10 (Context A's leftover). Renders at 10 px instead of 14.

The specific consumer that hit this in production is a `setInterval`-driven `<canvas>` in one embedder's shell painter, concurrent with a `save`/`restore` in a different context. Both contexts default to `'14px system-ui'` and both should draw at 14; the second consistently renders at 10 after the first `restore` fires.

## Fix

Add one line at the start of each of the three text-op functions:

```cpp
set_font_size(context, context->state->font_size);
```

Idempotent against the state's font_size (calls `FT_Set_Char_Size` on a cached face; sub-microsecond) — restores the per-context scale to the FT_Face immediately before shaping/measurement, so whatever the last cross-context leftover was is overwritten.

## Diff

```
 source/canvas.cc | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```

One re-pin call added at three sites:
- `nx_canvas_context_2d_fill_text` (right after argument parsing)
- `nx_canvas_context_2d_stroke_text` (right after argument parsing)
- `nx_canvas_context_2d_measure_text` (right after the hb_font guard)

## Minimum repro

```js
const a = new OffscreenCanvas(200, 50).getContext('2d');
const b = new OffscreenCanvas(200, 50).getContext('2d');
a.font = '14px system-ui';
b.font = '14px system-ui';

// A does a save/font-change/restore
a.save();
a.font = '20px system-ui';
a.fillText('A', 10, 30);
a.restore();

// B should draw at 14, but reads FT_Face char_size = 10 (canvas
// default) left behind by A's restore.
b.fillText('B', 10, 30);
```

Before this PR: B's "B" renders visibly smaller than A's "A" — about 10-px tall instead of 14. After: same visual size as A's, matching the state's font_size.

## Cost

One `FT_Set_Char_Size` + one `hb_font_set_scale` per fillText / strokeText / measureText. Both are cache hits on any face that's
been used at least once — sub-microsecond in practice, negligible next to the `SkCanvas::drawGlyphs` call that follows.

## Diff summary

```
 source/canvas.cc | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```

## Build / type-check status

Native C++ change; single file. Compiles against upstream `source/canvas.cc` locally. No public-API delta.
