### PR TITLE
test: conformance fixture for cross-context font size leakage (demonstrates #406)

### DIFF
--- a/packages/runtime/test/fixtures/canvas-font-cross-context.ts
+++ b/packages/runtime/test/fixtures/canvas-font-cross-context.ts
@@ -1,0 +1,103 @@
+import { test } from '../src/tap';
+
+// Regression tests for cross-context font size leakage (PR #406).
+//
+// In nx.js, all 2D contexts that resolve the same font share one
+// FreeType FT_Face + HarfBuzz hb_font. FT_Face's char_size is
+// device-global, so a save()/restore() on one context (whose restore
+// re-pins the popped state's font_size onto the shared face) used to
+// corrupt the effective font size of every other context sharing the
+// font — until that other context happened to re-assign a *different*
+// font string (same-string assignment short-circuits in the setter).
+//
+// Each test measures/draws on context B at 14px, runs a save/font/
+// restore dance on context A (whose outer state is the default
+// "10px sans-serif"), then measures/draws on B again. The results
+// must be identical.
+
+const TEXT = 'Hello nx.js';
+
+/** Count pixels with non-zero alpha (ink coverage). */
+function inkCoverage(
+	ctx: OffscreenCanvasRenderingContext2D,
+	w: number,
+	h: number,
+): number {
+	const d = ctx.getImageData(0, 0, w, h).data;
+	let n = 0;
+	for (let i = 3; i < d.length; i += 4) {
+		if (d[i] !== 0) n++;
+	}
+	return n;
+}
+
+test('measureText unaffected by save/restore on another context', (t) => {
+	const a = new OffscreenCanvas(200, 50).getContext('2d')!;
+	const b = new OffscreenCanvas(200, 50).getContext('2d')!;
+
+	b.font = '14px sans-serif';
+	const before = b.measureText(TEXT).width;
+	t.ok(before > 0, 'baseline measureText width is positive');
+
+	// Context A: outer state has the default "10px sans-serif";
+	// inner scope sets 20px, draws, and restores back to 10px.
+	a.save();
+	a.font = '20px sans-serif';
+	a.fillText('A', 10, 30);
+	a.restore();
+
+	const after = b.measureText(TEXT).width;
+	t.equal(
+		after,
+		before,
+		'measureText width on context B is unchanged after context A save/restore',
+	);
+});
+
+test('fillText unaffected by save/restore on another context', (t) => {
+	const a = new OffscreenCanvas(200, 50).getContext('2d')!;
+	const b = new OffscreenCanvas(200, 50).getContext('2d')!;
+
+	b.font = '14px sans-serif';
+	b.fillText(TEXT, 10, 30);
+	const before = inkCoverage(b, 200, 50);
+	t.ok(before > 0, 'baseline fillText produced ink');
+
+	a.save();
+	a.font = '20px sans-serif';
+	a.fillText('A', 10, 30);
+	a.restore();
+
+	b.clearRect(0, 0, 200, 50);
+	b.fillText(TEXT, 10, 30);
+	const after = inkCoverage(b, 200, 50);
+	t.equal(
+		after,
+		before,
+		'fillText ink coverage on context B is unchanged after context A save/restore',
+	);
+});
+
+test('strokeText unaffected by save/restore on another context', (t) => {
+	const a = new OffscreenCanvas(200, 50).getContext('2d')!;
+	const b = new OffscreenCanvas(200, 50).getContext('2d')!;
+
+	b.font = '14px sans-serif';
+	b.strokeText(TEXT, 10, 30);
+	const before = inkCoverage(b, 200, 50);
+	t.ok(before > 0, 'baseline strokeText produced ink');
+
+	a.save();
+	a.font = '20px sans-serif';
+	a.fillText('A', 10, 30);
+	a.restore();
+
+	b.clearRect(0, 0, 200, 50);
+	b.strokeText(TEXT, 10, 30);
+	const after = inkCoverage(b, 200, 50);
+	t.equal(
+		after,
+		before,
+		'strokeText ink coverage on context B is unchanged after context A save/restore',
+	);
+});


### PR DESCRIPTION
Draft PR to demonstrate the bug fixed by #406 in CI.

All 2D canvas contexts that resolve the same font share one `FT_Face` + `hb_font` (see `source/font.cc`). `FT_Face`'s char_size is device-global, so the implicit `set_font_size` at the end of `nx_canvas_context_2d_restore` re-pins the shared face to the popped state's `font_size`, corrupting the effective font size of every other context sharing the font. The other context never recovers because re-assigning the *same* font string short-circuits in the JS `font` setter.

This fixture (`canvas-font-cross-context.ts`) exercises that exact scenario for `measureText`, `fillText`, and `strokeText`. All 6 assertions pass in Chrome (verified locally via Playwright); the WebAssembly/conformance CI job is **expected to fail** on this branch because nxjs-test on `main` renders context B at context A's leftover 10px.

The same fixture has been added to #406's branch, where it passes — validating the fix.

Not intended to merge on its own; either close after #406 lands (which will carry the fixture), or rebase.