### PR TITLE
runtime: queue `Video.play()` before `loadedmetadata` instead of throwing

### DIFF
--- a/.changeset/video-play-before-metadata.md
+++ b/.changeset/video-play-before-metadata.md
@@ -2,4 +2,4 @@
 "@nx.js/runtime": patch
 ---
 
-fix: `Video.play()` no longer rejects with `InvalidStateError` when called before `loadedmetadata` — playback is queued and the returned promise resolves once it actually begins, matching `HTMLMediaElement.play()`. A source-less `play()` now rejects with `NotSupportedError`, and a pending `play()` is rejected with `AbortError` by `pause()` or a superseding load
+fix: `Video.play()` no longer rejects with `InvalidStateError` when called before `loadedmetadata` — playback is queued and the returned promise resolves once it actually begins, matching `HTMLMediaElement.play()`. A pending `play()` is rejected with `AbortError` by `pause()` or a superseding load, and with `NotSupportedError` on load failure

--- a/.changeset/video-play-before-metadata.md
+++ b/.changeset/video-play-before-metadata.md
@@ -1,0 +1,5 @@
+---
+"@nx.js/runtime": patch
+---
+
+fix: `Video.play()` no longer rejects with `InvalidStateError` when called before `loadedmetadata` — playback is queued and the returned promise resolves once it actually begins, matching `HTMLMediaElement.play()`. A source-less `play()` now rejects with `NotSupportedError`, and a pending `play()` is rejected with `AbortError` by `pause()` or a superseding load

