### PR TITLE
ci: post type-diff comment via workflow_run so fork PRs work

### DIFF
--- a/.github/workflows/type-diff-comment.yml
+++ b/.github/workflows/type-diff-comment.yml
@@ -47,7 +47,9 @@ jobs:
 
             // Resolve the PR number. `workflow_run.pull_requests` is empty
             // for fork PRs, so fall back to looking up open PRs by the run's
-            // head SHA.
+            // head SHA. For `pull_request`-triggered runs the head SHA is the
+            // PR branch tip, but also match `merge_commit_sha` defensively in
+            // case it is the synthetic merge commit.
             let prNumber = run.pull_requests?.[0]?.number;
             if (!prNumber) {
               const { data: prs } =
@@ -56,7 +58,11 @@ jobs:
                   repo: context.repo.repo,
                   commit_sha: run.head_sha,
                 });
-              const pr = prs.find((p) => p.head.sha === run.head_sha);
+              const pr = prs.find(
+                (p) =>
+                  p.head.sha === run.head_sha ||
+                  p.merge_commit_sha === run.head_sha,
+              );
               prNumber = pr?.number;
             }
             if (!prNumber) {
@@ -106,11 +112,13 @@ jobs:
               ].join('\n');
             }
 
-            // Find existing sticky comment
-            const { data: comments } = await github.rest.issues.listComments({
+            // Find existing sticky comment (paginate: it may not be on the
+            // first page of a busy PR)
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
+              per_page: 100,
             });
             const existing = comments.find((c) => c.body.includes(marker));
 

