### PR TITLE
module: expose JS-callable page-module execution (importmap + prefetched sources + `moduleRun`)

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -991,6 +991,7 @@ static void build_init_object(Isolate *iso, Local<Context> context,
 	nx_init_web(iso, init_obj);
 	nx_init_webgl(iso, init_obj);
 	nx_init_window(iso, init_obj);
+	nx_module_bindings(iso, init_obj);
 
 	NX_SET_FUNC(init_obj, "exit", js_exit);
 	NX_SET_FUNC(init_obj, "queueMicrotask", js_queue_microtask);

--- a/source/module.cc
+++ b/source/module.cc
@@ -25,6 +25,26 @@ std::unordered_map<int, std::string> g_module_urls;
 // The entrypoint module's URL (drives import.meta.main).
 std::string g_entrypoint_url;
 
+// Per-page importmap: page-base URL -> (bare specifier -> resolved target URL).
+// Populated by nx_module_set_importmap; consulted by resolve_specifier_with_map
+// when a bare specifier fails direct URL resolution. Targets are stored already
+// resolved against the page base so lookup is O(1) and does not re-parse.
+std::unordered_map<std::string,
+                   std::unordered_map<std::string, std::string>>
+    g_importmaps;
+// Resolved-URL -> source text prefetched by the runtime (via `fetch()`). When
+// present, load_module skips fopen and compiles from this text instead. Used
+// for URL schemes the engine has no direct filesystem access to (e.g.
+// brewser://, sdmc-scoped page assets), or when the runtime has already paid
+// for the read via JS fetch and wants to avoid a second read.
+std::unordered_map<std::string, std::string> g_prefetch_sources;
+// Resolved-URL -> page-base URL that the module belongs to. Used by
+// resolve_module_callback to look up which importmap applies when a module
+// imports a bare specifier: the map for `g_module_page_base[referrer.url]`.
+// Modules loaded outside a page context (e.g. the runtime entrypoint via
+// nx_run_entry_module) are absent from this map.
+std::unordered_map<std::string, std::string> g_module_page_base;
+
 void register_module(Isolate *iso, Local<Module> module,
                      const std::string &url) {
 	g_module_cache[url].Reset(iso, module);
@@ -101,6 +121,51 @@ bool resolve_specifier(const std::string &base, const std::string &specifier,
 	return true;
 }
 
+// Resolve `specifier` against `base`, with importmap fallback for bare
+// specifiers. If direct URL resolution succeeds, use it (browser importmap
+// spec: only bare specifiers consult the map). Otherwise consult the importmap
+// registered for `page_base`. Returns false if neither path resolves.
+bool resolve_specifier_with_map(const std::string &base,
+                                const std::string &page_base,
+                                const std::string &specifier,
+                                std::string &out) {
+	if (resolve_specifier(base, specifier, out))
+		return true;
+
+	if (page_base.empty())
+		return false;
+	auto page_it = g_importmaps.find(page_base);
+	if (page_it == g_importmaps.end())
+		return false;
+	// Exact-match branch first — a specifier that appears verbatim as an
+	// importmap key wins over any prefix that could also match.
+	auto spec_it = page_it->second.find(specifier);
+	if (spec_it != page_it->second.end()) {
+		out = spec_it->second;
+		return true;
+	}
+	// Prefix (packages-via-trailing-slash) match per importmap spec
+	// https://html.spec.whatwg.org/multipage/webappapis.html#resolving-an-imports-match.
+	// Any importmap key ending in `/` acts as a namespace prefix; a
+	// specifier that begins with the key resolves to the mapped value
+	// with the tail appended. Longest key wins so `foo/bar/` beats `foo/`
+	// when both are registered. Registered targets are already resolved
+	// against page_base (see nx_module_set_importmap), so tail append
+	// produces an absolute URL directly.
+	const std::string *best_key = nullptr;
+	for (const auto &kv : page_it->second) {
+		if (kv.first.empty() || kv.first.back() != '/') continue;
+		if (specifier.rfind(kv.first, 0) != 0) continue; // startsWith
+		if (best_key == nullptr || kv.first.size() > best_key->size())
+			best_key = &kv.first;
+	}
+	if (best_key != nullptr) {
+		out = page_it->second.at(*best_key) + specifier.substr(best_key->size());
+		return true;
+	}
+	return false;
+}
+
 // Map a resolved module URL to a path that fopen() can open. Mounted devoptab
 // schemes (romfs:/sdmc:/nxjs:) are opened as-is. `file://` (host test binary)
 // is stripped to an absolute path.
@@ -114,29 +179,57 @@ std::string url_to_fs_path(const std::string &url) {
 
 // Compile (and cache) the module at the already-resolved absolute URL `url`.
 // On failure, schedules a V8 exception and returns an empty MaybeLocal.
-MaybeLocal<Module> load_module(Isolate *iso, const std::string &url) {
+//
+// `page_base` (may be empty) tags the loaded module with the page-scope whose
+// importmap it should consult for bare specifiers. Runtime page-level module
+// runs propagate this through the recursive resolver; entrypoint / filesystem
+// modules pass empty.
+//
+// Source lookup precedence:
+//   1. g_prefetch_sources[url] — set by nx_module_set_source when the runtime
+//      has already fetched the body over its own (JS-side) `fetch`. Covers URL
+//      schemes the engine's fopen() cannot reach (brewser://, http(s)://, and
+//      sdmc:// resources living under paths the engine has no devoptab mount
+//      for).
+//   2. fopen(url_to_fs_path(url)) — the pre-existing filesystem path, used by
+//      the entrypoint module and any relative import chain rooted at it.
+MaybeLocal<Module> load_module(Isolate *iso, const std::string &url,
+                               const std::string &page_base = "") {
 	auto cached = g_module_cache.find(url);
 	if (cached != g_module_cache.end())
 		return cached->second.Get(iso);
 
-	std::string path = url_to_fs_path(url);
-	size_t len = 0;
-	char *src = read_module_file(path.c_str(), &len);
-	if (!src) {
-		char msg[1024];
-		snprintf(msg, sizeof(msg), "Cannot find module '%s'", url.c_str());
-		iso->ThrowException(Exception::Error(nx_str(iso, msg)));
-		return MaybeLocal<Module>();
-	}
-
 	Local<String> source;
-	bool ok = String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
-	              .ToLocal(&source);
-	free(src);
-	if (!ok) {
-		iso->ThrowException(Exception::Error(
-		    nx_str(iso, "module source too large or invalid UTF-8")));
-		return MaybeLocal<Module>();
+	auto pf_it = g_prefetch_sources.find(url);
+	if (pf_it != g_prefetch_sources.end()) {
+		const std::string &text = pf_it->second;
+		if (!String::NewFromUtf8(iso, text.c_str(), NewStringType::kNormal,
+		                         (int)text.size())
+		         .ToLocal(&source)) {
+			iso->ThrowException(Exception::Error(
+			    nx_str(iso, "module source too large or invalid UTF-8")));
+			return MaybeLocal<Module>();
+		}
+	} else {
+		std::string path = url_to_fs_path(url);
+		size_t len = 0;
+		char *src = read_module_file(path.c_str(), &len);
+		if (!src) {
+			char msg[1024];
+			snprintf(msg, sizeof(msg), "Cannot find module '%s'",
+			         url.c_str());
+			iso->ThrowException(Exception::Error(nx_str(iso, msg)));
+			return MaybeLocal<Module>();
+		}
+		bool ok =
+		    String::NewFromUtf8(iso, src, NewStringType::kNormal, (int)len)
+		        .ToLocal(&source);
+		free(src);
+		if (!ok) {
+			iso->ThrowException(Exception::Error(
+			    nx_str(iso, "module source too large or invalid UTF-8")));
+			return MaybeLocal<Module>();
+		}
 	}
 
 	ScriptOrigin origin(nx_str(iso, url.c_str()), 0, 0, false, -1,
@@ -148,10 +241,15 @@ MaybeLocal<Module> load_module(Isolate *iso, const std::string &url) {
 
 	// Register BEFORE returning so import cycles resolve to this instance.
 	register_module(iso, module, url);
+	if (!page_base.empty())
+		g_module_page_base[url] = page_base;
 	return module;
 }
 
 // V8 static-import resolver: resolve `specifier` against the `referrer`'s URL.
+// Bare specifiers consult the importmap registered for the referrer's page
+// scope (via g_module_page_base); if the referrer belongs to no page scope
+// (entrypoint / filesystem-loaded module), bare specifiers still fail.
 MaybeLocal<Module> resolve_module_callback(Local<Context> context,
                                            Local<String> specifier,
                                            Local<FixedArray> import_assertions,
@@ -162,20 +260,25 @@ MaybeLocal<Module> resolve_module_callback(Local<Context> context,
 
 	auto it = g_module_urls.find(referrer->GetIdentityHash());
 	std::string base = it != g_module_urls.end() ? it->second : g_entrypoint_url;
+	auto pb_it = g_module_page_base.find(base);
+	std::string page_base =
+	    pb_it != g_module_page_base.end() ? pb_it->second : std::string();
 
 	String::Utf8Value spec(iso, specifier);
 	std::string spec_str = utf8_to_string(spec);
 	std::string resolved;
-	if (!resolve_specifier(base, spec_str, resolved)) {
+	if (!resolve_specifier_with_map(base, page_base, spec_str, resolved)) {
 		char msg[1024];
 		snprintf(msg, sizeof(msg),
-		         "Cannot find module '%s' imported from '%s' (only relative "
-		         "and absolute-URL specifiers are supported)",
+		         "Cannot find module '%s' imported from '%s' (bare specifiers "
+		         "require an importmap for the page scope; relative and "
+		         "absolute-URL specifiers do not)",
 		         spec_str.c_str(), base.c_str());
 		iso->ThrowException(Exception::Error(nx_str(iso, msg)));
 		return MaybeLocal<Module>();
 	}
-	return load_module(iso, resolved);
+	// Propagate page_base so child modules see the same importmap.
+	return load_module(iso, resolved, page_base);
 }
 
 // Instantiate + evaluate a loaded module. Returns the evaluation result
@@ -231,11 +334,18 @@ MaybeLocal<Promise> dynamic_import_callback(
 	std::string spec_str = utf8_to_string(spec);
 	std::string resolved;
 
+	// The importing script's page scope (if it is a page-level module) drives
+	// bare-specifier resolution here too — dynamic import() from a
+	// page-module inherits the page's importmap.
+	auto pb_it = g_module_page_base.find(base);
+	std::string page_base =
+	    pb_it != g_module_page_base.end() ? pb_it->second : std::string();
+
 	TryCatch try_catch(iso);
 	bool failed = false;
 	Local<Value> error;
 
-	if (!resolve_specifier(base, spec_str, resolved)) {
+	if (!resolve_specifier_with_map(base, page_base, spec_str, resolved)) {
 		char msg[1024];
 		snprintf(msg, sizeof(msg), "Cannot find module '%s' imported from '%s'",
 		         spec_str.c_str(), base.c_str());
@@ -244,7 +354,7 @@ MaybeLocal<Promise> dynamic_import_callback(
 	}
 
 	Local<Module> module;
-	if (!failed && !load_module(iso, resolved).ToLocal(&module)) {
+	if (!failed && !load_module(iso, resolved, page_base).ToLocal(&module)) {
 		error = try_catch.Exception();
 		failed = true;
 	}
@@ -302,9 +412,297 @@ MaybeLocal<Promise> dynamic_import_callback(
 
 } // namespace
 
+// ---------------------------------------------------------------------------
+// JS-callable page-module surface. Exposed on the `$` init object so runtime
+// code (brewser-runtime canvas-runner, or any embedder driving per-page module
+// execution) can wire an HTML `<script type="module">` and its `<script
+// type="importmap">` sibling into V8's real module system without shelling out
+// to a userland loader like SystemJS.
+//
+// Design contract (see also NXJS_PATCHES_NEEDED.md #105):
+//   1. Runtime calls moduleSetImportmap(pageBase, mapJson) for each importmap
+//      tag on the page. Multiple calls merge (last write wins per specifier).
+//   2. Runtime walks the entry module's imports (JS-side scan), calls
+//      moduleSetSource(resolvedUrl, source) for every URL it fetches. This
+//      lets the engine's resolver skip fopen for scheme URLs it cannot open
+//      itself (brewser://, http(s)://) and for source it has already read.
+//   3. Runtime calls moduleRun(source, url, pageBase) with the inline module's
+//      body (or fetched src). The returned Promise resolves when top-level
+//      await settles.
+//   4. On page navigation, runtime calls moduleClearPage(pageBase) to purge
+//      the page's importmap, module cache entries, and prefetched sources.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Parse a JSON importmap of the shape `{"imports": {spec: target, ...}, ...}`
+// and merge entries into g_importmaps[page_base]. Targets are resolved against
+// page_base at registration time; specifier lookups at resolve time are then
+// O(1) and never re-parse. `scopes` is accepted (permissive) but ignored for
+// this pass; unscoped `imports` covers the common case (single-page demos and
+// the whole Three.js ecosystem's importmap convention). Silently no-ops on
+// malformed JSON — a broken importmap should not abort the page.
+void nx_module_set_importmap(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> context = iso->GetCurrentContext();
+	if (info.Length() < 2 || !info[0]->IsString() || !info[1]->IsString())
+		return;
+
+	String::Utf8Value base(iso, info[0]);
+	String::Utf8Value json(iso, info[1]);
+	std::string base_s = utf8_to_string(base);
+	if (base_s.empty())
+		return;
+
+	Local<String> json_str = info[1].As<String>();
+	Local<Value> parsed;
+	if (!JSON::Parse(context, json_str).ToLocal(&parsed))
+		return;
+	if (!parsed->IsObject())
+		return;
+	Local<Object> map_obj = parsed.As<Object>();
+
+	Local<Value> imports_val;
+	if (!map_obj->Get(context, nx_str(iso, "imports")).ToLocal(&imports_val))
+		return;
+	if (!imports_val->IsObject())
+		return;
+	Local<Object> imports = imports_val.As<Object>();
+	Local<Array> names;
+	if (!imports->GetOwnPropertyNames(context).ToLocal(&names))
+		return;
+
+	auto &page_map = g_importmaps[base_s]; // create-or-merge
+	uint32_t n = names->Length();
+	for (uint32_t i = 0; i < n; i++) {
+		Local<Value> key_val;
+		if (!names->Get(context, i).ToLocal(&key_val))
+			continue;
+		if (!key_val->IsString())
+			continue;
+		Local<Value> val;
+		if (!imports->Get(context, key_val).ToLocal(&val))
+			continue;
+		if (!val->IsString())
+			continue;
+
+		String::Utf8Value key_u(iso, key_val);
+		String::Utf8Value val_u(iso, val);
+		std::string k = utf8_to_string(key_u);
+		std::string v = utf8_to_string(val_u);
+		if (k.empty() || v.empty())
+			continue;
+
+		// Resolve target against page_base so bare-specifier lookups return a
+		// fully-qualified URL. If the target is itself a bare identifier
+		// (importmap chaining), store as-is; resolve_specifier will refuse it
+		// at load time, which surfaces as a clear error.
+		std::string resolved;
+		if (resolve_specifier(base_s, v, resolved))
+			page_map[k] = resolved;
+		else
+			page_map[k] = v;
+	}
+}
+
+// Register `source` as the body for `url`. load_module consults this map
+// before fopen. Idempotent (last write wins) so a repeat fetch during
+// development or a re-invocation does not error.
+void nx_module_set_source(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	if (info.Length() < 2 || !info[0]->IsString() || !info[1]->IsString())
+		return;
+	String::Utf8Value url(iso, info[0]);
+	String::Utf8Value src(iso, info[1]);
+	std::string url_s = utf8_to_string(url);
+	if (url_s.empty())
+		return;
+	g_prefetch_sources[url_s] = utf8_to_string(src);
+}
+
+// Compile `source` as a module identified by `url`, tag it with `pageBase` so
+// its bare-specifier imports consult the right importmap, InstantiateModule
+// (recursively resolving), Evaluate, and return a Promise that mirrors the
+// evaluation promise (fulfilled with the module namespace, rejected on any
+// failure at compile/instantiate/evaluate).
+void nx_module_run(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	Local<Context> context = iso->GetCurrentContext();
+
+	Local<Promise::Resolver> resolver;
+	if (!Promise::Resolver::New(context).ToLocal(&resolver))
+		return;
+	info.GetReturnValue().Set(resolver->GetPromise());
+
+	if (info.Length() < 3 || !info[0]->IsString() || !info[1]->IsString() ||
+	    !info[2]->IsString()) {
+		resolver
+		    ->Reject(context,
+		             Exception::TypeError(nx_str(
+		                 iso, "moduleRun(source, url, pageBase): 3 strings")))
+		    .Check();
+		return;
+	}
+
+	String::Utf8Value src(iso, info[0]);
+	String::Utf8Value url(iso, info[1]);
+	String::Utf8Value base(iso, info[2]);
+	std::string url_s = utf8_to_string(url);
+	std::string base_s = utf8_to_string(base);
+	if (url_s.empty() || base_s.empty()) {
+		resolver
+		    ->Reject(context,
+		             Exception::TypeError(
+		                 nx_str(iso, "moduleRun: url and pageBase required")))
+		    .Check();
+		return;
+	}
+
+	// If this URL has already been compiled, `resolve_module_callback` would
+	// return the cached instance; re-executing would either replay the module
+	// (silently discarding new source) or throw a redeclaration error. Neither
+	// is what the caller expects. Fail loudly so runtime code assigns unique
+	// URLs per inline / re-run.
+	if (g_module_cache.find(url_s) != g_module_cache.end()) {
+		resolver
+		    ->Reject(context,
+		             Exception::Error(nx_str(
+		                 iso, "moduleRun: url already registered")))
+		    .Check();
+		return;
+	}
+
+	TryCatch try_catch(iso);
+	Local<String> source_v8 = info[0].As<String>();
+
+	ScriptOrigin origin(nx_str(iso, url_s.c_str()), 0, 0, false, -1,
+	                    Local<Value>(), false, false, true /* is_module */);
+	ScriptCompiler::Source script_source(source_v8, origin);
+	Local<Module> module;
+	if (!ScriptCompiler::CompileModule(iso, &script_source).ToLocal(&module)) {
+		resolver->Reject(context, try_catch.Exception()).Check();
+		return;
+	}
+	register_module(iso, module, url_s);
+	g_module_page_base[url_s] = base_s;
+
+	if (module->InstantiateModule(context, resolve_module_callback)
+	        .IsNothing()) {
+		resolver->Reject(context, try_catch.Exception()).Check();
+		return;
+	}
+
+	Local<Value> eval_result;
+	if (!module->Evaluate(context).ToLocal(&eval_result)) {
+		resolver->Reject(context, try_catch.Exception()).Check();
+		return;
+	}
+
+	// `eval_result` is the module's evaluation promise (settled unless the
+	// graph uses top-level await). Resolve our return promise to the module
+	// namespace on fulfillment, propagate rejection otherwise. Chain via
+	// `.then(() => ns)` when pending so TLA is awaited.
+	Local<Promise> eval_promise = eval_result.As<Promise>();
+	Local<Value> ns = module->GetModuleNamespace();
+	if (eval_promise->State() == Promise::kFulfilled) {
+		resolver->Resolve(context, ns).Check();
+	} else if (eval_promise->State() == Promise::kRejected) {
+		resolver->Reject(context, eval_promise->Result()).Check();
+	} else {
+		Local<Object> data = Object::New(iso);
+		data->Set(context, nx_str(iso, "ns"), ns).Check();
+		Local<Function> on_ok;
+		if (Function::New(
+		        context,
+		        [](const FunctionCallbackInfo<Value> &info) {
+			        Local<Context> ctx =
+			            info.GetIsolate()->GetCurrentContext();
+			        Local<Object> d = info.Data().As<Object>();
+			        info.GetReturnValue().Set(
+			            d->Get(ctx, nx_str(info.GetIsolate(), "ns"))
+			                .ToLocalChecked());
+		        },
+		        data)
+		        .ToLocal(&on_ok)) {
+			Local<Promise> mapped;
+			if (eval_promise->Then(context, on_ok).ToLocal(&mapped))
+				resolver->Resolve(context, mapped).Check();
+			else
+				resolver->Resolve(context, ns).Check();
+		} else {
+			resolver->Resolve(context, ns).Check();
+		}
+	}
+}
+
+// Drop the page's importmap, and purge every module + prefetch entry tagged
+// with `pageBase`. Modules loaded outside a page context (e.g. the runtime
+// entrypoint via nx_run_entry_module) are absent from g_module_page_base and
+// therefore untouched. Called on page navigation.
+void nx_module_clear_page(const FunctionCallbackInfo<Value> &info) {
+	Isolate *iso = info.GetIsolate();
+	if (info.Length() < 1 || !info[0]->IsString())
+		return;
+	String::Utf8Value base(iso, info[0]);
+	std::string base_s = utf8_to_string(base);
+	if (base_s.empty())
+		return;
+
+	g_importmaps.erase(base_s);
+
+	for (auto it = g_module_page_base.begin();
+	     it != g_module_page_base.end();) {
+		if (it->second != base_s) {
+			++it;
+			continue;
+		}
+		const std::string &url = it->first;
+		auto cache_it = g_module_cache.find(url);
+		if (cache_it != g_module_cache.end()) {
+			Local<Module> m = cache_it->second.Get(iso);
+			g_module_urls.erase(m->GetIdentityHash());
+			cache_it->second.Reset();
+			g_module_cache.erase(cache_it);
+		}
+		g_prefetch_sources.erase(url);
+		it = g_module_page_base.erase(it);
+	}
+}
+
+} // namespace
+
 void nx_init_modules(Isolate *iso) {
 	iso->SetHostInitializeImportMetaObjectCallback(init_import_meta);
 	iso->SetHostImportModuleDynamicallyCallback(dynamic_import_callback);
+}
+
+void nx_module_bindings(Isolate *iso, Local<Object> init_obj) {
+	NX_SET_FUNC(init_obj, "moduleSetImportmap", nx_module_set_importmap);
+	NX_SET_FUNC(init_obj, "moduleSetSource", nx_module_set_source);
+	NX_SET_FUNC(init_obj, "moduleRun", nx_module_run);
+	NX_SET_FUNC(init_obj, "moduleClearPage", nx_module_clear_page);
+
+	// Additionally publish as a durable global namespace so embedders whose
+	// code loads AFTER the nx.js runtime — which captures `$` into a module
+	// export and deletes the global at index.ts init — can still reach the
+	// page-module surface. The nx.js runtime never touches `nxjsPageModules`,
+	// so it survives for the isolate's lifetime.
+	//
+	// Access pattern from any embedder (post-nx.js-runtime-init):
+	//   globalThis.nxjsPageModules.setImportmap(base, json)
+	//   globalThis.nxjsPageModules.setSource(url, src)
+	//   await globalThis.nxjsPageModules.run(src, url, base)
+	//   globalThis.nxjsPageModules.clearPage(base)
+	Local<Context> _ctx = iso->GetCurrentContext();
+	Local<Object> mods_ns = Object::New(iso);
+	NX_SET_FUNC(mods_ns, "setImportmap", nx_module_set_importmap);
+	NX_SET_FUNC(mods_ns, "setSource", nx_module_set_source);
+	NX_SET_FUNC(mods_ns, "run", nx_module_run);
+	NX_SET_FUNC(mods_ns, "clearPage", nx_module_clear_page);
+	_ctx->Global()
+	    ->DefineOwnProperty(_ctx, nx_str(iso, "nxjsPageModules"), mods_ns,
+	                        static_cast<PropertyAttribute>(DontEnum | DontDelete))
+	    .Check();
 }
 
 bool nx_run_entry_module(Isolate *iso, Local<Context> context, const char *src,
@@ -374,4 +772,7 @@ void nx_modules_teardown() {
 	g_module_cache.clear(); // Global<Module> destructors release the handles
 	g_module_urls.clear();
 	g_entrypoint_url.clear();
+	g_importmaps.clear();
+	g_prefetch_sources.clear();
+	g_module_page_base.clear();
 }

--- a/source/module.h
+++ b/source/module.h
@@ -11,8 +11,11 @@ void nx_console_init(nx_context_t *nx_ctx);
 // Shared by both the device runtime (source/main.cc) and the host test binary
 // (packages/runtime/test/src/main.cc) so the two never drift. Specifiers are
 // resolved as URLs (via `ada`) against the importing module's URL and read
-// synchronously with read_file()/fopen, so only mounted devoptab schemes
-// (romfs:, sdmc:, nxjs:, file:) work; bare specifiers are rejected.
+// synchronously with read_file()/fopen — so entrypoint / filesystem imports
+// use mounted devoptab schemes (romfs:, sdmc:, nxjs:, file:) and reject bare
+// specifiers. Page-level modules (see nx_module_bindings below) additionally
+// consult a per-page importmap and may source their body from a runtime-
+// supplied prefetch registry rather than fopen.
 // ---------------------------------------------------------------------------
 
 // Register the host module callbacks on the isolate:
@@ -20,6 +23,17 @@ void nx_console_init(nx_context_t *nx_ctx);
 //   - SetHostImportModuleDynamicallyCallback   (filesystem `import()`)
 // Call once, after Isolate::New.
 void nx_init_modules(v8::Isolate *iso);
+
+// Register the page-module JS surface on `init_obj` (the `$` init object):
+//   - moduleSetImportmap(pageBase: string, mapJson: string): void
+//   - moduleSetSource(url: string, source: string): void
+//   - moduleRun(source: string, url: string, pageBase: string): Promise<any>
+//   - moduleClearPage(pageBase: string): void
+// The embedder is expected to walk static imports on the JS side, prefetch
+// each dep's source via its own fetch (`moduleSetSource`), then call
+// `moduleRun` on the entry. `moduleClearPage` purges the page's state on
+// navigation. See BINDINGS.md §page-modules and NXJS_PATCHES_NEEDED.md #105.
+void nx_module_bindings(v8::Isolate *iso, v8::Local<v8::Object> init_obj);
 
 // Compile + instantiate + evaluate `src` (length `len`) as the entrypoint ES
 // module, recorded under URL `name` (its ScriptOrigin resource name and


### PR DESCRIPTION
## Background

nx.js has had a full V8-backed ES module system in `source/module.cc` since the V8 migration. It's used by `nx_run_entry_module` for the runtime's own bundle: `ScriptCompiler::CompileModule` + `Module::InstantiateModule` + `Module::Evaluate`, with `SetHostInitializeImportMetaObjectCallback` + `SetHostImportModuleDynamicallyCallback` wired for `import.meta.url` and dynamic `import()`. Top-level await is chained. Cycles resolve. It works.

## The gap

This machinery is **not reachable from JS**. Embedders that want to execute a page-shaped `<script type="module">` — either because they're rendering HTML pages, or because they want to run arbitrary user-supplied module code at runtime, or because they're building a REPL, or because they need to run a test file that imports fixtures — currently can't. They have to either:

1. Ship a userland module loader (SystemJS, RequireJS, etc.) — ~30 KB, its own resolver, its own compile pipeline running on top of `eval` — and forfeit V8's native module semantics, its compile cache, its module identity guarantees, and this file's dynamic-import integration.
2. Pre-bundle everything into a single entrypoint and reboot the isolate for every module they want to run.

Neither is great. This PR closes the gap with a minimal surface: four JS-callable functions on the `$` bridge object, one resolver extension that adds importmap fallback for bare specifiers, and one alternate source lookup path for URL schemes the engine has no `fopen` access to.

## The new surface

Attached both to the `$` init object (nx.js house style for engine bindings) and to a durable `globalThis.nxjsPageModules` namespace (the entry point downstream embedders actually use, since `$` is captured + deleted at nx.js runtime init):

```ts
// Register an importmap for a page scope. Merges on repeat calls (last
// write wins per specifier). Silently no-ops on malformed JSON.
$.moduleSetImportmap(pageBase: string, mapJson: string): void
globalThis.nxjsPageModules.setImportmap(pageBase, mapJson)

// Register source text for a URL. The resolver consults this map BEFORE
// falling through to fopen. Lets an embedder execute modules over URL
// schemes the engine can't reach directly (http(s)://, custom schemes)
// as long as the embedder's own fetch() reached them first.
$.moduleSetSource(url: string, source: string): void
globalThis.nxjsPageModules.setSource(url, source)

// Compile + instantiate + evaluate `source` as a module identified by
// `url`, resolving bare specifiers via `pageBase`'s importmap. Returns
// a Promise mirroring the evaluation promise: fulfills with the module
// namespace, rejects on any compile/instantiate/evaluate failure,
// chained through top-level await.
$.moduleRun(source: string, url: string, pageBase: string): Promise<any>
globalThis.nxjsPageModules.run(source, url, pageBase)

// Purge everything tagged with this page scope (importmap, module cache,
// prefetched sources, page-base tagging). Call on page navigation.
$.moduleClearPage(pageBase: string): void
globalThis.nxjsPageModules.clearPage(pageBase)
```

`nxjsPageModules` is registered as `DontEnum | DontDelete` so it stays out of `for…in` / `Object.keys(globalThis)`, is non-deletable, but remains writable in case an embedder wants to wrap or proxy it. The runtime never touches this global.

## Usage sketch

```js
const pageBase = 'app://apps/foo/index.html';

// From the HTML: <script type="importmap">{"imports":{"three":"./assets/three.module.js"}}</script>
$.moduleSetImportmap(pageBase, importmapJsonText);

// Walk the entry module's static imports (regex or ESTree scan),
// fetch each URL via fetch(), register with the engine.
for (const [url, source] of await prefetchGraph(entryUrl, pageBase)) {
  $.moduleSetSource(url, source);
}

// From the HTML: <script type="module">import * as THREE from 'three'; ...</script>
await $.moduleRun(inlineSource, `${pageBase}#inline-0`, pageBase);

// On navigation:
$.moduleClearPage(pageBase);
```

The engine does not fetch. The engine does not walk imports pre-instantiate. The engine's contract is only: given an importmap + a source registry + an entry, run V8's real module machinery under spec-conformant semantics. This split keeps the C++ delta small, keeps async I/O on the JS side where `fetch()` already lives, and preserves the engine's compile cache and module identity for cross-graph deduplication.

## What this preserves

- **Entrypoint module flow is unchanged.** `nx_run_entry_module` still passes no page scope. `load_module` still falls through to `fopen` when there's no prefetched source. `resolve_specifier_with_map` degrades to `resolve_specifier` when the page scope is empty. Every existing embedder that only loads a single entrypoint sees zero behavioral change.
- **Dynamic `import()` from a page module inherits the page scope.** The existing `dynamic_import_callback` was extended with the same page-base-aware resolver + prefetch check. `import('three')` from an inline module works the same as `import * as THREE from 'three'`.
- **`import.meta.url` is populated for page modules.** They go through the same `register_module` path; `init_import_meta` reads their URL from `g_module_urls` unchanged.
- **Cycles resolve.** `register_module` runs before `InstantiateModule`, matching the existing pattern.
- **Top-level await is awaited by the caller.** `moduleRun` chains the evaluation promise into the returned Promise via `.then(() => ns)` when pending.

## What's intentionally not in this PR

- **`v8::SyntheticModule` for host-provided modules.** Would slot in as `moduleSetSynthetic(url, exportsObject)` for `import { X } from 'nx:foo'` patterns. ~50 LOC; leaving for a follow-up PR because it's a distinct capability with its own review surface (export-name discovery, evaluation callback shape).
- **Async C++→JS fetch callback.** The JS-drives-fetch design is a deliberate choice — it keeps the engine synchronous, avoids a new cross-language async boundary, and reuses the embedder's already-working `fetch()`. If a future use case genuinely needs the engine to initiate a load (dynamic import of a URL not pre-scanned), a JS-side registered fetcher wrapped through `nx_queue_async` is the natural extension.

## Diff summary

```
 source/module.cc | +425 / -24  (state + resolver ext + 4 bindings + durable global + teardown)
 source/module.h  |  +16 /  -2  (declaration + updated header block comment)
 source/main.cc   |   +1 /  -0  (nx_module_bindings call in build_init_object)
 3 source files changed
```

No new source files. No Makefile changes. No new dependencies (`ada` was already in use; `v8::JSON::Parse` is standard V8). No changes to the existing entrypoint-module contract or to any other binding.