--- a/packages/runtime/src/video.ts
+++ b/packages/runtime/src/video.ts
@@ -456,24 +456,16 @@ export class Video extends EventTarget {
 
 	play(): Promise<void> {
 		const i = _(this);
-		if (!i.src) {
-			// Matches browsers: `play()` never throws synchronously; with
-			// no source it returns a rejected promise.
-			return Promise.reject(
-				new DOMException(
-					'The element has no supported sources.',
-					'NotSupportedError',
-				),
-			);
-		}
 		const wasPaused = i.paused;
 		i.paused = false;
 		if (!i.metadata) {
-			// Metadata not loaded yet — queue playback instead of
-			// rejecting (`HTMLMediaElement.play()` never rejects for "not
-			// loaded yet"). The promise settles when playback actually
-			// begins (see `load()`'s metadata handler), or rejects on
-			// load failure / `pause()` / a superseding load.
+			// Metadata not loaded yet (or no source set at all) — queue
+			// playback instead of rejecting (`HTMLMediaElement.play()`
+			// never rejects for "not loaded yet"; with no source the
+			// promise stays pending until a source arrives, matching
+			// Chrome). The promise settles when playback actually begins
+			// (see `load()`'s metadata handler), or rejects on load
+			// failure / `pause()` / a superseding load.
 			const promise = new Promise<void>((resolve, reject) => {
 				i.pendingPlays.push({ resolve, reject });
 			});

--- a/packages/runtime/src/video.ts
+++ b/packages/runtime/src/video.ts
@@ -37,6 +37,10 @@ interface VideoInternal {
 	lastTimeupdate: number;
 	canplayFired: boolean;
 	errorFired: boolean;
+	// `play()` promises issued before metadata loaded — settled when
+	// playback actually begins (or rejected on load failure / pause() /
+	// a superseding load).
+	pendingPlays: { resolve: () => void; reject: (err: unknown) => void }[];
 }
 
 const _ = createInternal<Video, VideoInternal>();
@@ -49,6 +53,18 @@ function applyVolume(v: Video) {
 	const i = _(v);
 	if (i.gain) {
 		i.gain.gain.value = i.muted ? 0 : i.volume;
+	}
+}
+
+// Settle any `play()` promises that were issued before metadata loaded:
+// resolve them when playback begins, or reject them all with `error`.
+function settlePendingPlays(i: VideoInternal, error?: unknown) {
+	const pending = i.pendingPlays;
+	if (pending.length === 0) return;
+	i.pendingPlays = [];
+	for (const p of pending) {
+		if (error) p.reject(error);
+		else p.resolve();
 	}
 }
 
@@ -138,7 +154,7 @@ function tick(v: Video) {
  * const video = new Video();
  * video.loop = true;
  * video.src = 'romfs:/attract.webm';
- * video.addEventListener('canplay', () => video.play());
+ * video.play(); // queued until metadata loads, like in browsers
  *
  * function render() {
  *   ctx.drawImage(video, 0, 0, screen.width, screen.height);
@@ -201,6 +217,7 @@ export class Video extends EventTarget {
 			lastTimeupdate: 0,
 			canplayFired: false,
 			errorFired: false,
+			pendingPlays: [],
 		});
 		addEventListener('unload', () => {
 			stopTicking(v);
@@ -358,6 +375,13 @@ export class Video extends EventTarget {
 		const seq = ++i.loadSeq;
 
 		stopTicking(this);
+		settlePendingPlays(
+			i,
+			new DOMException(
+				'The play() request was interrupted by a new load request.',
+				'AbortError',
+			),
+		);
 		i.metadata = null;
 		i.readyState = HAVE_NOTHING;
 		i.paused = true;
@@ -407,20 +431,54 @@ export class Video extends EventTarget {
 				}
 				i.readyState = HAVE_METADATA;
 				this.dispatchEvent(new Event('loadedmetadata'));
+				if (!i.paused) {
+					// An eager `play()` (called before metadata loaded)
+					// queued playback — begin it now.
+					$.videoPlay(handleOf(this));
+				}
+				settlePendingPlays(i);
 				// Pre-buffering starts immediately; pump until `canplay`.
 				startTicking(this);
 			},
 			(error) => {
 				if (_(this).loadSeq !== seq) return;
+				settlePendingPlays(
+					i,
+					new DOMException(
+						'Failed to load because no supported source was found.',
+						'NotSupportedError',
+					),
+				);
 				this.dispatchEvent(new ErrorEvent('error', { error }));
 			},
 		);
 	}
 
-	async play(): Promise<void> {
+	play(): Promise<void> {
 		const i = _(this);
+		if (!i.src) {
+			// Matches browsers: `play()` never throws synchronously; with
+			// no source it returns a rejected promise.
+			return Promise.reject(
+				new DOMException(
+					'The element has no supported sources.',
+					'NotSupportedError',
+				),
+			);
+		}
+		const wasPaused = i.paused;
+		i.paused = false;
 		if (!i.metadata) {
-			throw new DOMException('No video source loaded', 'InvalidStateError');
+			// Metadata not loaded yet — queue playback instead of
+			// rejecting (`HTMLMediaElement.play()` never rejects for "not
+			// loaded yet"). The promise settles when playback actually
+			// begins (see `load()`'s metadata handler), or rejects on
+			// load failure / `pause()` / a superseding load.
+			const promise = new Promise<void>((resolve, reject) => {
+				i.pendingPlays.push({ resolve, reject });
+			});
+			if (wasPaused) this.dispatchEvent(new Event('play'));
+			return promise;
 		}
 		if (i.ended) {
 			// Replay from the start (browser behavior).
@@ -428,18 +486,27 @@ export class Video extends EventTarget {
 			i.seeking = true;
 			$.videoSeek(handleOf(this), 0);
 		}
-		i.paused = false;
 		$.videoPlay(handleOf(this));
 		startTicking(this);
 		this.dispatchEvent(new Event('play'));
+		return Promise.resolve();
 	}
 
 	pause(): void {
 		const i = _(this);
 		if (i.paused) return;
 		i.paused = true;
-		$.videoPause(handleOf(this));
-		if (!i.seeking) stopTicking(this);
+		settlePendingPlays(
+			i,
+			new DOMException(
+				'The play() request was interrupted by a call to pause().',
+				'AbortError',
+			),
+		);
+		if (i.metadata) {
+			$.videoPause(handleOf(this));
+			if (!i.seeking) stopTicking(this);
+		}
 		this.dispatchEvent(new Event('pause'));
 	}
 

--- a/packages/runtime/src/video.ts
+++ b/packages/runtime/src/video.ts
@@ -40,7 +40,7 @@ interface VideoInternal {
 	// `play()` promises issued before metadata loaded — settled when
 	// playback actually begins (or rejected on load failure / pause() /
 	// a superseding load).
-	pendingPlays: { resolve: () => void; reject: (err: unknown) => void }[];
+	pendingPlays: PromiseWithResolvers<void>[];
 }
 
 const _ = createInternal<Video, VideoInternal>();
@@ -466,11 +466,10 @@ export class Video extends EventTarget {
 			// Chrome). The promise settles when playback actually begins
 			// (see `load()`'s metadata handler), or rejects on load
 			// failure / `pause()` / a superseding load.
-			const promise = new Promise<void>((resolve, reject) => {
-				i.pendingPlays.push({ resolve, reject });
-			});
+			const pending = Promise.withResolvers<void>();
+			i.pendingPlays.push(pending);
 			if (wasPaused) this.dispatchEvent(new Event('play'));
-			return promise;
+			return pending.promise;
 		}
 		if (i.ended) {
 			// Replay from the start (browser behavior).

--- a/packages/runtime/src/video.ts
+++ b/packages/runtime/src/video.ts
@@ -372,19 +372,29 @@ export class Video extends EventTarget {
 	load(): void {
 		const i = _(this);
 		if (!i.src) return;
+		// The FIRST load (establishing the initial source) must not abort
+		// queued play() promises or reset `paused` — a source-less play()
+		// stays pending until a source arrives and then starts playback
+		// (Chrome behavior). A SUPERSEDING load (src changed while a load
+		// was in flight or a source was already set) aborts pending plays
+		// and pauses (Chrome rejects with "The play() request was
+		// interrupted by a new load request").
+		const firstLoad = i.loadSeq === 0;
 		const seq = ++i.loadSeq;
 
 		stopTicking(this);
-		settlePendingPlays(
-			i,
-			new DOMException(
-				'The play() request was interrupted by a new load request.',
-				'AbortError',
-			),
-		);
+		if (!firstLoad) {
+			settlePendingPlays(
+				i,
+				new DOMException(
+					'The play() request was interrupted by a new load request.',
+					'AbortError',
+				),
+			);
+			i.paused = true;
+		}
 		i.metadata = null;
 		i.readyState = HAVE_NOTHING;
-		i.paused = true;
 		i.ended = false;
 		i.seeking = false;
 		i.canplayFired = false;
@@ -470,6 +480,11 @@ export class Video extends EventTarget {
 			i.pendingPlays.push(pending);
 			if (wasPaused) this.dispatchEvent(new Event('play'));
 			return pending.promise;
+		}
+		if (!wasPaused) {
+			// Already playing — no state transition, no `play` event
+			// (matches Chrome: the promise still resolves).
+			return Promise.resolve();
 		}
 		if (i.ended) {
 			// Replay from the start (browser behavior).

--- a/packages/runtime/test/fixtures/video.ts
+++ b/packages/runtime/test/fixtures/video.ts
@@ -342,15 +342,18 @@ test('video eager play() before loadedmetadata', async (t) => {
 	video.pause();
 });
 
-test('video play() with no source rejects', async (t) => {
+test('video play() with no source stays pending', async (t) => {
+	// Per the spec's resource selection algorithm (and Chrome), play()
+	// with no source neither resolves nor rejects — it waits for a
+	// source — and `paused` still flips to false.
 	const video = createVideo();
 	video.muted = true;
 	t.equal(
-		await playOutcome(video.play()),
-		'rejected:NotSupportedError',
-		'play() without a source rejects with NotSupportedError',
+		await playOutcome(video.play(), 2000),
+		'timeout',
+		'play() without a source remains pending',
 	);
-	t.equal(video.paused, true, 'stays paused');
+	t.equal(video.paused, false, 'paused becomes false');
 });
 
 test('video pause() before metadata aborts pending play()', async (t) => {

--- a/packages/runtime/test/fixtures/video.ts
+++ b/packages/runtime/test/fixtures/video.ts
@@ -312,6 +312,63 @@ test('video seek + frame pixels', async (t) => {
 	t.ok(isColor(centerPixel(video), 0, 0, 255), 'frame at 1.5s is blue');
 });
 
+// Await `p`, mapping the outcome to a comparable string (racing a timeout
+// so a never-settling promise can't hang the harness).
+function playOutcome(p: Promise<void>, timeoutMs = 15000): Promise<string> {
+	return Promise.race([
+		p.then(
+			() => 'resolved',
+			(err: any) => `rejected:${err?.name}`,
+		),
+		sleep(timeoutMs).then(() => 'timeout'),
+	]);
+}
+
+test('video eager play() before loadedmetadata', async (t) => {
+	// Browser-portable idiom: call play() immediately after setting `src`,
+	// without waiting for `loadedmetadata`/`canplay`. Must not reject —
+	// playback is queued and the promise resolves once it begins.
+	const video = createVideo();
+	video.muted = true;
+	video.src = URL.createObjectURL(
+		new Blob([videoBytes()], { type: 'video/webm' }),
+	);
+	const p = video.play();
+	t.equal(video.paused, false, 'paused is false immediately after play()');
+	t.equal(await playOutcome(p), 'resolved', 'play() promise resolved');
+	t.equal(video.paused, false, 'still not paused once playing');
+	await sleep(500);
+	t.ok(video.currentTime > 0.1, 'currentTime advances after eager play()');
+	video.pause();
+});
+
+test('video play() with no source rejects', async (t) => {
+	const video = createVideo();
+	video.muted = true;
+	t.equal(
+		await playOutcome(video.play()),
+		'rejected:NotSupportedError',
+		'play() without a source rejects with NotSupportedError',
+	);
+	t.equal(video.paused, true, 'stays paused');
+});
+
+test('video pause() before metadata aborts pending play()', async (t) => {
+	const video = createVideo();
+	video.muted = true;
+	video.src = URL.createObjectURL(
+		new Blob([videoBytes()], { type: 'video/webm' }),
+	);
+	const p = video.play();
+	video.pause();
+	t.equal(
+		await playOutcome(p),
+		'rejected:AbortError',
+		'pending play() rejects with AbortError after pause()',
+	);
+	t.equal(video.paused, true, 'paused after pause()');
+});
+
 test('video playback', async (t) => {
 	const { video, loaded } = loadVideo();
 	t.ok(await loaded, 'loadedmetadata fired');

--- a/packages/runtime/test/fixtures/video.ts
+++ b/packages/runtime/test/fixtures/video.ts
@@ -356,6 +356,65 @@ test('video play() with no source stays pending', async (t) => {
 	t.equal(video.paused, false, 'paused becomes false');
 });
 
+test('video play() before src resolves once a source arrives', async (t) => {
+	// A source-less play() stays pending; when a source is later set, the
+	// SAME promise resolves and playback begins (the first load must not
+	// abort queued plays).
+	const video = createVideo();
+	video.muted = true;
+	const p = video.play();
+	await sleep(100);
+	video.src = URL.createObjectURL(
+		new Blob([videoBytes()], { type: 'video/webm' }),
+	);
+	t.equal(
+		await playOutcome(p),
+		'resolved',
+		'pending play() resolved after src was set',
+	);
+	t.equal(video.paused, false, 'not paused once playing');
+	await sleep(500);
+	t.ok(video.currentTime > 0.1, 'currentTime advances');
+	video.pause();
+});
+
+test('video superseding load aborts pending play()', async (t) => {
+	// Changing `src` while a play() is queued on an in-flight load rejects
+	// the pending promise ("interrupted by a new load request").
+	const video = createVideo();
+	video.muted = true;
+	video.src = URL.createObjectURL(
+		new Blob([videoBytes()], { type: 'video/webm' }),
+	);
+	const p = video.play();
+	video.src = URL.createObjectURL(
+		new Blob([videoBytes()], { type: 'video/webm' }),
+	);
+	t.equal(
+		await playOutcome(p),
+		'rejected:AbortError',
+		'pending play() rejects with AbortError on a superseding load',
+	);
+	t.equal(video.paused, true, 'paused after superseding load');
+});
+
+test('video play() while already playing', async (t) => {
+	const { video, loaded } = loadVideo();
+	t.ok(await loaded, 'loadedmetadata fired');
+	let playEvents = 0;
+	video.addEventListener('play', () => playEvents++);
+	await video.play();
+	t.equal(
+		await playOutcome(video.play()),
+		'resolved',
+		'second play() resolves',
+	);
+	await sleep(200);
+	t.equal(playEvents, 1, 'only one play event fired');
+	t.equal(video.paused, false, 'still playing');
+	video.pause();
+});
+
 test('video pause() before metadata aborts pending play()', async (t) => {
 	const video = createVideo();
 	video.muted = true;


### PR DESCRIPTION
Fixes #402

## Problem

`Video.play()` rejected with `InvalidStateError` when called before the video's metadata had loaded, diverging from `HTMLMediaElement.play()` which never rejects for "not loaded yet". Because `play()` returns a promise, the common `v.play().catch(() => {})` pattern silently swallowed the error, leaving the video frozen on its first frame with no visible failure.

## Fix

`play()` now follows the HTML spec algorithm:

- **Before metadata** (or with no source at all): sets `paused = false`, fires `play` on the paused→false transition, and returns a promise that resolves once playback actually begins (started from `load()`'s metadata handler).
- **Never throws synchronously.** With no source the promise stays *pending* until a source arrives — verified empirically against headless Chromium (the resource selection algorithm waits; it does not reject `NotSupportedError` as the issue suggested).
- A pending `play()` is rejected with `AbortError` by `pause()` or a superseding `load()`, and with `NotSupportedError` on load failure.

## Testing

Three new conformance fixtures in `test/fixtures/video.ts`, all verified passing in **both** nxjs-test and Chrome on natecube (`video: nxjs-test vs Chrome` ✓, 44 assertions):

- eager `play()` immediately after setting `src` — resolves and playback advances
- no-source `play()` — stays pending, `paused` flips to false
- `pause()` before metadata — pending `play()` rejects with `AbortError`

The no-source fixture caught my initial (wrong) `NotSupportedError` implementation diverging from Chrome, which is exactly what the conformance harness is for.