--- a/.github/workflows/type-diff-comment.yml
+++ b/.github/workflows/type-diff-comment.yml
@@ -1,0 +1,133 @@
+name: Type Diff Comment
+
+# Posts the sticky "Runtime Type Changes" PR comment from the artifact
+# produced by the "Type Diff" workflow. Runs via `workflow_run` so it has a
+# write-capable token even when the PR comes from a fork (the `pull_request`
+# token is read-only for fork PRs).
+#
+# SECURITY: the artifact is produced by a workflow that built untrusted fork
+# code, so its contents must be treated as attacker-controlled text:
+#   - The PR number is resolved from the workflow_run payload / head SHA,
+#     never from artifact contents (which could target an arbitrary PR).
+#   - The diff is only ever embedded as text inside a code fence, using a
+#     fence longer than any backtick run in the content so it cannot escape.
+# Never check out or execute code from the triggering ref in this workflow.
+
+on:
+  workflow_run:
+    workflows: ['Type Diff']
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post Type Diff Comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download diff artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: type-diff
+          path: type-diff
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Post or update comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const run = context.payload.workflow_run;
+
+            // Resolve the PR number. `workflow_run.pull_requests` is empty
+            // for fork PRs, so fall back to looking up open PRs by the run's
+            // head SHA.
+            let prNumber = run.pull_requests?.[0]?.number;
+            if (!prNumber) {
+              const { data: prs } =
+                await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: run.head_sha,
+                });
+              const pr = prs.find((p) => p.head.sha === run.head_sha);
+              prNumber = pr?.number;
+            }
+            if (!prNumber) {
+              core.setFailed(`Unable to resolve PR for head SHA ${run.head_sha}`);
+              return;
+            }
+
+            const diff = fs.readFileSync('type-diff/diff.txt', 'utf8');
+            const changed = diff.length > 0;
+            const marker = '<!-- type-diff-report -->';
+
+            let body;
+            if (changed) {
+              // Truncate if extremely large (GitHub comment limit is 65536 chars)
+              let diffBlock = diff;
+              if (diffBlock.length > 60000) {
+                diffBlock = diffBlock.slice(0, 60000) + '\n... (truncated)';
+              }
+              // Fence must be longer than any backtick run in the (untrusted)
+              // diff so the content cannot break out of the code block.
+              const maxTicks = Math.max(
+                2,
+                ...[...diffBlock.matchAll(/`+/g)].map((m) => m[0].length),
+              );
+              const fence = '`'.repeat(maxTicks + 1);
+              body = [
+                marker,
+                '## 📝 Runtime Type Changes',
+                '',
+                'This PR modifies the public TypeScript API surface (`packages/runtime/dist/index.d.ts`):',
+                '',
+                '<details>',
+                '<summary>View type diff</summary>',
+                '',
+                fence + 'diff',
+                diffBlock,
+                fence,
+                '',
+                '</details>',
+              ].join('\n');
+            } else {
+              body = [
+                marker,
+                '## 📝 Runtime Type Changes',
+                '',
+                '✅ No changes to the public TypeScript API surface.',
+              ].join('\n');
+            }
+
+            // Find existing sticky comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated comment ${existing.id} on PR #${prNumber}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created new comment on PR #${prNumber}`);
+            }

--- a/.github/workflows/type-diff.yml
+++ b/.github/workflows/type-diff.yml
@@ -1,10 +1,16 @@
 name: Type Diff
 
+# Builds the base and PR `@nx.js/runtime` type declarations, diffs them, and
+# uploads the diff as an artifact. The sticky PR comment is posted by the
+# "Type Diff Comment" workflow (`workflow_run`), which runs with a
+# write-capable token — the `pull_request` token is read-only for fork PRs,
+# so commenting from this workflow 403s on any fork-originated PR.
+
 on:
   pull_request:
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   type-diff:
@@ -48,81 +54,30 @@ jobs:
           pnpm build --filter @nx.js/runtime
           cp packages/runtime/dist/index.d.ts /tmp/pr-types.d.ts
 
-      - name: Generate diff and post comment
-        uses: actions/github-script@v7
+      - name: Generate diff
+        run: |
+          mkdir -p /tmp/type-diff
+          # `diff` exits 1 when the files differ; only >1 is a real error
+          diff -u --label "base: index.d.ts" /tmp/base-types.d.ts \
+                  --label "pr: index.d.ts" /tmp/pr-types.d.ts \
+                  > /tmp/type-diff/diff.txt || [ $? -eq 1 ]
+
+      - name: Write job summary
+        run: |
+          if [ -s /tmp/type-diff/diff.txt ]; then
+            {
+              echo '## 📝 Runtime Type Changes'
+              echo ''
+              echo '```diff'
+              head -c 60000 /tmp/type-diff/diff.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '✅ No changes to the public TypeScript API surface.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@v7
         with:
-          script: |
-            const fs = require('fs');
-            const { execSync } = require('child_process');
-
-            // Generate diff
-            let diff = '';
-            try {
-              diff = execSync(
-                'diff -u --label "base: index.d.ts" /tmp/base-types.d.ts --label "pr: index.d.ts" /tmp/pr-types.d.ts',
-                { encoding: 'utf8' }
-              );
-            } catch (e) {
-              // diff exits 1 when files differ
-              diff = e.stdout || '';
-            }
-
-            const changed = diff.length > 0;
-            const marker = '<!-- type-diff-report -->';
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-
-            let body;
-            if (changed) {
-              // Truncate if extremely large (GitHub comment limit is 65536 chars)
-              let diffBlock = diff;
-              if (diffBlock.length > 60000) {
-                diffBlock = diffBlock.slice(0, 60000) + '\n... (truncated)';
-              }
-              body = [
-                marker,
-                '## 📝 Runtime Type Changes',
-                '',
-                'This PR modifies the public TypeScript API surface (`packages/runtime/dist/index.d.ts`):',
-                '',
-                '<details>',
-                '<summary>View type diff</summary>',
-                '',
-                '```diff',
-                diffBlock,
-                '```',
-                '',
-                '</details>',
-              ].join('\n');
-            } else {
-              body = [
-                marker,
-                '## 📝 Runtime Type Changes',
-                '',
-                '✅ No changes to the public TypeScript API surface.',
-              ].join('\n');
-            }
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-              core.info(`Updated comment ${existing.id}`);
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-              core.info('Created new comment');
-            }
+          name: type-diff
+          path: /tmp/type-diff/

--- a/.github/workflows/type-diff.yml
+++ b/.github/workflows/type-diff.yml
@@ -65,12 +65,19 @@ jobs:
       - name: Write job summary
         run: |
           if [ -s /tmp/type-diff/diff.txt ]; then
+            # The diff is built from untrusted PR code; use a code fence
+            # longer than any backtick run in it so the content cannot
+            # escape the fence (same approach as the comment workflow).
+            max=$(grep -o '`\+' /tmp/type-diff/diff.txt | awk '{ if (length($0) > m) m = length($0) } END { print m + 0 }' || true)
+            n=$(( max >= 3 ? max + 1 : 3 ))
+            fence=$(printf '%*s' "$n" '' | tr ' ' '`')
             {
               echo '## 📝 Runtime Type Changes'
               echo ''
-              echo '```diff'
+              echo "${fence}diff"
               head -c 60000 /tmp/type-diff/diff.txt
-              echo '```'
+              echo ''
+              echo "$fence"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo '✅ No changes to the public TypeScript API surface.' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The **Runtime Type Diff** check fails on every fork-originated PR (seen on #404, #405) with:

```
RequestError [HttpError]: Resource not accessible by integration
POST /repos/TooTallNate/nx.js/issues/<n>/comments → 403
```

The type build + diff itself succeeds — only the sticky-comment posting fails. On the `pull_request` event, fork PRs get a **read-only** `GITHUB_TOKEN`; the workflow-level `permissions: pull-requests: write` cannot elevate past that cap.

## Fix

Standard two-stage `workflow_run` pattern:

- **`type-diff.yml`** (`pull_request`, `contents: read` only): builds base + PR types, diffs, writes the diff to the job summary, uploads it as the `type-diff` artifact. No API writes, so it can never 403.
- **`type-diff-comment.yml`** (new, `workflow_run` on "Type Diff" completion, `pull-requests: write` + `actions: read`): downloads the artifact from the triggering run and posts/updates the sticky comment. Works for fork PRs because `workflow_run` workflows execute from the default branch with a base-repo token.

## Security notes

The artifact is produced by a workflow that built untrusted fork code, so the comment workflow treats it as attacker-controlled:

- PR number is resolved from the `workflow_run` payload / head SHA lookup — never from artifact contents (which could otherwise target an arbitrary PR).
- The diff text is embedded using a code fence longer than any backtick run in the content, so it can't escape the fence and inject markdown into a bot-authored comment.
- The comment workflow never checks out or executes code from the triggering ref.

## Notes

- `workflow_run.pull_requests` is empty for fork PRs, so the PR is resolved via `listPullRequestsAssociatedWithCommit(head_sha)` with an exact `head.sha` match.
- The `pull_request` job also writes the diff to `$GITHUB_STEP_SUMMARY`, so the result is visible on the run page even before/without the comment.
- No changeset: workflow-only change, no published package affected.
- `type-diff-comment.yml` only takes effect once merged to `main` (`workflow_run` workflows run from the default branch). After merge, re-running the check on #404 will use the updated `pull_request` workflow via the refreshed merge ref.