### PR TITLE
ci: look up fork PRs via the head repository in type-diff-comment

### DIFF
--- a/.github/workflows/type-diff-comment.yml
+++ b/.github/workflows/type-diff-comment.yml
@@ -46,22 +46,28 @@ jobs:
             const run = context.payload.workflow_run;
 
             // Resolve the PR number. `workflow_run.pull_requests` is empty
-            // for fork PRs, so fall back to looking up open PRs by the run's
-            // head SHA. For `pull_request`-triggered runs the head SHA is the
-            // PR branch tip, but also match `merge_commit_sha` defensively in
-            // case it is the synthetic merge commit.
+            // for fork PRs, so fall back to looking up PRs by the run's head
+            // SHA. The commit lives in the HEAD repository (the fork), so the
+            // commit→PRs lookup must be done there — querying the base repo
+            // returns nothing for fork commits. Filter to PRs that target
+            // this repo and whose head is exactly the run's head SHA.
             let prNumber = run.pull_requests?.[0]?.number;
             if (!prNumber) {
+              const headOwner =
+                run.head_repository?.owner?.login ?? context.repo.owner;
+              const headRepo = run.head_repository?.name ?? context.repo.repo;
               const { data: prs } =
                 await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
+                  owner: headOwner,
+                  repo: headRepo,
                   commit_sha: run.head_sha,
                 });
+              const baseFullName = `${context.repo.owner}/${context.repo.repo}`;
               const pr = prs.find(
                 (p) =>
-                  p.head.sha === run.head_sha ||
-                  p.merge_commit_sha === run.head_sha,
+                  p.base.repo.full_name === baseFullName &&
+                  (p.head.sha === run.head_sha ||
+                    p.merge_commit_sha === run.head_sha),
               );
               prNumber = pr?.number;
             }


### PR DESCRIPTION
Follow-up to #409. The first live fork-PR run (on #404, after syncing it with main) failed in the comment workflow with:

```
##[error]Unable to resolve PR for head SHA f63803413b82214531c93033fefe60ebcc376ae9
```

Root cause: `listPullRequestsAssociatedWithCommit` returns an **empty list when the base repo is queried with a commit that only exists in a fork** — verified directly:

- `GET /repos/TooTallNate/nx.js/commits/f638034.../pulls` → `[]`
- `GET /repos/natureglass/nx.js_extended/commits/f638034.../pulls` → PR #404

So the fallback failed for exactly the fork PRs this workflow exists to serve (same-repo PRs never reach the fallback, since `workflow_run.pull_requests` is populated for them).

## Fix

Query the `workflow_run.head_repository` (the fork) for the commit→PR association, and filter results to PRs that:
- target this repo (`base.repo.full_name` match), and
- have the run's exact head SHA (`head.sha` or `merge_commit_sha`)

The association data comes from GitHub's API and is authoritative — a fork cannot fabricate a PR association pointing at an arbitrary PR, so the comment-targeting security property from #409 is preserved.

After merging, re-running the "Type Diff" check on #404 will trigger a fresh comment run using this fixed workflow.